### PR TITLE
Fix soundness bug: if/else with returning branches dropped by the topological sort (#221)

### DIFF
--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -1708,6 +1708,14 @@ class ProofEngine:
                 node, frog_ast.ReturnStatement
             )
 
+        def contains_return(statement: frog_ast.Statement) -> bool:
+            return (
+                visitors.SearchVisitor(
+                    lambda n: isinstance(n, frog_ast.ReturnStatement)
+                ).visit(statement)
+                is not None
+            )
+
         dfs_stack: list[dependencies.Node] = []
         # Use identity-keyed visited set to handle duplicate statements
         dfs_visited_ids: set[int] = set()
@@ -1739,6 +1747,22 @@ class ProofEngine:
 
             found = visitors.SearchVisitor(uses_field).visit(statement)
             if id(statement) not in dfs_visited_ids and found is not None:
+                dfs_stack.append(graph.get_node(statement))
+                do_dfs()
+
+        # Rescue any statement that contains a return anywhere within it but
+        # has not been reached above. The two loops above seed only from a
+        # top-level ReturnStatement and from field-referencing statements, so
+        # an if/else whose branches each return -- with nothing after it and no
+        # field reference -- is missed by both. In the dependency graph such a
+        # return lives *inside* the if/else node, so there is no standalone
+        # return node to find; the if/else nonetheless determines the method's
+        # result and must not be dropped. Without this rescue the sort
+        # collapsed the method to an empty body, making semantically distinct
+        # methods compare equal (soundness bug #221). Statements that genuinely
+        # contain no return remain prunable as dead code.
+        for statement in block.statements:
+            if id(statement) not in dfs_visited_ids and contains_return(statement):
                 dfs_stack.append(graph.get_node(statement))
                 do_dfs()
 

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -681,6 +681,17 @@ class RemoveUnreachableTransformer(BlockTransformer):
         self._block_versions: dict[int, dict[str, int]] = {}
 
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
+        # Any statement following an unconditional top-level return is
+        # unreachable. Truncating here keeps blocks well-formed when an
+        # earlier pass flattens an if/else whose branches return into a
+        # straight-line sequence with a trailing dead return (e.g. the
+        # topological sort emitting `return a; return b;`).
+        for index, statement in enumerate(block.statements):
+            if isinstance(statement, frog_ast.ReturnStatement) and index + 1 < len(
+                block.statements
+            ):
+                return frog_ast.Block(block.statements[: index + 1])
+
         def contains_unconditional_return(block: frog_ast.Block) -> bool:
             return any(
                 isinstance(statement, frog_ast.ReturnStatement)

--- a/tests/unit/engine/test_non_interchangeable.py
+++ b/tests/unit/engine/test_non_interchangeable.py
@@ -161,3 +161,53 @@ def test_early_return_guard_is_a_reorder_barrier() -> None:
         "guard `if (z == target) return ssStar;` — doing so changes the "
         "observable behavior on a second Hash query at the same z."
     )
+
+
+def test_if_else_returning_branches_not_dropped() -> None:
+    """Regression test for issue #221 (soundness bug).
+
+    A method whose body is a single `if (b) { return x; } else { return y; }`
+    has no top-level return statement and references no game field. The
+    topological sort previously seeded its dependency DFS only from a
+    top-level return statement and from field-using statements, so the
+    if/else (which is neither) was dropped entirely, collapsing the method
+    to an empty body.
+
+    Selector.pick and SelectorSwapped.pick return different values for the
+    same inputs, so they must NOT canonicalize to the same form.
+    """
+    selector = frog_parser.parse_game("""
+    Game Selector(Set T) {
+        T pick(T x, T y, Bool b) {
+            if (b) {
+                return x;
+            } else {
+                return y;
+            }
+        }
+    }
+    """)
+    selector_swapped = frog_parser.parse_game("""
+    Game SelectorSwapped(Set T) {
+        T pick(T x, T y, Bool b) {
+            if (b) {
+                return y;
+            } else {
+                return x;
+            }
+        }
+    }
+    """)
+    engine = _make_engine()
+    canonical_selector = engine.canonicalize_game(selector)
+    canonical_swapped = engine.canonicalize_game(selector_swapped)
+
+    # The if/else must survive canonicalization (not collapse to empty).
+    assert canonical_selector.methods[0].block.statements, (
+        "Issue #221: an if/else whose branches all return must not be "
+        "dropped by the topological sort"
+    )
+    assert canonical_selector != canonical_swapped, (
+        "Issue #221: Selector.pick(x, y, b) and SelectorSwapped.pick(x, y, b) "
+        "return different values and must NOT be interchangeable"
+    )

--- a/tests/unit/transforms/test_unreachable_transformer.py
+++ b/tests/unit/transforms/test_unreachable_transformer.py
@@ -6,6 +6,40 @@ from proof_frog.transforms.control_flow import RemoveUnreachableTransformer
 @pytest.mark.parametrize(
     "method,expected",
     [
+        # Statements after an unconditional top-level return are unreachable
+        # and must be dropped (regression coverage for the flattened
+        # `return a; return b;` shape the topological sort can emit).
+        (
+            """
+            Int f(Int x) {
+                Int y = x + 1;
+                return y;
+                return x;
+            }
+            """,
+            """
+            Int f(Int x) {
+                Int y = x + 1;
+                return y;
+            }
+            """,
+        ),
+        (
+            """
+            BitString<8> f() {
+                BitString<8> a <- BitString<8>;
+                return a;
+                BitString<8> b <- BitString<8>;
+                return b;
+            }
+            """,
+            """
+            BitString<8> f() {
+                BitString<8> a <- BitString<8>;
+                return a;
+            }
+            """,
+        ),
         (
             """
             Int f(Bool b) {


### PR DESCRIPTION
## Summary

Fixes #221. ProofFrog reported two clearly non-interchangeable games as interchangeable when a method's body was an `if/else` whose branches each return. The reporter's minimal POC — `Selector.pick(x, y, b)` returning `x`/`y` vs `SelectorSwapped` returning `y`/`x` — "proved" successfully when it must fail.

## Root cause

The culprit is the **topological sort** (`sort_block` in `proof_engine.py`), not the `RemoveUnreachable` pass the issue speculated about. `sort_block` builds a method's body from the statements backward-reachable from its *sinks*, seeded from (a) the first top-level `ReturnStatement` and (b) field-referencing statements.

In the dependency graph each top-level statement is one atomic node, and a `return` nested inside an `if/else` lives *inside* that `if/else` node — there is no standalone return node to find. So an `if/else` whose branches each return, with nothing after it and no field reference, was seeded by neither rule and **dropped entirely**, collapsing the method to an empty body. Every game of that shape collapsed identically, so the engine declared them all equal.

This bit because `sort_block` runs before `ElseUnwrap`/`SimplifyReturn` in the first canonicalization iteration, so it sees the raw `if/else`.

## Fix

Two small, individually-sound changes:

1. **`sort_block` (`proof_engine.py`)** — also seed the live set from every statement that *contains* a return anywhere within it, so an `if/else` whose branches return is kept. Statements that genuinely contain no return remain prunable as dead code.

2. **`RemoveUnreachable` (`control_flow.py`)** — truncate statements after an unconditional top-level return. Fixing (1) means a kept `if/else` can later flatten into a straight-line sequence with a trailing unreachable return (`return a; return b;`), which nothing previously removed (the pass handled `if/else` and Z3-subsumed sequences, but not a bare top-level return followed by more statements). Code after an unconditional return is unreachable, so this is unambiguously sound.

The second change is required because an in-tree proof (`CounterPRG_PRGSecurity`) had been inadvertently relying on the unsound drop to delete a dead branch; without the truncation it would regress once the drop is fixed.

## Tests
- `tests/unit/engine/test_non_interchangeable.py`: negative test — `Selector` and `SelectorSwapped` must not canonicalize to the same form, and the `if/else` must not collapse to an empty body.
- `tests/unit/transforms/test_unreachable_transformer.py`: statements after an unconditional top-level return are dropped.
- Full proof suite and `make lint` pass.
