### PR TITLE
Soundness fixes: verify preconditions in FreshInputRFToUniform and UniqExclusionBranchElimination

### DIFF
--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -189,17 +189,34 @@ class UniqExclusionBranchEliminationTransformer(BlockTransformer):
 
     @staticmethod
     def _written_var_names(stmt: frog_ast.Statement) -> set[str]:
-        """Return the set of variable names written by *stmt*.
+        """Return the set of variable names written anywhere inside *stmt*.
 
         Used to invalidate constraints when a tracked variable (or a
         free variable of its exclusion-set elements) is reassigned.
+
+        Walks the full statement, so writes nested in if/for branches
+        count, and resolves element writes (``M[k] = v``) and slice
+        writes through ``ArrayAccess``/``Slice`` layers to the backing
+        variable. Invalidation happens before the statement's conditions
+        are rewritten, so an if-statement writing a tracked variable in
+        its own branch conservatively forgoes the fold of its own
+        condition.
         """
-        if isinstance(
-            stmt, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
-        ):
-            if isinstance(stmt.var, frog_ast.Variable):
-                return {stmt.var.name}
-        return set()
+        names: set[str] = set()
+
+        def _collect(node: frog_ast.ASTNode) -> bool:
+            if isinstance(
+                node, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
+            ):
+                target: frog_ast.ASTNode = node.var
+                while isinstance(target, (frog_ast.ArrayAccess, frog_ast.Slice)):
+                    target = target.the_array
+                if isinstance(target, frog_ast.Variable):
+                    names.add(target.name)
+            return False
+
+        SearchVisitor(_collect).visit(stmt)
+        return names
 
     def _try_simplify_eq(
         self,

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -933,25 +933,251 @@ def _find_rf_call_of_var(
     return result  # type: ignore[return-value]
 
 
+# ---------------------------------------------------------------------------
+# Soundness gate for FreshInputRFToUniform
+# ---------------------------------------------------------------------------
+#
+# Replacing a call ``RF(arg)`` (where the fresh ``v <-uniq[S]`` sits at
+# projection position k of ``arg``) with a fresh uniform sample is sound only
+# if RF has *never been queried at the value `arg`* before, in any execution
+# and any oracle.  Since ``arg`` collides with a prior query iff that query
+# agrees with ``arg`` in the k-th component (tuples/concats are injective in
+# each leaf), it suffices that the exclusion set ``S`` contains the k-th
+# projection of every input RF is ever queried on.  Two checkable regimes
+# guarantee this:
+#
+#   (A) ``S`` is the called RF's own domain ``RF.domain`` (whole-argument
+#       case only): RF.domain by construction holds every prior query, and the
+#       RF's semantics keep it in sync (including adversary oracle queries).
+#
+#   (B) ``S`` is a persistent game field, never reset, into which EVERY RF
+#       call site inserts its argument's k-th projection (either the projection
+#       is itself ``<-uniq[S]`` sampled, or the call's method does
+#       ``S = S union {proj}``).  This is the projection-tracking idiom (e.g.
+#       an ``Eval``/``Hash`` oracle doing ``seen = seen union {x[0]}`` before
+#       ``KDF(x)``).
+#
+# The previously-missing check is what made an own-outputs-only exclusion set
+# (which does NOT track an adversary Hash oracle's queries) wrongly eligible.
+
+
+def _all_rf_call_args(
+    method: frog_ast.Method, rf_name: str
+) -> list[frog_ast.Expression]:
+    """Every single argument expression of a call ``rf_name(arg)`` in *method*."""
+    args: list[frog_ast.Expression] = []
+
+    def collector(node: frog_ast.ASTNode) -> bool:
+        if (
+            isinstance(node, frog_ast.FuncCall)
+            and isinstance(node.func, frog_ast.Variable)
+            and node.func.name == rf_name
+            and len(node.args) == 1
+        ):
+            args.append(node.args[0])
+        return False
+
+    SearchVisitor(collector).visit(method.block)
+    return args
+
+
+def _projection_expr(
+    arg: frog_ast.Expression, proj_index: int | None
+) -> frog_ast.Expression | None:
+    """The sub-expression of *arg* at projection *proj_index*.
+
+    ``proj_index is None`` means the whole argument (simple ``RF(v)``).  For a
+    tuple/concat we take the k-th element/leaf; for a whole-tuple variable we
+    synthesize ``arg[k]`` so it can be matched against ``S = S union {x[k]}``.
+    """
+    if proj_index is None:
+        return arg
+    if isinstance(arg, frog_ast.Tuple):
+        if 0 <= proj_index < len(arg.values):
+            return arg.values[proj_index]
+        return None
+    if (
+        isinstance(arg, frog_ast.BinaryOperation)
+        and arg.operator == frog_ast.BinaryOperators.OR
+    ):
+        leaves = _flatten_concat(arg)
+        if 0 <= proj_index < len(leaves):
+            return leaves[proj_index]
+        return None
+    if isinstance(arg, frog_ast.Variable):
+        return frog_ast.ArrayAccess(arg, frog_ast.Integer(proj_index))
+    return None
+
+
+def _index_of_var_in_arg(arg: frog_ast.Expression, var_name: str) -> int | None | bool:
+    """Position of *var_name* in an RF argument.
+
+    Returns ``None`` for the simple whole-argument case (``arg`` is the
+    variable itself), an ``int`` index for a tuple/concat leaf, or ``False``
+    when the variable cannot be located (gate should then refuse to fire).
+    """
+    if isinstance(arg, frog_ast.Variable) and arg.name == var_name:
+        return None
+    if isinstance(arg, frog_ast.Tuple):
+        for i, elem in enumerate(arg.values):
+            if isinstance(elem, frog_ast.Variable) and elem.name == var_name:
+                return i
+    if (
+        isinstance(arg, frog_ast.BinaryOperation)
+        and arg.operator == frog_ast.BinaryOperators.OR
+    ):
+        for i, leaf in enumerate(_flatten_concat(arg)):
+            if isinstance(leaf, frog_ast.Variable) and leaf.name == var_name:
+                return i
+    return False
+
+
+def _proj_tracked_in_set(
+    method: frog_ast.Method, set_name: str, proj: frog_ast.Expression
+) -> bool:
+    """True if *proj* is guaranteed to be in *set_name* within *method*.
+
+    Either *proj* is a variable sampled ``<-uniq[set_name]``, or *method*
+    contains ``set_name = set_name union {... proj ...}`` (or ``+``).
+    """
+    found = [False]
+
+    def visit(node: frog_ast.ASTNode) -> bool:
+        if (
+            isinstance(node, frog_ast.UniqueSample)
+            and isinstance(node.var, frog_ast.Variable)
+            and isinstance(proj, frog_ast.Variable)
+            and node.var.name == proj.name
+            and isinstance(node.unique_set, frog_ast.Variable)
+            and node.unique_set.name == set_name
+        ):
+            found[0] = True
+        if (
+            isinstance(node, frog_ast.Assignment)
+            and isinstance(node.var, frog_ast.Variable)
+            and node.var.name == set_name
+            and isinstance(node.value, frog_ast.BinaryOperation)
+            and node.value.operator
+            in (frog_ast.BinaryOperators.UNION, frog_ast.BinaryOperators.ADD)
+            and isinstance(node.value.left_expression, frog_ast.Variable)
+            and node.value.left_expression.name == set_name
+            and isinstance(node.value.right_expression, frog_ast.Set)
+            and any(elem == proj for elem in node.value.right_expression.elements)
+        ):
+            found[0] = True
+        return False
+
+    SearchVisitor(visit).visit(method.block)
+    return found[0]
+
+
+def _set_only_monotone(game: frog_ast.Game, set_name: str) -> bool:
+    """True if *set_name* is only ever grown monotonically (never reset).
+
+    Any assignment to *set_name* other than ``set_name = set_name union {..}``
+    / ``+ {..}`` breaks the accumulation invariant and makes the projection
+    unreliable.  A bare ``set_name = {}`` is tolerated only inside
+    ``Initialize`` (the one-time initial empty set).
+    """
+    ok = [True]
+
+    def visit_method(method: frog_ast.Method) -> None:
+        is_init = method.signature.name == "Initialize"
+
+        def visit(node: frog_ast.ASTNode) -> bool:
+            if isinstance(node, frog_ast.Assignment) and isinstance(
+                node.var, frog_ast.Variable
+            ):
+                if node.var.name == set_name:
+                    v = node.value
+                    monotone = (
+                        isinstance(v, frog_ast.BinaryOperation)
+                        and v.operator
+                        in (
+                            frog_ast.BinaryOperators.UNION,
+                            frog_ast.BinaryOperators.ADD,
+                        )
+                        and isinstance(v.left_expression, frog_ast.Variable)
+                        and v.left_expression.name == set_name
+                    )
+                    empty_init = (
+                        is_init and isinstance(v, frog_ast.Set) and len(v.elements) == 0
+                    )
+                    if not (monotone or empty_init):
+                        ok[0] = False
+            # element-level mutation of the set is also a reset-like change
+            if (
+                isinstance(node, frog_ast.Assignment)
+                and isinstance(node.var, frog_ast.ArrayAccess)
+                and isinstance(node.var.the_array, frog_ast.Variable)
+                and node.var.the_array.name == set_name
+            ):
+                ok[0] = False
+            return False
+
+        SearchVisitor(visit).visit(method.block)
+
+    for method in game.methods:
+        visit_method(method)
+    return ok[0]
+
+
+def _exclusion_adequate(
+    game: frog_ast.Game,
+    rf_name: str,
+    set_name: str,
+    proj_index: int | None,
+    field_names: set[str],
+) -> bool:
+    """Whether ``v <-uniq[set_name]`` at projection *proj_index* of an
+    ``rf_name(arg)`` call guarantees the queried point is fresh for ``rf_name``.
+    See the regime (A)/(B) discussion above."""
+    # Regime (A): the exclusion set is the called RF's own domain.
+    if set_name == f"{rf_name}.domain" and proj_index is None:
+        return True
+    # Regime (B): persistent, never-reset field that tracks the k-th
+    # projection of every RF call site.
+    if set_name not in field_names:
+        return False
+    if not _set_only_monotone(game, set_name):
+        return False
+    for method in game.methods:
+        for arg in _all_rf_call_args(method, rf_name):
+            proj = _projection_expr(arg, proj_index)
+            if proj is None:
+                return False
+            if not _proj_tracked_in_set(method, set_name, proj):
+                return False
+    return True
+
+
 class _FreshInputRFTransformer(BlockTransformer):
     """Replace ``RF(v)`` (or ``RF([..., v, ...])`` / ``RF(... || v || ...)``)
     with ``z <- RangeType`` when *v* is a ``<-uniq[S]`` sampled variable used
     only in that one RF call.
 
-    The exclusion set ``S`` guarantees that *v* differs from all inputs on
-    which the RF has been queried elsewhere (e.g., via an adversary oracle).
-    When *v* appears inside a tuple or concatenation, varying *v* produces a
-    distinct composite argument, so the RF output is still an independent
-    uniform draw.
+    The replacement is sound only when the exclusion set ``S`` provably
+    contains the relevant projection of every input the RF is queried on, so
+    that *v* (hence the composite argument) is genuinely fresh.  This is
+    enforced by :func:`_exclusion_adequate` (regimes A/B documented there);
+    when it cannot be established the transform refuses to fire and records a
+    near-miss.  When *v* appears inside a tuple or concatenation, the leaf is
+    injective, so a fresh leaf yields a fresh composite argument.
     """
 
     def __init__(
         self,
         rf_types: dict[str, frog_ast.FunctionType],
         ctx: PipelineContext | None = None,
+        game: frog_ast.Game | None = None,
+        field_names: set[str] | None = None,
     ) -> None:
         self.rf_types = rf_types
         self.ctx = ctx
+        # Original game and its field names, used by the soundness gate to
+        # verify the <-uniq exclusion set provably covers the RF's domain.
+        self.game = game
+        self.field_names = field_names if field_names is not None else set()
         self._loop_depth = 0
 
     def transform_numeric_for(  # type: ignore[override]
@@ -1018,6 +1244,49 @@ class _FreshInputRFTransformer(BlockTransformer):
             if _rf_call_in_loop(remaining, rf_name):
                 continue
 
+            # SOUNDNESS GATE: the <-uniq exclusion set must provably exclude
+            # every input the RF has been (or will be) queried on, in the
+            # k-th projection where the fresh variable sits.  Without this,
+            # an exclusion set that does not track the RF's full domain (e.g.
+            # an own-outputs-only set that ignores an adversary Hash oracle)
+            # would yield an unsound RF(v) -> uniform replacement.
+            set_name = _get_unique_set_name(stmt.unique_set)
+            proj_index = _index_of_var_in_arg(rf_call.args[0], var_name)
+            if proj_index is False or self.game is None:
+                _adequate = False
+            else:
+                _adequate = _exclusion_adequate(
+                    self.game,
+                    rf_name,
+                    set_name,
+                    proj_index,  # type: ignore[arg-type]
+                    self.field_names,
+                )
+            if not _adequate:
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Fresh Input RF To Uniform",
+                            reason=(
+                                f"RF '{rf_name}' input is sampled <-uniq"
+                                f"[{set_name}], but '{set_name}' is not "
+                                f"provably a superset of '{rf_name}'.domain "
+                                "(its relevant projection): some RF call site "
+                                "does not add its argument to the exclusion "
+                                "set, so RF(input) may not be fresh"
+                            ),
+                            location=stmt.origin,
+                            suggestion=(
+                                f"sample with <-uniq[{rf_name}.domain], or "
+                                "ensure every RF call site inserts its input's "
+                                "matching component into the exclusion set"
+                            ),
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
+                continue
+
             range_type = copy.deepcopy(self.rf_types[rf_name].range_type)
 
             # Replace the RF call node with a fresh variable, and add a
@@ -1050,9 +1319,11 @@ class FreshInputRFToUniform(TransformPass):
     Handles bare variables, tuples containing the variable, and
     concatenations containing the variable.
 
-    When the input is sampled via ``<-uniq[S]``, the exclusion set
-    guarantees it differs from all other RF inputs.  This makes the
-    replacement exactly sound — no guessing loss.
+    The replacement is exactly sound (no guessing loss) only when the
+    ``<-uniq[S]`` exclusion set provably covers the RF's queried domain at the
+    variable's position; this is checked by :func:`_exclusion_adequate`
+    (regimes A/B).  When it cannot be established the pass declines and records
+    a near-miss rather than firing unsoundly.
     """
 
     name = "Fresh Input RF To Uniform"
@@ -1095,7 +1366,10 @@ class FreshInputRFToUniform(TransformPass):
         if not rf_types:
             return game
 
-        return _FreshInputRFTransformer(rf_types, ctx).transform(game)
+        field_names = {f.name for f in game.fields}
+        return _FreshInputRFTransformer(
+            rf_types, ctx, game=game, field_names=field_names
+        ).transform(game)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/transforms/test_fresh_input_rf_to_uniform.py
+++ b/tests/unit/transforms/test_fresh_input_rf_to_uniform.py
@@ -1,308 +1,302 @@
 """Tests for the FreshInputRFToUniform transform pass.
 
-The transform replaces RF(v) with a uniform sample when v is a <-uniq
-sampled variable used only in that one RF call.  It must NOT fire on
-plain uniform samples (<-).
+The transform replaces ``RF(v)`` with a uniform sample when ``v`` is a
+``<-uniq[S]`` single-use input.  The replacement is sound ONLY when the
+exclusion set ``S`` provably covers the RF's queried domain (in the relevant
+projection).  Two regimes are accepted:
+
+  (A) ``S`` is the called RF's own ``RF.domain``; or
+  (B) ``S`` is a persistent, never-reset game field into which every RF call
+      site inserts its argument's matching component (projection-tracking).
+
+The transform must NOT fire when neither holds -- in particular when ``S`` is
+an own-outputs-only set that ignores an adversary oracle's queries to the same
+RF (which would make ``RF(v)`` not actually fresh).
 """
 
-import pytest
 from proof_frog import frog_ast, frog_parser
-from proof_frog.transforms.random_functions import _FreshInputRFTransformer
-
-_RF_TYPES: dict[str, frog_ast.FunctionType] = {
-    "H": frog_ast.FunctionType(
-        frog_ast.BitStringType(frog_ast.Integer(8)),
-        frog_ast.BitStringType(frog_ast.Integer(16)),
-    ),
-}
-
-_RF_TYPES_TUPLE: dict[str, frog_ast.FunctionType] = {
-    "H": frog_ast.FunctionType(
-        frog_ast.ProductType([
-            frog_ast.BitStringType(frog_ast.Integer(8)),
-            frog_ast.BitStringType(frog_ast.Integer(8)),
-        ]),
-        frog_ast.BitStringType(frog_ast.Integer(16)),
-    ),
-}
-
-_RF_TYPES_CONCAT: dict[str, frog_ast.FunctionType] = {
-    "H": frog_ast.FunctionType(
-        frog_ast.BitStringType(frog_ast.Integer(16)),
-        frog_ast.BitStringType(frog_ast.Integer(16)),
-    ),
-}
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.transforms.random_functions import FreshInputRFToUniform
+from proof_frog.visitors import NameTypeMap
 
 
-def _run(method_str: str) -> frog_ast.Method:
-    ast = frog_parser.parse_method(method_str)
-    while True:
-        new_ast = _FreshInputRFTransformer(_RF_TYPES).transform(ast)
-        if new_ast == ast:
-            return ast
-        ast = new_ast
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
 
 
-def _run_tuple(method_str: str) -> frog_ast.Method:
-    ast = frog_parser.parse_method(method_str)
-    while True:
-        new_ast = _FreshInputRFTransformer(_RF_TYPES_TUPLE).transform(ast)
-        if new_ast == ast:
-            return ast
-        ast = new_ast
+def _apply(game_src: str) -> tuple[frog_ast.Game, PipelineContext]:
+    game = frog_parser.parse_game(game_src)
+    ctx = _ctx()
+    transformed = FreshInputRFToUniform().apply(game, ctx)
+    return transformed, ctx
 
 
-def _run_concat(method_str: str) -> frog_ast.Method:
-    ast = frog_parser.parse_method(method_str)
-    while True:
-        new_ast = _FreshInputRFTransformer(_RF_TYPES_CONCAT).transform(ast)
-        if new_ast == ast:
-            return ast
-        ast = new_ast
+def _assert_game(actual_src: str, expected_src: str) -> frog_ast.Game:
+    transformed, _ = _apply(actual_src)
+    expected = frog_parser.parse_game(expected_src)
+    assert transformed == expected
+    return transformed
 
 
-@pytest.mark.parametrize(
-    "method,expected",
-    [
-        # Basic: <-uniq input, single use in RF call -> replaced with uniform
-        (
-            """
-            BitString<16> f(Set<BitString<8>> S) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H(v);
+# ---------------------------------------------------------------------------
+# Regime (A): S == RF.domain  ->  fires
+# ---------------------------------------------------------------------------
+
+
+def test_fires_when_exclusion_is_rf_domain() -> None:
+    _assert_game(
+        """
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
+                BitString<8> c <-uniq[H.domain] BitString<8>;
+                BitString<16> z = H(c);
                 return z;
             }
-            """,
-            """
-            BitString<16> f(Set<BitString<8>> S) {
-                BitString<16> __fresh_rf_v__ <- BitString<16>;
-                BitString<16> z = __fresh_rf_v__;
+        }
+        """,
+        """
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
+                BitString<16> __fresh_rf_c__ <- BitString<16>;
+                BitString<16> z = __fresh_rf_c__;
                 return z;
             }
-            """,
-        ),
-        # Plain uniform sample (<-): must NOT fire
-        (
-            """
-            BitString<16> f() {
-                BitString<8> v <- BitString<8>;
-                BitString<16> z = H(v);
+        }
+        """,
+    )
+
+
+def test_fires_rf_domain_even_with_adversary_oracle() -> None:
+    # H is also exposed via Hash, but S == H.domain covers those queries too.
+    _assert_game(
+        """
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
+                BitString<8> c <-uniq[H.domain] BitString<8>;
+                BitString<16> z = H(c);
                 return z;
             }
-            """,
-            """
-            BitString<16> f() {
-                BitString<8> v <- BitString<8>;
-                BitString<16> z = H(v);
+            BitString<16> Hash(BitString<8> x) {
+                return H(x);
+            }
+        }
+        """,
+        """
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
+                BitString<16> __fresh_rf_c__ <- BitString<16>;
+                BitString<16> z = __fresh_rf_c__;
                 return z;
             }
-            """,
-        ),
-        # Variable used more than once: must NOT fire
-        (
-            """
-            [BitString<8>, BitString<16>] f(Set<BitString<8>> S) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H(v);
-                return [v, z];
+            BitString<16> Hash(BitString<8> x) {
+                return H(x);
             }
-            """,
-            """
-            [BitString<8>, BitString<16>] f(Set<BitString<8>> S) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H(v);
-                return [v, z];
+        }
+        """,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regime (B): persistent field tracking the projection of every RF call
+# ---------------------------------------------------------------------------
+
+
+def test_fires_projection_tracking_tuple() -> None:
+    # Challenge samples c <-uniq[seen] and queries H([c, x]); the Eval oracle
+    # inserts y[0] into seen before its own H(y) -- so every H query's first
+    # component is in seen, and H([c, x]) is fresh.
+    _assert_game(
+        """
+        Game G() {
+            Function<[BitString<8>, BitString<8>], BitString<16>> H;
+            Set<BitString<8>> seen;
+            Void Initialize() {
+                H <- Function<[BitString<8>, BitString<8>], BitString<16>>;
             }
-            """,
-        ),
-        # RF call inside a loop: must NOT fire
-        (
-            """
-            BitString<16> f(Set<BitString<8>> S) {
+            BitString<16> Challenge(BitString<8> x) {
+                BitString<8> c <-uniq[seen] BitString<8>;
+                BitString<16> z = H([c, x]);
+                return z;
+            }
+            BitString<16> Eval([BitString<8>, BitString<8>] y) {
+                seen = seen union {y[0]};
+                return H(y);
+            }
+        }
+        """,
+        """
+        Game G() {
+            Function<[BitString<8>, BitString<8>], BitString<16>> H;
+            Set<BitString<8>> seen;
+            Void Initialize() {
+                H <- Function<[BitString<8>, BitString<8>], BitString<16>>;
+            }
+            BitString<16> Challenge(BitString<8> x) {
+                BitString<16> __fresh_rf_c__ <- BitString<16>;
+                BitString<16> z = __fresh_rf_c__;
+                return z;
+            }
+            BitString<16> Eval([BitString<8>, BitString<8>] y) {
+                seen = seen union {y[0]};
+                return H(y);
+            }
+        }
+        """,
+    )
+
+
+# ---------------------------------------------------------------------------
+# UNSOUND shapes: must NOT fire (the gap this gate closes)
+# ---------------------------------------------------------------------------
+
+
+def _assert_unchanged(game_src: str) -> PipelineContext:
+    transformed, ctx = _apply(game_src)
+    expected = frog_parser.parse_game(game_src)
+    assert transformed == expected
+    return ctx
+
+
+def test_does_not_fire_own_outputs_set_with_untracked_adversary_oracle() -> None:
+    # S = seen accumulates only the challenge's own c's; the Hash oracle queries
+    # H(x) WITHOUT adding x to seen, so H(c) for c<-uniq[seen] is NOT fresh
+    # (c can equal an adversary Hash query).  Must not fire.
+    ctx = _assert_unchanged("""
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Set<BitString<8>> seen;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
+                BitString<8> c <-uniq[seen] BitString<8>;
+                BitString<16> z = H(c);
+                return z;
+            }
+            BitString<16> Hash(BitString<8> x) {
+                return H(x);
+            }
+        }
+        """)
+    assert any(
+        nm.transform_name == "Fresh Input RF To Uniform" for nm in ctx.near_misses
+    )
+
+
+def test_does_not_fire_arbitrary_local_exclusion_set() -> None:
+    # S is a method parameter (not a field, not RF.domain): cannot guarantee
+    # cross-call distinctness / domain coverage.  Must not fire.
+    _assert_unchanged("""
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge(Set<BitString<8>> S) {
+                BitString<8> c <-uniq[S] BitString<8>;
+                BitString<16> z = H(c);
+                return z;
+            }
+        }
+        """)
+
+
+def test_does_not_fire_when_set_is_reset() -> None:
+    # seen tracks projections, but a reset (seen = {}) mid-stream breaks the
+    # accumulation invariant.  Must not fire.
+    _assert_unchanged("""
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Set<BitString<8>> seen;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
+                BitString<8> c <-uniq[seen] BitString<8>;
+                BitString<16> z = H(c);
+                return z;
+            }
+            Void Reset() {
+                seen = {};
+            }
+        }
+        """)
+
+
+# ---------------------------------------------------------------------------
+# Structural negatives (independent of the exclusion-set gate)
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_fire_on_plain_uniform_sample() -> None:
+    # Plain <- (not <-uniq): a real sampling-with-replacement loss that must be
+    # accounted for via an assumption hop, never silently simplified.
+    _assert_unchanged("""
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
+                BitString<8> c <- BitString<8>;
+                BitString<16> z = H(c);
+                return z;
+            }
+        }
+        """)
+
+
+def test_does_not_fire_when_input_used_more_than_once() -> None:
+    _assert_unchanged("""
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            [BitString<8>, BitString<16>] Challenge() {
+                BitString<8> c <-uniq[H.domain] BitString<8>;
+                BitString<16> z = H(c);
+                return [c, z];
+            }
+        }
+        """)
+
+
+def test_does_not_fire_inside_loop() -> None:
+    _assert_unchanged("""
+        Game G() {
+            Function<BitString<8>, BitString<16>> H;
+            Void Initialize() {
+                H <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Challenge() {
                 BitString<16> z;
                 for (Int i = 0 to 3) {
-                    BitString<8> v <-uniq[S] BitString<8>;
-                    z = H(v);
+                    BitString<8> c <-uniq[H.domain] BitString<8>;
+                    z = H(c);
                 }
                 return z;
             }
-            """,
-            """
-            BitString<16> f(Set<BitString<8>> S) {
-                BitString<16> z;
-                for (Int i = 0 to 3) {
-                    BitString<8> v <-uniq[S] BitString<8>;
-                    z = H(v);
-                }
-                return z;
-            }
-            """,
-        ),
-        # Non-RF function call (G is not in rf_types): must NOT fire
-        (
-            """
-            BitString<16> f(Set<BitString<8>> S) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = G(v);
-                return z;
-            }
-            """,
-            """
-            BitString<16> f(Set<BitString<8>> S) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = G(v);
-                return z;
-            }
-            """,
-        ),
-        # RF sample (Function type): must NOT fire (handled by LocalRFToUniform)
-        (
-            """
-            BitString<16> f() {
-                Function<BitString<8>, BitString<16>> RF;
-                RF <- Function<BitString<8>, BitString<16>>;
-                BitString<16> z = H(RF);
-                return z;
-            }
-            """,
-            """
-            BitString<16> f() {
-                Function<BitString<8>, BitString<16>> RF;
-                RF <- Function<BitString<8>, BitString<16>>;
-                BitString<16> z = H(RF);
-                return z;
-            }
-            """,
-        ),
-    ],
-)
-def test_fresh_input_rf_to_uniform(method: str, expected: str) -> None:
-    transformed = _run(method)
-    expected_ast = frog_parser.parse_method(expected)
-    print("EXPECTED", expected_ast)
-    print("TRANSFORMED", transformed)
-    assert expected_ast == transformed
-
-
-@pytest.mark.parametrize(
-    "method,expected",
-    [
-        # Tuple: H([v, x]) where v <-uniq -> should fire
-        (
-            """
-            BitString<16> f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H([v, x]);
-                return z;
-            }
-            """,
-            """
-            BitString<16> f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<16> __fresh_rf_v__ <- BitString<16>;
-                BitString<16> z = __fresh_rf_v__;
-                return z;
-            }
-            """,
-        ),
-        # Tuple: v used elsewhere too -> must NOT fire
-        (
-            """
-            [BitString<8>, BitString<16>] f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H([v, x]);
-                return [v, z];
-            }
-            """,
-            """
-            [BitString<8>, BitString<16>] f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H([v, x]);
-                return [v, z];
-            }
-            """,
-        ),
-        # Tuple: plain sample (<-) -> must NOT fire
-        (
-            """
-            BitString<16> f(BitString<8> x) {
-                BitString<8> v <- BitString<8>;
-                BitString<16> z = H([v, x]);
-                return z;
-            }
-            """,
-            """
-            BitString<16> f(BitString<8> x) {
-                BitString<8> v <- BitString<8>;
-                BitString<16> z = H([v, x]);
-                return z;
-            }
-            """,
-        ),
-    ],
-)
-def test_fresh_input_rf_tuple(method: str, expected: str) -> None:
-    transformed = _run_tuple(method)
-    expected_ast = frog_parser.parse_method(expected)
-    assert expected_ast == transformed
-
-
-@pytest.mark.parametrize(
-    "method,expected",
-    [
-        # Concat: H(v || x) where v <-uniq -> should fire
-        (
-            """
-            BitString<16> f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H(v || x);
-                return z;
-            }
-            """,
-            """
-            BitString<16> f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<16> __fresh_rf_v__ <- BitString<16>;
-                BitString<16> z = __fresh_rf_v__;
-                return z;
-            }
-            """,
-        ),
-        # Concat: v used elsewhere too -> must NOT fire
-        (
-            """
-            [BitString<8>, BitString<16>] f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H(v || x);
-                return [v, z];
-            }
-            """,
-            """
-            [BitString<8>, BitString<16>] f(Set<BitString<8>> S, BitString<8> x) {
-                BitString<8> v <-uniq[S] BitString<8>;
-                BitString<16> z = H(v || x);
-                return [v, z];
-            }
-            """,
-        ),
-        # Concat: plain sample (<-) -> must NOT fire
-        (
-            """
-            BitString<16> f(BitString<8> x) {
-                BitString<8> v <- BitString<8>;
-                BitString<16> z = H(v || x);
-                return z;
-            }
-            """,
-            """
-            BitString<16> f(BitString<8> x) {
-                BitString<8> v <- BitString<8>;
-                BitString<16> z = H(v || x);
-                return z;
-            }
-            """,
-        ),
-    ],
-)
-def test_fresh_input_rf_concat(method: str, expected: str) -> None:
-    transformed = _run_concat(method)
-    expected_ast = frog_parser.parse_method(expected)
-    assert expected_ast == transformed
+        }
+        """)

--- a/tests/unit/transforms/test_uniq_exclusion_branch_elim.py
+++ b/tests/unit/transforms/test_uniq_exclusion_branch_elim.py
@@ -179,6 +179,62 @@ from proof_frog.transforms.control_flow import UniqExclusionBranchEliminationTra
             }
             """,
         ),
+        # Element write to the exclusion element's backing map invalidates:
+        # after M[0] = b, M[0] == b is true, so folding to false would be
+        # unsound.
+        (
+            """
+            Int f(Map<Int, BitString<8>> M) {
+                BitString<8> b <-uniq[{M[0]}] BitString<8>;
+                M[0] = b;
+                if (M[0] == b) {
+                    return 1;
+                }
+                return 0;
+            }
+            """,
+            """
+            Int f(Map<Int, BitString<8>> M) {
+                BitString<8> b <-uniq[{M[0]}] BitString<8>;
+                M[0] = b;
+                if (M[0] == b) {
+                    return 1;
+                }
+                return 0;
+            }
+            """,
+        ),
+        # Write nested inside an if-branch invalidates: on the c path a == b
+        # holds after a = b, so folding the later condition to false would be
+        # unsound.
+        (
+            """
+            Int f(Bool c) {
+                BitString<8> a <- BitString<8>;
+                BitString<8> b <-uniq[{a}] BitString<8>;
+                if (c) {
+                    a = b;
+                }
+                if (a == b) {
+                    return 1;
+                }
+                return 0;
+            }
+            """,
+            """
+            Int f(Bool c) {
+                BitString<8> a <- BitString<8>;
+                BitString<8> b <-uniq[{a}] BitString<8>;
+                if (c) {
+                    a = b;
+                }
+                if (a == b) {
+                    return 1;
+                }
+                return 0;
+            }
+            """,
+        ),
         # Condition with `==` deeper inside an AND chain: still rewritten.
         (
             """


### PR DESCRIPTION
## Summary

Two soundness fixes to canonicalization transforms that conclude *freshness*
or *uniqueness* from a sampling set or guard. In both cases the pass trusted a
precondition it never checked, so the engine accepted hops between games that
are not actually interchangeable. Each pass now verifies its precondition in
code and declines (recording a near-miss) when it cannot.

## Changes

### `FreshInputRFToUniform` — verify the exclusion set covers the RF's domain
`RF(v)` is rewritten to a fresh uniform draw when `v` is a single-use variable
sampled via `<-uniq[S]`, on the premise that `S` keeps `v` out of every input
the RF has already been queried on. The pass never checked that premise — it
trusted whatever set the proof supplied. With an own-outputs-only set that
ignores, say, an adversary-driven `Hash` oracle querying the same RF, the
sampled `v` can equal a point the adversary already queried, making `RF(v)` a
known value rather than a fresh one — and the engine accepted the hop.

The rewrite is now gated on the exclusion set actually covering the RF's domain
at `v`'s position: it fires only when the set is the called RF's own `.domain`,
or a game field that is never reset and into which every RF call site inserts
its argument's component at that position (the projection-tracking idiom used by
the X3DH-ladder proofs). Otherwise it declines and records a near-miss. The
sibling `UniqueRFSimplification` already ran the analogous all-call-sites check
and is unaffected.

### `UniqExclusionBranchElimination` — track element and nested writes
The pass folds `v == s` to false when `v <-uniq[S]` with `s in S`, invalidating
the constraint when either side is reassigned. Write detection only caught
top-level assignments to plain variables, missing two write forms that each
produced a demonstrably unsound fold:

- **Element writes:** after `M[0] = b`, the condition `M[0] == b` is true, but a
  constraint from `b <-uniq[{M[0]}]` survived the write and folded it to false.
- **Branch-nested writes:** after `if (c) { a = b; }`, the condition `a == b` is
  true on the `c` path, but a constraint from `b <-uniq[{a}]` survived and folded
  it to false.

Written names are now collected recursively over the whole statement, resolving
`ArrayAccess`/`Slice` targets to their backing variable. Invalidation stays
ahead of condition rewriting, so an if-statement that writes a tracked variable
in its own branch conservatively forgoes folding its own condition.

## Examples submodule
Advances the `examples` submodule to its matching branch, which replaces the
misusable caller-supplied `UniqueSampling` helper with `NonzeroSampling` and
`DistinctSampling` for the non-random-oracle uses and relands the affected
proofs onto them.

## Testing
- Freshness-RF unit tests rewritten at game level to express the cross-oracle
  conditions the new gate depends on, covering both accepted idioms and the
  rejected ones.
- Added `UniqExclusionBranchElimination` cases for element writes and
  branch-nested writes.
- Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
