### PR TITLE
Fix reference/write-scan blindness in canonicalization passes

### DIFF
--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -40,14 +40,22 @@ def generate_dependency_graph(
         return isinstance(node, frog_ast.ReturnStatement)
 
     def mutates_field(stmt: frog_ast.Statement) -> bool:
-        if not isinstance(
-            stmt, (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample)
-        ):
-            return False
-        # Peel element/slice/field accesses so nested element writes
-        # (`M[0][0] = v`) and field writes (`X.f = v`) to a field still count.
-        base = visitors.lvalue_base_name(stmt.var)
-        return base is not None and base in field_names
+        # A statement mutates a field if it contains ANYWHERE -- including
+        # nested inside an if/for block -- a write whose l-value base is a
+        # field. Checking only the top-level statement kind missed a field
+        # write buried in a branch (`if (...) { F[k] = v; }`), letting a later
+        # return be hoisted above the side-effecting branch (the branch then
+        # looks dead and is dropped). Peel element/slice/field accesses so
+        # `M[0][0] = v` and `X.f = v` to a field still count.
+        def _is_field_write(node: frog_ast.ASTNode) -> bool:
+            if not isinstance(
+                node, (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample)
+            ):
+                return False
+            base = visitors.lvalue_base_name(node.var)
+            return base is not None and base in field_names
+
+        return visitors.SearchVisitor(_is_field_write).visit(stmt) is not None
 
     def writes_name(node: frog_ast.ASTNode, name: str) -> bool:
         """True if *node* contains a write whose l-value base is *name* --

--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -9,6 +9,7 @@ def generate_dependency_graph(
     block: frog_ast.Block,
     fields: list[frog_ast.Field],
     proof_namespace: frog_ast.Namespace,
+    shadowed_names: set[str] | None = None,
 ) -> DependencyGraph:
     dependency_graph = DependencyGraph()
     for statement in block.statements:
@@ -18,6 +19,22 @@ def generate_dependency_graph(
         node_in_graph.add_neighbour(dependency_graph.get_node(statement))
 
     field_names = [field.name for field in fields]
+    # Names bound by an enclosing scope (method parameters, fields).  A bare
+    # ``VariableDeclaration`` of such a name is a *shadowing binder*: every
+    # later reference to the name resolves to the inner local, so the
+    # declaration must not be pruned as disconnected dead code (doing so
+    # rebinds those references to the outer binding -- RC1 scope-awareness,
+    # SliceOfInlineConcat attack-1).  We therefore make later uses of the name
+    # depend on the declaration so it is reachable from the return and ordered
+    # ahead of its uses.
+    shadowed = set(shadowed_names or set())
+
+    def binds_shadowed(stmt: frog_ast.Statement, name: str) -> bool:
+        return (
+            isinstance(stmt, frog_ast.VariableDeclaration)
+            and stmt.name == name
+            and name in shadowed
+        )
 
     def contains_return(node: frog_ast.ASTNode) -> bool:
         return isinstance(node, frog_ast.ReturnStatement)
@@ -100,6 +117,10 @@ def generate_dependency_graph(
                     related = name in visitors.referenced_variable_names(depends_on)
                 else:
                     related = writes_name(depends_on, name)
+                # A shadowing declaration of `name` is a binder the later use
+                # depends on, whether the use reads or writes.
+                if not related and binds_shadowed(depends_on, name):
+                    related = True
                 if related:
                     add_dependency(node_in_graph, depends_on)
                     break
@@ -275,28 +296,67 @@ def unnecessary_statement_info(
 
 
 def remove_unnecessary_statements(
-    fields: list[str], block: frog_ast.Block
+    fields: list[str], block: frog_ast.Block, outer_names: set[str] | None = None
 ) -> frog_ast.Block:
     required_map, _ = unnecessary_statement_info(fields, block)
+    base_outer_names = outer_names if outer_names is not None else set()
 
-    def construct_new(block: frog_ast.Block) -> frog_ast.Block:
+    def _block_local_names(block: frog_ast.Block) -> set[str]:
+        names: set[str] = set()
+        for statement in block.statements:
+            if isinstance(statement, frog_ast.VariableDeclaration):
+                names.add(statement.name)
+            elif isinstance(
+                statement,
+                (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
+            ):
+                base = visitors.lvalue_base_name(statement.var)
+                if base is not None:
+                    names.add(base)
+        return names
+
+    def construct_new(block: frog_ast.Block, enclosing: set[str]) -> frog_ast.Block:
+        # Names bound by enclosing scopes (params, fields, outer-block locals).
+        # A bare ``VariableDeclaration`` that shadows one of these may NOT be
+        # dropped: removing it would silently rebind every subsequent reference
+        # of that name to the enclosing binding (a different variable, possibly
+        # of a different type/length), changing the program's meaning.  (RC1
+        # scope-awareness; surfaces e.g. SliceOfInlineConcat attack-1.)
+        #
+        # Names bound at *this* level are visible to any nested block, so they
+        # extend the enclosing set we hand to deeper recursion.
+        inner_enclosing = enclosing | _block_local_names(block)
         new_statements: list[frog_ast.Statement] = []
         for statement in block.statements:
             if isinstance(statement, (frog_ast.NumericFor, frog_ast.GenericFor)):
                 new_statement = copy.deepcopy(statement)
-                nested_block = construct_new(statement.block)
-                new_statement.block = nested_block
+                binder = (
+                    statement.name
+                    if isinstance(statement, frog_ast.NumericFor)
+                    else statement.var_name
+                )
+                new_statement.block = construct_new(
+                    statement.block, inner_enclosing | {binder}
+                )
                 new_statements.append(new_statement)
             elif isinstance(statement, frog_ast.IfStatement):
                 new_if_statement = copy.deepcopy(statement)
-                nested_blocks = [construct_new(block) for block in statement.blocks]
-                new_if_statement.blocks = nested_blocks
+                new_if_statement.blocks = [
+                    construct_new(b, inner_enclosing) for b in statement.blocks
+                ]
                 new_statements.append(new_if_statement)
             elif required_map.get(statement):
                 new_statements.append(statement)
+            elif (
+                isinstance(statement, frog_ast.VariableDeclaration)
+                and statement.name in enclosing
+            ):
+                # Shadowing declaration -- keep it so the inner binding (and its
+                # declared type) survives.
+                new_statements.append(statement)
         return frog_ast.Block(new_statements)
 
-    return construct_new(block)
+    return construct_new(block, set(base_outer_names))
 
 
 def _collect_field_access_refs(game: frog_ast.Game) -> list[frog_ast.Variable]:
@@ -351,9 +411,17 @@ def remove_unnecessary_fields(game: frog_ast.Game) -> frog_ast.Game:
         if frog_ast.Variable(field.name) in necessary_vars
     ]
     actually_necessary_field_names = [field.name for field in new_game.fields]
+    # Names bound outside any method body: every field (a method local may
+    # shadow even a field that this pass is about to drop) plus the method's
+    # own parameters.  A bare local declaration shadowing one of these must not
+    # be removed (it would rebind references to the outer binding).
+    all_field_names = {field.name for field in game.fields}
     for method in new_game.methods:
+        param_names = {param.name for param in method.signature.parameters}
         method.block = remove_unnecessary_statements(
-            actually_necessary_field_names, method.block
+            actually_necessary_field_names,
+            method.block,
+            outer_names=all_field_names | param_names,
         )
     # Remove Void methods with empty bodies (e.g., Initialize after field removal)
     new_game.methods = [

--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import functools
 import copy
 from typing import Optional, Callable, Tuple
 from . import visitors
@@ -28,14 +27,33 @@ def generate_dependency_graph(
             stmt, (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample)
         ):
             return False
-        target = stmt.var
-        if isinstance(target, frog_ast.Variable):
-            return target.name in field_names
-        if isinstance(target, frog_ast.ArrayAccess) and isinstance(
-            target.the_array, frog_ast.Variable
-        ):
-            return target.the_array.name in field_names
-        return False
+        # Peel element/slice/field accesses so nested element writes
+        # (`M[0][0] = v`) and field writes (`X.f = v`) to a field still count.
+        base = visitors.lvalue_base_name(stmt.var)
+        return base is not None and base in field_names
+
+    def writes_name(node: frog_ast.ASTNode, name: str) -> bool:
+        """True if *node* contains a write whose l-value base is *name* --
+        a plain, element, slice, or field write."""
+
+        def _writes(inner: frog_ast.ASTNode) -> bool:
+            if (
+                isinstance(
+                    inner,
+                    (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
+                )
+                and visitors.lvalue_base_name(inner.var) == name
+            ):
+                return True
+            # `x <-uniq[S] T` implicitly inserts the draw into S, so a read of S
+            # must be ordered relative to it.
+            return (
+                isinstance(inner, frog_ast.UniqueSample)
+                and inner.surface_form == "uniq"
+                and name in visitors.referenced_variable_names(inner.unique_set)
+            )
+
+        return visitors.SearchVisitor(_writes).visit(node) is not None
 
     for index, statement in enumerate(block.statements):
         node_in_graph = dependency_graph.get_node(statement)
@@ -61,53 +79,28 @@ def generate_dependency_graph(
                 ):
                     add_dependency(node_in_graph, preceding_statement)
 
-        variables = visitors.VariableCollectionVisitor().visit(statement)
-        for variable in variables:
+        # Complete read-set, in first-appearance order so dependency-edge order
+        # is deterministic: includes variables referenced through a FieldAccess
+        # (`M` in `|M.keys|`) or array/slice access, which
+        # VariableCollectionVisitor drops -- without them a read of a map view
+        # looks independent of a write to the map and gets reordered across it.
+        statement_write_cache: dict[str, bool] = {}
+        for variable in visitors.referenced_variables_in_order(statement):
+            name = variable.name
+            if name in proof_namespace:
+                continue
+            # Does *this* statement write `name`?  If so it must come after any
+            # earlier statement that references `name` (WAR / WAW); otherwise it
+            # only reads `name` and must come after any earlier writer (RAW).
+            if name not in statement_write_cache:
+                statement_write_cache[name] = writes_name(statement, name)
+            statement_writes = statement_write_cache[name]
             for depends_on in earlier_statements:
-                if variable.name in proof_namespace:
-                    continue
-
-                def search_for_assignment(
-                    variable: frog_ast.Variable, node: frog_ast.ASTNode
-                ) -> bool:
-                    return (
-                        isinstance(
-                            node,
-                            (
-                                frog_ast.Assignment,
-                                frog_ast.Sample,
-                                frog_ast.UniqueSample,
-                            ),
-                        )
-                    ) and node.var == variable
-
-                has_write = False
-                if (
-                    visitors.SearchVisitor(
-                        functools.partial(search_for_assignment, variable)
-                    ).visit(statement)
-                    is not None
-                ):
-                    has_write = True
-
-                def search_for_any(
-                    variable: frog_ast.Variable, node: frog_ast.ASTNode
-                ) -> bool:
-                    return variable == node
-
-                if (
-                    has_write
-                    and visitors.SearchVisitor(
-                        functools.partial(search_for_any, variable)
-                    ).visit(depends_on)
-                    is not None
-                ) or (
-                    not has_write
-                    and visitors.SearchVisitor(
-                        functools.partial(search_for_assignment, variable)
-                    ).visit(depends_on)
-                    is not None
-                ):
+                if statement_writes:
+                    related = name in visitors.referenced_variable_names(depends_on)
+                else:
+                    related = writes_name(depends_on, name)
+                if related:
                     add_dependency(node_in_graph, depends_on)
                     break
 
@@ -236,6 +229,12 @@ class BubbleSortFieldAssignment(visitors.BlockTransformer):
         return frog_ast.Block(new_statements)
 
 
+def _vars_of(node: frog_ast.ASTNode) -> list[frog_ast.Variable]:
+    """Complete read-set as Variable nodes -- includes variables under a
+    FieldAccess/ArrayAccess/Slice that VariableCollectionVisitor drops."""
+    return visitors.referenced_variables_in_order(node)
+
+
 def unnecessary_statement_info(
     fields: list[str], block: frog_ast.Block
 ) -> Tuple[frog_ast.ASTMap[bool], list[frog_ast.Variable]]:
@@ -251,27 +250,23 @@ def unnecessary_statement_info(
             if isinstance(
                 statement, frog_ast.ReturnStatement
             ) or visitors.assigns_variable(necessary_vars, statement):
-                all_vars = visitors.VariableCollectionVisitor().visit(statement)
+                # Complete read-set: variables reached through a FieldAccess
+                # (`M` in `|M.keys|`) keep their backing writes alive too.
+                all_vars = _vars_of(statement)
                 necessary_vars += all_vars
                 required_map.set(statement, True)
             elif isinstance(statement, frog_ast.NumericFor):
-                necessary_vars += visitors.VariableCollectionVisitor().visit(
-                    statement.start
-                ) + visitors.VariableCollectionVisitor().visit(statement.end)
+                necessary_vars += _vars_of(statement.start) + _vars_of(statement.end)
                 remove_helper(statement.block)
             elif isinstance(
                 statement,
                 frog_ast.GenericFor,
             ):
-                necessary_vars += visitors.VariableCollectionVisitor().visit(
-                    statement.over
-                )
+                necessary_vars += _vars_of(statement.over)
                 remove_helper(statement.block)
             elif isinstance(statement, frog_ast.IfStatement):
                 for condition in statement.conditions:
-                    necessary_vars += visitors.VariableCollectionVisitor().visit(
-                        condition
-                    )
+                    necessary_vars += _vars_of(condition)
                 for if_block in statement.blocks:
                     remove_helper(if_block)
 

--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -1695,12 +1695,21 @@ class ProofEngine:
     def sort_game(self, game: frog_ast.Game) -> frog_ast.Game:
         new_game = copy.deepcopy(game)
         for method in new_game.methods:
-            method.block = self.sort_block(game, method.block)
+            param_names = {p.name for p in method.signature.parameters}
+            method.block = self.sort_block(game, method.block, param_names)
         return new_game
 
-    def sort_block(self, game: frog_ast.Game, block: frog_ast.Block) -> frog_ast.Block:
+    def sort_block(
+        self,
+        game: frog_ast.Game,
+        block: frog_ast.Block,
+        param_names: set[str] | None = None,
+    ) -> frog_ast.Block:
+        # A bare declaration that shadows a field or parameter must survive the
+        # sort (its removal would rebind later references to the outer binding).
+        shadowed = {field.name for field in game.fields} | (param_names or set())
         graph = dependencies.generate_dependency_graph(
-            block, game.fields, self.proof_namespace
+            block, game.fields, self.proof_namespace, shadowed_names=shadowed
         )
 
         def is_return(node: frog_ast.ASTNode) -> bool:

--- a/proof_frog/transforms/_requirements.py
+++ b/proof_frog/transforms/_requirements.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .. import frog_ast
-from ..visitors import SearchVisitor
+from ..visitors import SearchVisitor, lvalue_base_name
 
 
 def _set_contains_literal_zero(expr: frog_ast.Expression) -> bool:
@@ -17,25 +17,57 @@ def _set_contains_literal_zero(expr: frog_ast.Expression) -> bool:
 
 
 def is_known_nonzero(var_name: str, game: frog_ast.Game) -> bool:
-    """True if *var_name* is sampled via ``<-uniq[S]`` with ``0 ∈ S`` (literal).
+    """True if *var_name* is provably nonzero throughout *game*.
 
-    The analysis is purely syntactic: scan *game* for a :class:`UniqueSample`
-    whose bound variable is ``var_name`` and inspect the exclusion set. Return
-    ``True`` iff the exclusion set is a set literal that contains the integer
-    literal ``0``.
+    The exponent that re-keys a persistent map must itself be a persistent
+    game FIELD whose nonzero value is established once, at setup, and never
+    disturbed:
+
+    * ``var_name`` must be a game field (a local/parameter of the same name is
+      not the persistent key, and an adversary parameter is untrusted);
+    * its nonzero value must come from a ``<-uniq[S]`` with literal ``0 in S``
+      in ``Initialize`` -- the method guaranteed to run once before any oracle.
+      A uniq sample in some other oracle (``Unrelated``) may never run, so the
+      field would stay at its default (F-136 variant B); and
+    * NO other write to the field exists anywhere -- a later ``k = 0``, a plain
+      sample, a ``<-uniq`` without ``0``, or any write outside ``Initialize``
+      voids the guarantee (F-136 variant A).
     """
-
-    found: list[bool] = []
-
-    def _visit(node: frog_ast.ASTNode) -> bool:
-        if not isinstance(node, frog_ast.UniqueSample):
-            return False
-        bound = node.var
-        if not isinstance(bound, frog_ast.Variable) or bound.name != var_name:
-            return False
-        if _set_contains_literal_zero(node.unique_set):
-            found.append(True)
+    if var_name not in {f.name for f in game.fields}:
         return False
+    for method in game.methods:
+        for param in method.signature.parameters:
+            if param.name == var_name:
+                return False
 
-    SearchVisitor(_visit).visit(game)
-    return bool(found)
+    def _writes_to_field(method: frog_ast.Method) -> list[frog_ast.Statement]:
+        out: list[frog_ast.Statement] = []
+
+        def _visit(node: frog_ast.ASTNode) -> bool:
+            if (
+                isinstance(
+                    node,
+                    (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
+                )
+                and lvalue_base_name(node.var) == var_name
+            ):
+                out.append(node)
+            return False
+
+        SearchVisitor(_visit).visit(method)
+        return out
+
+    has_nonzero_sample = False
+    for method in game.methods:
+        in_initialize = method.signature.name == "Initialize"
+        for write in _writes_to_field(method):
+            is_uniq_zero = isinstance(
+                write, frog_ast.UniqueSample
+            ) and _set_contains_literal_zero(write.unique_set)
+            if in_initialize and is_uniq_zero:
+                has_nonzero_sample = True
+            else:
+                # Any non-uniq-zero write, or any write outside Initialize, may
+                # leave the field zero or unknown.
+                return False
+    return has_nonzero_sample

--- a/proof_frog/transforms/_wrappers.py
+++ b/proof_frog/transforms/_wrappers.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Hashable, Optional
 
 from .. import frog_ast
-from ..visitors import SearchVisitor
+from ..visitors import SearchVisitor, lvalue_base_name
 from ._base import PipelineContext, _lookup_primitive_method
 from ._requirements import is_known_nonzero
 
@@ -252,17 +252,17 @@ class _PrimCallShape(WrapperShape):
                 nonlocal bad
                 if bad is not None:
                     return False
-                target: Optional[frog_ast.Expression] = None
                 if isinstance(
                     n,
                     (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
                 ):
-                    target = n.var
-                if (
-                    isinstance(target, frog_ast.Variable)
-                    and target.name in context_names
-                ):
-                    bad = (target.name, "context arg is assigned outside Initialize")
+                    # Peel element/slice/field accesses so an element write
+                    # (`sk[0] = v`) or field write to a context arg counts as a
+                    # mutation -- a bare-Variable target check missed those
+                    # (F-135).
+                    base = lvalue_base_name(n.var)
+                    if base is not None and base in context_names:
+                        bad = (base, "context arg is mutated outside Initialize")
                 return False
 
             SearchVisitor(_visit).visit(method)

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -939,10 +939,13 @@ def _count_field_assigns_recursive(node: frog_ast.ASTNode, field_name: str) -> i
 
     def _counter(n: frog_ast.ASTNode) -> bool:
         nonlocal count
+        # Peel element/slice/field accesses: an element write `M[k] = v`
+        # mutates the field, so a field that is also element-written must not
+        # be miscounted as single-assignment (and therefore inlined as a
+        # constant).
         if (
             isinstance(n, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample))
-            and isinstance(n.var, frog_ast.Variable)
-            and n.var.name == field_name
+            and lvalue_base_name(n.var) == field_name
         ):
             count += 1
         return False  # never stop early — visit all nodes

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -1084,23 +1084,21 @@ class IfConditionAliasSubstitutionTransformer(BlockTransformer):
                 new_branch = SubstitutionTransformer(inline_map).transform(new_branch)
 
             # Phase 2: Substitute each comparison field with its replacement.
-            # Stop at the first reassignment of any comparison field within the
-            # branch, since after reassignment the field value may differ from
-            # the replacement.
+            # The substitution ``field -> replacement`` is valid only while the
+            # field still equals the replacement, i.e. until EITHER side is
+            # written. Stop at the first statement that writes (anywhere, incl.
+            # nested blocks and element/slice/field writes -- F-075 A2/A3) any
+            # comparison field OR any free variable of a replacement expression
+            # (reassigning the local breaks ``field == local`` -- A4). Keep that
+            # statement and everything after it unsubstituted.
             alias_map = frog_ast.ASTMap[frog_ast.ASTNode](identity=False)
+            invalidating_names = set(field_var_names)
             for field_expr, replacement in alias_pairs:
                 alias_map.set(field_expr, replacement)
+                invalidating_names |= referenced_variable_names(replacement)
             new_stmts: list[frog_ast.Statement] = []
             for stmt_idx, branch_stmt in enumerate(new_branch.statements):
-                # Check if this statement reassigns one of the comparison fields
-                if (
-                    isinstance(
-                        branch_stmt,
-                        (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
-                    )
-                    and isinstance(branch_stmt.var, frog_ast.Variable)
-                    and branch_stmt.var.name in field_var_names
-                ):
+                if reassigns_or_rebinds(invalidating_names, branch_stmt):
                     # Stop substituting: keep this and all remaining as-is
                     new_stmts.extend(new_branch.statements[stmt_idx:])
                     break

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -2109,6 +2109,28 @@ class DeadGuardedAssignmentEliminationTransformer(BlockTransformer):
     ciphertexts.
     """
 
+    def __init__(self) -> None:
+        # Field names and their read counts across the WHOLE game, populated by
+        # ``transform_game``.  Empty when the transformer is driven on a bare
+        # block (unit tests): then every name is treated as a method-local and
+        # the block-scoped read count applies.
+        self._field_names: set[str] = set()
+        self._field_read_counts: dict[str, int] = {}
+
+    def transform_game(self, game: frog_ast.Game) -> frog_ast.Game:
+        self._field_names = {f.name for f in game.fields}
+        # A field persists across oracle calls, so a read of it in ANY method
+        # observes the value.  Count reads of each field over every method
+        # block (F-099): a field whose value is read in a sibling oracle is not
+        # dead even though the block-scoped count over one method is 1.
+        self._field_read_counts = {
+            name: sum(self._read_count(m.block, name) for m in game.methods)
+            for name in self._field_names
+        }
+        new_game = copy.copy(game)
+        new_game.methods = [self.transform(m) for m in game.methods]
+        return new_game
+
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         for index, statement in enumerate(block.statements):
             use = self._match_guarded_use(statement, block.statements[index + 1 :])
@@ -2119,8 +2141,26 @@ class DeadGuardedAssignmentEliminationTransformer(BlockTransformer):
             # read solely by the matched `if (v)` guard. Any other read of `v`
             # would observe the rewritten `false` value. Count reads (variable
             # occurrences that are not an assignment target); exactly one --
-            # the guard condition -- is required.
-            if self._read_count(block, v_name) != 1:
+            # the guard condition -- is required. A FIELD additionally persists
+            # across oracle calls (F-099), so:
+            #   - its value may be read in a sibling/later oracle -> the read
+            #     count must span the whole game (not just this block); and
+            #   - a guarded/conditional assignment leaves the field carrying its
+            #     previous-call value into the guard read, so the kill is sound
+            #     only if the field is UNCONDITIONALLY assigned before the guard
+            #     in this call (definite assignment overwrites any stale value).
+            if v_name in self._field_names:
+                if self._field_read_counts.get(v_name, 0) != 1:
+                    continue
+                prefix_stmts = block.statements[:index]
+                if not any(
+                    isinstance(s, frog_ast.Assignment)
+                    and isinstance(s.var, frog_ast.Variable)
+                    and s.var.name == v_name
+                    for s in prefix_stmts
+                ):
+                    continue
+            elif self._read_count(block, v_name) != 1:
                 continue
             guard_lits = [
                 _condition_literal(g, True) for g in _flatten_top_level_and(guard)

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -26,7 +26,7 @@ from ..visitors import (
     Z3FormulaVisitor,
     GetTypeMapVisitor,
     NameTypeMap,
-    assigns_variable,
+    lvalue_base_name,
     referenced_variable_names,
     reassigns_or_rebinds,
     block_unconditionally_returns,
@@ -631,19 +631,16 @@ class SimplifyReturnTransformer(BlockTransformer):
             # Check that no intervening statement modifies a free variable
             # of the expression being inlined.  Without this check, moving
             # `expr` from its original evaluation point to the return point
-            # could change its value.
-            expr_free_vars = VariableCollectionVisitor().visit(
-                copy.deepcopy(statement.value)
-            )
+            # could change its value.  The read-set must see variables under
+            # FieldAccess (`M` in `|M.keys|`) and the write-set must see
+            # element/slice/field writes, `<-uniq[S]` exclusion-set insertion,
+            # and loop-binder shadowing -- so both use the node-kind-complete
+            # scanners rather than VariableCollectionVisitor/assigns_variable.
+            expr_free_vars = referenced_variable_names(statement.value)
             if expr_free_vars:
                 for skipped_idx in range(index + 1, len(block.statements) - 1):
                     skipped = block.statements[skipped_idx]
-                    if (
-                        SearchVisitor(
-                            functools.partial(assigns_variable, expr_free_vars)
-                        ).visit(skipped)
-                        is not None
-                    ):
+                    if reassigns_or_rebinds(expr_free_vars, skipped):
                         return block
             return self.transform_block(
                 frog_ast.Block(block.statements[:index])
@@ -720,19 +717,23 @@ class RemoveUnreachableTransformer(BlockTransformer):
             updated = []
 
             def assigns_variable_search(search_node: frog_ast.ASTNode) -> bool:
-                if not isinstance(search_node, (frog_ast.Assignment, frog_ast.Sample)):
-                    return False
-                var = None
-                if isinstance(search_node.var, frog_ast.Variable):
-                    var = search_node.var
-                if isinstance(search_node.var, frog_ast.ArrayAccess) and isinstance(
-                    search_node.var.the_array, frog_ast.Variable
+                if not isinstance(
+                    search_node,
+                    (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
                 ):
-                    var = search_node.var.the_array
-
-                if var in used_variables and var not in updated:
-                    variable_version_map[var.name] += 1
-                    updated.append(var)
+                    return False
+                # Peel element/slice/field accesses to the written base name so
+                # nested element writes (`M[0][0] = v`) bump the version too --
+                # a depth-1-only check left `M` looking unmodified and let Z3
+                # wrongly prove the following statements unreachable.
+                base_name = lvalue_base_name(search_node.var)
+                if (
+                    base_name is not None
+                    and base_name in variable_version_map
+                    and base_name not in updated
+                ):
+                    variable_version_map[base_name] += 1
+                    updated.append(base_name)
                     return True
                 return False
 

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -27,6 +27,8 @@ from ..visitors import (
     GetTypeMapVisitor,
     NameTypeMap,
     assigns_variable,
+    referenced_variable_names,
+    reassigns_or_rebinds,
     block_unconditionally_returns,
 )
 from ._base import TransformPass, PipelineContext, NearMiss, has_nondeterministic_call
@@ -471,19 +473,24 @@ class GuardConditionSimplificationTransformer(Transformer):
         let_types = self.ctx.proof_let_types if self.ctx else None
         return not has_nondeterministic_call(expr, namespace, let_types)
 
-    @staticmethod
-    def _reassigns_any(names: set[str], block: frog_ast.Block) -> bool:
-        def writes(node: frog_ast.ASTNode) -> bool:
-            return (
-                isinstance(
-                    node,
-                    (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
-                )
-                and isinstance(node.var, frog_ast.Variable)
-                and node.var.name in names
+    def _note_unstable_guard(self, cond: frog_ast.Expression) -> None:
+        if self.ctx is None:
+            return
+        self.ctx.near_misses.append(
+            NearMiss(
+                transform_name="Guard Condition Simplification",
+                reason=(
+                    "Guard not substituted into its branch: a variable the "
+                    "guard reads is reassigned, has an element/field/slice "
+                    "write, is inserted into via <-uniq, or is rebound by a "
+                    "loop in the branch, so the guard's value is not invariant"
+                ),
+                location=None,
+                suggestion=None,
+                variable=str(cond),
+                method=None,
             )
-
-        return SearchVisitor(writes).visit(block) is not None
+        )
 
     def _substitute(
         self, block: frog_ast.Block, cond: frog_ast.Expression, value: bool
@@ -499,13 +506,16 @@ class GuardConditionSimplificationTransformer(Transformer):
         if len(if_statement.conditions) == 1:
             cond = if_statement.conditions[0]
             if self._is_deterministic(cond) and not isinstance(cond, frog_ast.Boolean):
-                cond_vars = {v.name for v in VariableCollectionVisitor().visit(cond)}
-                if not self._reassigns_any(cond_vars, new_blocks[0]):
+                cond_vars = referenced_variable_names(cond)
+                if reassigns_or_rebinds(cond_vars, new_blocks[0]):
+                    self._note_unstable_guard(cond)
+                else:
                     new_blocks[0] = self._substitute(new_blocks[0], cond, True)
-                if if_statement.has_else_block() and not self._reassigns_any(
-                    cond_vars, new_blocks[1]
-                ):
-                    new_blocks[1] = self._substitute(new_blocks[1], cond, False)
+                if if_statement.has_else_block():
+                    if reassigns_or_rebinds(cond_vars, new_blocks[1]):
+                        self._note_unstable_guard(cond)
+                    else:
+                        new_blocks[1] = self._substitute(new_blocks[1], cond, False)
         # Recurse into the (possibly substituted) children.
         return frog_ast.IfStatement(
             [self.transform(c) for c in if_statement.conditions],

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -23,6 +23,8 @@ from ..visitors import (
     Visitor,
     ReplaceTransformer,
     VariableCollectionVisitor,
+    referenced_variable_names,
+    reassigns_or_rebinds,
 )
 from ._base import (
     TransformPass,
@@ -191,20 +193,6 @@ class InlineSingleUseVariableTransformer(BlockTransformer):
             var_name = statement.var.name
             expr = statement.value
 
-            def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
-                return (
-                    isinstance(
-                        node,
-                        (
-                            frog_ast.Sample,
-                            frog_ast.Assignment,
-                            frog_ast.UniqueSample,
-                        ),
-                    )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == name
-                )
-
             def uses_var(name: str, node: frog_ast.ASTNode) -> bool:
                 return isinstance(node, frog_ast.Variable) and node.name == name
 
@@ -212,13 +200,9 @@ class InlineSingleUseVariableTransformer(BlockTransformer):
                 copy.deepcopy(list(block.statements[index + 1 :]))
             )
 
-            # Skip if var is reassigned anywhere in remaining
-            if (
-                SearchVisitor(functools.partial(is_written_to, var_name)).visit(
-                    remaining_block
-                )
-                is not None
-            ):
+            # Skip if var is reassigned anywhere in remaining (element/field
+            # writes and <-uniq insertion count too, via the shared scanner).
+            if reassigns_or_rebinds({var_name}, remaining_block):
                 continue
 
             # Find the first use of var in remaining_block
@@ -257,19 +241,19 @@ class InlineSingleUseVariableTransformer(BlockTransformer):
                     )
                 continue
 
-            # Collect free variables in expr and check none are written to
-            # between the declaration and the single use site
-            free_vars = VariableCollectionVisitor().visit(copy.deepcopy(expr))
+            # Collect free variables in expr (complete read-set: sees variables
+            # under FieldAccess such as `M` in `|M.keys|`) and check none are
+            # mutated between the declaration and the single use site -- where a
+            # mutation is any element/slice/field write, a <-uniq insertion, or a
+            # loop-binder rebind.
+            free_var_names = referenced_variable_names(expr)
             intermediate = frog_ast.Block(
                 list(remaining_block.statements[:first_use_idx])
             )
             modified_free_vars = [
-                fv.name
-                for fv in free_vars
-                if SearchVisitor(functools.partial(is_written_to, fv.name)).visit(
-                    intermediate
-                )
-                is not None
+                name
+                for name in sorted(free_var_names)
+                if reassigns_or_rebinds({name}, intermediate)
             ]
             if modified_free_vars:
                 if self.ctx is not None:
@@ -518,20 +502,6 @@ class InlineMultiUsePureExpressionTransformer(BlockTransformer):
             ):
                 continue
 
-            def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
-                return (
-                    isinstance(
-                        node,
-                        (
-                            frog_ast.Sample,
-                            frog_ast.Assignment,
-                            frog_ast.UniqueSample,
-                        ),
-                    )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == name
-                )
-
             def uses_var(name: str, node: frog_ast.ASTNode) -> bool:
                 return isinstance(node, frog_ast.Variable) and node.name == name
 
@@ -539,13 +509,9 @@ class InlineMultiUsePureExpressionTransformer(BlockTransformer):
                 copy.deepcopy(list(block.statements[index + 1 :]))
             )
 
-            # Skip if var is reassigned
-            if (
-                SearchVisitor(functools.partial(is_written_to, var_name)).visit(
-                    remaining_block
-                )
-                is not None
-            ):
+            # Skip if var is reassigned (element/field writes and <-uniq
+            # insertion are reassignments too, via the shared scanner).
+            if reassigns_or_rebinds({var_name}, remaining_block):
                 continue
 
             # Skip if var is not used at all
@@ -557,15 +523,13 @@ class InlineMultiUsePureExpressionTransformer(BlockTransformer):
             ):
                 continue
 
-            # Skip if any free variable in expr is reassigned
-            free_vars = VariableCollectionVisitor().visit(copy.deepcopy(expr))
-            if any(
-                SearchVisitor(functools.partial(is_written_to, fv.name)).visit(
-                    remaining_block
-                )
-                is not None
-                for fv in free_vars
-            ):
+            # Skip if any free variable of expr is mutated between the binding
+            # and its use sites: the read-set must see variables under
+            # FieldAccess (`M` in `|M.keys|`) and the write-set must see
+            # element/slice/field writes, `<-uniq[S]` exclusion-set insertion,
+            # and loop-binder shadowing -- otherwise the inlined expression
+            # would silently take a different value at the use site.
+            if reassigns_or_rebinds(referenced_variable_names(expr), remaining_block):
                 continue
 
             # Replace all occurrences of var with expr
@@ -940,38 +904,15 @@ class ForwardExpressionAliasTransformer(BlockTransformer):
                 copy.deepcopy(block.statements[index + 1 :])
             )
 
-            def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
-                return (
-                    isinstance(
-                        node,
-                        (
-                            frog_ast.Sample,
-                            frog_ast.Assignment,
-                            frog_ast.UniqueSample,
-                        ),
-                    )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == name
-                )
-
-            # Skip if var is reassigned
-            if (
-                SearchVisitor(functools.partial(is_written_to, var_name)).visit(
-                    remaining_block
-                )
-                is not None
-            ):
+            # Skip if var is reassigned (element/field writes and <-uniq
+            # insertion count too, via the shared scanner).
+            if reassigns_or_rebinds({var_name}, remaining_block):
                 continue
 
-            # Skip if any free variable in expr is reassigned
-            free_vars = VariableCollectionVisitor().visit(copy.deepcopy(expr))
-            if any(
-                SearchVisitor(functools.partial(is_written_to, fv.name)).visit(
-                    remaining_block
-                )
-                is not None
-                for fv in free_vars
-            ):
+            # Skip if any free variable of expr is mutated later: a complete
+            # read-set (vars under FieldAccess) and write/rebind scan are
+            # required so the inlined expression keeps its original value.
+            if reassigns_or_rebinds(referenced_variable_names(expr), remaining_block):
                 continue
 
             # Find a structurally-equal occurrence of expr in remaining block

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -610,6 +610,17 @@ class CollapseAssignmentTransformer(BlockTransformer):
                     and later_statement.var == statement.var
                 ):
                     break
+                # A *typed* later statement (`Type v <- e`) is a re-DECLARATION,
+                # i.e. a new binding (possibly shadowing the earlier `v` if an
+                # intervening scope was flattened into this block), not a plain
+                # reassignment of the same variable. Folding the declaration's
+                # type forward onto it would mis-type the new binding (RC1
+                # scope-awareness; SliceOfInlineConcat attack-3b, where a sunk
+                # outer `BitString<k> a` collided with an inner
+                # `BitString<k+m> a` and produced `BitString<k> a <- ...k+m...`).
+                # Only an untyped reassignment is a safe collapse target.
+                if later_statement.the_type is not None:
+                    break
                 later_rhs = (
                     later_statement.sampled_from
                     if isinstance(later_statement, frog_ast.Sample)

--- a/proof_frog/transforms/map_reindex.py
+++ b/proof_frog/transforms/map_reindex.py
@@ -299,6 +299,13 @@ def _discover_shape(
                 if bad is not None:
                     return bad
 
+    # ids of `.entries` views that are the iterable of a recognized loop --
+    # those are validated by Pass 1 and must not be re-blocked in Pass 2.
+    entries_loop_over_ids: set[int] = set()
+    for method in game.methods:
+        for loop in _find_entries_loops(method, map_name):
+            entries_loop_over_ids.add(id(loop.over))
+
     # Pass 2: read sites.
     for method in game.methods:
         mname = method.signature.name
@@ -308,6 +315,26 @@ def _discover_shape(
                 continue
             key_expr = _extract_read_key(hit)
             if key_expr is None:
+                # Non-key access. ``|M|`` (size) and ``M.values`` are invariant
+                # under an injective key reindexing, and an ``M.entries`` that
+                # drives a recognized loop is validated by Pass 1. But a direct
+                # ``M.keys`` (or a loose ``M.entries`` not consumed by a
+                # recognized loop) exposes the map's KEY structure, which the
+                # reindexing would change -- block rather than silently skip
+                # (F-134).
+                if isinstance(hit, frog_ast.UnaryOperation):
+                    continue
+                if isinstance(hit, frog_ast.FieldAccess):
+                    if hit.name == "values":
+                        continue
+                    if hit.name == "entries" and id(hit) in entries_loop_over_ids:
+                        continue
+                    return _DiscoveryResult(
+                        None,
+                        f"map key-view '.{hit.name}' is read directly; key "
+                        "reindexing would change the observed keys",
+                        mname,
+                    )
                 continue
             whole_shape = first_match_whole(recognizers, key_expr, ctx, game)
             if whole_shape is None:

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -442,11 +442,16 @@ def _rf_call_in_loop(block: frog_ast.Block, rf_name: str) -> bool:
 
 
 def _count_rf_calls(block: frog_ast.Block, rf_name: str) -> tuple[int, int]:
-    """Count RF calls and non-call references to *rf_name* in a block.
+    """Count RF calls and field-access references to *rf_name* in a block.
 
     Returns ``(call_count, field_access_count)``.  Field accesses are
     references like ``RF.domain`` that prevent simplification.  The
     ``Variable("RF")`` inside ``FuncCall(RF, x)`` is not counted separately.
+
+    NOTE: ``field_access_count`` is *only* the ``RF.domain`` style references.
+    A bare-variable copy (``RF2 = RF``) or argument pass (``f(RF)``) is NOT
+    counted here; callers that need the complete non-call reference set must
+    use :func:`_count_variable_refs` (``total occurrences - call_count``).
     """
     counts: list[int] = [0, 0]  # [calls, field_accesses]
 
@@ -515,7 +520,16 @@ class LocalRFToUniformTransformer(BlockTransformer):
 
             remaining = frog_ast.Block(block.statements[sample_idx + 1 :])
 
-            call_count, other_ref_count = _count_rf_calls(remaining, rf_name)
+            # The rewrite is sound only if the RF is evaluated exactly once and
+            # never otherwise referenced. ``_count_rf_calls`` reports only
+            # ``RF.domain``-style field accesses; a bare-variable copy
+            # (``RF2 = RF``), an argument pass (``f(RF)``), or a set/tuple
+            # element would let the function value escape and be evaluated a
+            # second time. Use the complete reference count: every
+            # ``Variable(rf_name)`` occurrence that is not the ``func`` position
+            # of a counted call is a blocking non-call reference (F-026).
+            call_count, _ = _count_rf_calls(remaining, rf_name)
+            other_ref_count = _count_variable_refs(remaining, rf_name) - call_count
 
             if call_count != 1 or other_ref_count > 0:
                 if self.ctx is not None and call_count > 0:

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -2140,6 +2140,18 @@ def _match_idiom_suffix(
     if not _expr_references_any(key_expr, param_names):
         return None
 
+    # (F-005) The key expression must not read the map itself.  A
+    # self-referential key such as ``(k in M)`` is history-dependent: the
+    # assign-site write ``M[key] = x`` changes the state ``key_expr`` reads on
+    # later calls, so the three structural key occurrences no longer evaluate
+    # identically and the collapsed ``return M(key);`` cannot reproduce the
+    # behaviour (and the output ``M(k in M)`` is ill-typed besides).  The
+    # if-condition's ``in M`` and the return/assign ``M[...]`` map occurrences
+    # are matched separately by ``_is_idiom_if_expr``; this guard targets
+    # references to ``M`` *inside* ``key_expr`` only.
+    if _references_map(key_expr, map_name):
+        return None
+
     # Purity: if any embedded FuncCall is non-deterministic, rewriting the
     # three occurrences of the key into one is unsound.
     if ctx is not None and has_nondeterministic_call(
@@ -2161,12 +2173,35 @@ def _match_idiom_suffix(
 
 
 def _references_map(node: frog_ast.ASTNode, map_name: str) -> bool:
-    """Return True if *node* syntactically references ``Variable(map_name)``."""
+    """Return True if *node* syntactically references the map field, whether
+    spelled as a bare ``Variable(map_name)`` or as a dotted
+    ``FieldAccess(_, map_name)`` (e.g. ``this.M``).
+
+    Both spellings denote the same field, so a node-kind-incomplete scan that
+    matched only ``Variable`` let dotted out-of-idiom uses such as
+    ``this.M[k] = v;`` evade the lazy-map preconditions (F-005/F-006)."""
 
     def matcher(n: frog_ast.ASTNode) -> bool:
-        return isinstance(n, frog_ast.Variable) and n.name == map_name
+        return (isinstance(n, frog_ast.Variable) and n.name == map_name) or (
+            isinstance(n, frog_ast.FieldAccess) and n.name == map_name
+        )
 
     return SearchVisitor(matcher).visit(node) is not None
+
+
+def _lvalue_targets_map(target: frog_ast.ASTNode, map_name: str) -> bool:
+    """Return True if assignment l-value *target* writes the map field, peeling
+    element/slice subscripts so that ``M``, ``M[k]``, ``this.M`` and
+    ``this.M[k]`` all count.  The dotted spellings (``FieldAccess``) were
+    invisible to the old ``Variable``/``ArrayAccess(Variable)``-only check,
+    letting ``Initialize`` pre-populate the map undetected (F-006)."""
+    while isinstance(target, (frog_ast.ArrayAccess, frog_ast.Slice)):
+        target = target.the_array
+    if isinstance(target, frog_ast.Variable):
+        return target.name == map_name
+    if isinstance(target, frog_ast.FieldAccess):
+        return target.name == map_name
+    return False
 
 
 class LazyMapToSampledFunction(TransformPass):
@@ -2217,6 +2252,24 @@ class LazyMapToSampledFunction(TransformPass):
             for m in game.methods
         )
 
+        # A field-level initializer (``Map<...> M = preset;``) is missed by the
+        # Initialize-body scan and dropped by the rebuild (same blind spot as
+        # F-009 in the pair sibling): a preset map would be silently replaced
+        # by a fresh empty sampled Function.
+        if fld.value is not None:
+            if any_idiom:
+                self._emit_near_miss(
+                    ctx,
+                    (
+                        f"Map '{map_name}' has a field initializer; lazy-map "
+                        "canonicalization requires an empty initial map"
+                    ),
+                    fld.origin,
+                    map_name,
+                    None,
+                )
+            return None
+
         if self._initialize_touches_map(game, map_name, value_type, ctx):
             return None
 
@@ -2265,15 +2318,7 @@ class LazyMapToSampledFunction(TransformPass):
             for stmt in method.block.statements:
                 if not isinstance(stmt, (frog_ast.Assignment, frog_ast.Sample)):
                     continue
-                v = stmt.var
-                target_var: frog_ast.Variable | None = None
-                if isinstance(v, frog_ast.Variable):
-                    target_var = v
-                elif isinstance(v, frog_ast.ArrayAccess) and isinstance(
-                    v.the_array, frog_ast.Variable
-                ):
-                    target_var = v.the_array
-                if target_var is None or target_var.name != map_name:
+                if not _lvalue_targets_map(stmt.var, map_name):
                     continue
                 if any(
                     _match_idiom_suffix(m, map_name, value_type, ctx) is not None
@@ -2505,6 +2550,15 @@ def _match_pair_idiom_suffix(
     if sample.sampled_from != value_type:
         return None
 
+    # Anti-alias (F-009): if the freshly-sampled local reuses the key
+    # parameter's name, the sample declaration shadows the parameter.  The
+    # guard ``if (k in Mi)`` then reads the parameter binding while the write
+    # ``Mi[k] = s`` and ``return s`` use the freshly sampled local -- two
+    # different bindings the collapsed ``return F(k)`` cannot reproduce.
+    # Mirrors the single-map guard in _match_idiom_suffix.
+    if s_name == k:
+        return None
+
     asgn = stmts[if_idx + 2]
     if not isinstance(asgn, frog_ast.Assignment):
         return None
@@ -2711,6 +2765,27 @@ class LazyMapPairToSampledFunction(TransformPass):
             for m in game.methods
             if m.signature.name != "Initialize"
         )
+
+        # (P2-2 / F-009) Neither map may carry a field-level initializer.  The
+        # Initialize-body scan below only inspects the Initialize *method*; a
+        # ``Map<...> M = preset;`` field initializer (``Field.value``) is never
+        # seen, and ``_build_rewritten_game`` creates the merged field with
+        # initializer ``None`` -- silently discarding the preset entries.
+        for fld in (m1, m2):
+            if fld.value is not None:
+                if any_idiom:
+                    self._emit_near_miss(
+                        ctx,
+                        (
+                            f"Map '{fld.name}' has a field initializer; "
+                            "lazy-map-pair canonicalization requires empty "
+                            "initial maps"
+                        ),
+                        fld.origin,
+                        fld.name,
+                        None,
+                    )
+                return None
 
         matches: dict[str, _PairIdiomMatch] = {}
         for method in game.methods:

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -21,7 +21,13 @@ from dataclasses import dataclass, field
 from sympy import Rational, Symbol, simplify as sympy_simplify
 
 from .. import frog_ast
-from ..visitors import BlockTransformer, SearchVisitor, ReplaceTransformer, Transformer
+from ..visitors import (
+    BlockTransformer,
+    SearchVisitor,
+    ReplaceTransformer,
+    Transformer,
+    lvalue_base_name,
+)
 from ._base import (
     TransformPass,
     PipelineContext,
@@ -75,9 +81,13 @@ def _exclusion_set_modified(game: frog_ast.Game, set_name: str) -> bool:
 
     Returns True if a problematic modification is found.
     """
-    # RF.domain sets are implicitly maintained by the RF's semantics.
-    # The RF initialization (Sample) is not a modification.
-    if "." in set_name:
+    # An ``RF.domain`` exclusion set is implicitly maintained by the RF's
+    # own semantics (querying ``RF(r)`` adds ``r`` to ``RF.domain``), so an
+    # explicit assignment is neither expected nor needed -- exempt it.  But
+    # only ``.domain`` is auto-maintained: any OTHER dotted set (e.g. a plain
+    # field accessed as ``obj.field``) must still be checked for an explicit
+    # modification that would break the implicit-maintenance assumption (F-020).
+    if set_name.endswith(".domain"):
         return False
 
     def _is_set_assign(node: frog_ast.ASTNode) -> bool:
@@ -86,25 +96,76 @@ def _exclusion_set_modified(game: frog_ast.Game, set_name: str) -> bool:
         ):
             return False
         var = node.var
-        # Direct assignment: S = ...
-        if isinstance(var, frog_ast.Variable) and var.name == set_name:
+        # Direct assignment: S = ...  (covers both a bare ``S`` and a dotted
+        # ``obj.field`` whose l-value base name matches the set).
+        target_name = _get_unique_set_name(var)
+        if target_name == set_name:
             # Typed declaration (field initializer) is OK — that's the
             # initial empty set.  Untyped assignment is a modification.
             if isinstance(node, frog_ast.Assignment) and node.the_type is not None:
                 return False
             return True
-        # Element assignment: S[k] = ...
-        if isinstance(var, frog_ast.ArrayAccess) and isinstance(
-            var.the_array, frog_ast.Variable
-        ):
-            if var.the_array.name == set_name:
-                return True
+        # Element/field-element assignment: S[k] = ... or obj.field[k] = ...
+        base = lvalue_base_name(var)
+        if base is not None and (base == set_name or set_name.startswith(base + ".")):
+            return True
         return False
 
     for method in game.methods:
         if SearchVisitor(_is_set_assign).visit(method.block) is not None:
             return True
     return False
+
+
+def _rf_value_escapes(game: frog_ast.Game, rf_name: str) -> bool:
+    """True if the function field *rf_name* appears anywhere other than a
+    safe position, i.e. it may be copied/passed and evaluated through an
+    alias that the call-site analysis cannot see (F-019).
+
+    Safe positions (each consumes one ``Variable(rf_name)`` occurrence):
+      - the ``func`` of a ``FuncCall`` (a direct call -- guards are checked
+        elsewhere);
+      - the ``the_object`` of a ``FieldAccess`` (a property like ``RF.domain``,
+        which reads metadata, not the function value);
+      - the l-value target of its own initialization (``RF <- Function<...>``).
+
+    Any *other* occurrence -- a bare copy ``g = RF``, an argument ``f(RF)``, a
+    set/tuple element -- lets the function value escape: an unguarded
+    evaluation through the alias would survive while a guarded site is
+    rewritten to an independent sample, breaking same-input consistency.
+    """
+    counts = {"total": 0, "calls": 0, "field_access": 0, "init_target": 0}
+
+    def visit(node: frog_ast.ASTNode) -> bool:
+        if isinstance(node, frog_ast.Variable) and node.name == rf_name:
+            counts["total"] += 1
+        if (
+            isinstance(node, frog_ast.FuncCall)
+            and isinstance(node.func, frog_ast.Variable)
+            and node.func.name == rf_name
+        ):
+            counts["calls"] += 1
+        if (
+            isinstance(node, frog_ast.FieldAccess)
+            and isinstance(node.the_object, frog_ast.Variable)
+            and node.the_object.name == rf_name
+        ):
+            counts["field_access"] += 1
+        if (
+            isinstance(
+                node,
+                (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample),
+            )
+            and isinstance(node.var, frog_ast.Variable)
+            and node.var.name == rf_name
+        ):
+            counts["init_target"] += 1
+        return False
+
+    for method in game.methods:
+        SearchVisitor(visit).visit(method.block)
+    safe = counts["calls"] + counts["field_access"] + counts["init_target"]
+    return counts["total"] > safe
 
 
 def _analyze_rf_eligibility(
@@ -121,6 +182,13 @@ def _analyze_rf_eligibility(
 
     for method in game.methods:
         _analyze_block(method.block, analysis, rf_types, field_names)
+
+    # Post-analysis: reject any RF whose function value escapes to a position
+    # the call-site walk cannot see (a copy/alias/argument), which could carry
+    # an unguarded evaluation (F-019).
+    for rf_name, rf_analysis in analysis.items():
+        if rf_analysis.eligible and _rf_value_escapes(game, rf_name):
+            rf_analysis.eligible = False
 
     # Post-analysis: reject RFs where any argument variable is used more
     # than once across call sites (RF is a function, so same input must
@@ -388,6 +456,30 @@ class UniqueRFSimplification(TransformPass):
         eligible = {
             name: rf_types[name] for name, result in analysis.items() if result.eligible
         }
+
+        # Near-miss: an RF that has a guarded call but escapes via a copy /
+        # argument / alias cannot be soundly simplified (F-019).
+        if ctx is not None:
+            for rf_name, result in analysis.items():
+                if not result.eligible and _rf_value_escapes(game, rf_name):
+                    ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Unique RF Simplification",
+                            reason=(
+                                f"Random function '{rf_name}' not simplified: its "
+                                "function value escapes (copied, aliased, or passed "
+                                "as an argument), so an unguarded evaluation may "
+                                "survive"
+                            ),
+                            location=None,
+                            suggestion=(
+                                "Avoid copying or passing the random function "
+                                "value; call it directly at each use site"
+                            ),
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
 
         if not eligible:
             return game

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -237,8 +237,51 @@ class SliceOfInlineConcatTransformer(Transformer):
                     param.type.parameterization is not None
                 ):
                     self._var_lengths[param.name] = param.type.parameterization
-            for stmt in method.block.statements:
-                if (
+            # The method body's own declarations are recorded scope-aware by
+            # ``transform_block`` as the traversal descends -- a nested
+            # redeclaration shadows the outer length only within its own block,
+            # and is restored on block exit.  (F-029.)
+            return self.transform(method)
+        finally:
+            self._var_lengths = saved
+
+    @staticmethod
+    def _declared_length(
+        name_type: frog_ast.Type | None,
+    ) -> frog_ast.Expression | None:
+        """The ``BitString`` length expression for a declared type, else None."""
+        if (
+            isinstance(name_type, frog_ast.BitStringType)
+            and name_type.parameterization is not None
+        ):
+            return name_type.parameterization
+        return None
+
+    def _record_declaration(self, name: str, name_type: frog_ast.Type | None) -> None:
+        """Record (or, when the declared type is not a known-length
+        ``BitString``, *shadow-clear*) the length for ``name``.
+
+        Shadow-clearing is the soundness-critical half: a redeclaration of an
+        outer ``BitString`` to a non-``BitString`` (or unparameterized) type
+        must not leave the outer length in the map, or a slice on the inner
+        binding would resolve against the stale outer length."""
+        length = self._declared_length(name_type)
+        if length is not None:
+            self._var_lengths[name] = length
+        else:
+            self._var_lengths.pop(name, None)
+
+    def transform_block(self, block: frog_ast.Block) -> frog_ast.Block:
+        # Scope-aware length tracking: record this block's own declarations
+        # (including bare ``VariableDeclaration`` and untyped re-binds, which
+        # the previous flat top-level scan missed -- Gaps A and B of F-029),
+        # restoring the enclosing scope's lengths on exit.
+        saved = dict(self._var_lengths)
+        try:
+            for stmt in block.statements:
+                if isinstance(stmt, frog_ast.VariableDeclaration):
+                    self._record_declaration(stmt.name, stmt.type)
+                elif (
                     isinstance(
                         stmt,
                         (
@@ -248,13 +291,38 @@ class SliceOfInlineConcatTransformer(Transformer):
                         ),
                     )
                     and isinstance(stmt.var, frog_ast.Variable)
-                    and isinstance(stmt.the_type, frog_ast.BitStringType)
-                    and stmt.the_type.parameterization is not None
+                    and stmt.the_type is not None
                 ):
-                    self._var_lengths[stmt.var.name] = stmt.the_type.parameterization
-            return self.transform(method)
+                    self._record_declaration(stmt.var.name, stmt.the_type)
+            return frog_ast.Block(
+                [self.transform(statement) for statement in block.statements]
+            )
         finally:
             self._var_lengths = saved
+
+    def transform_numeric_for(self, node: frog_ast.NumericFor) -> frog_ast.NumericFor:
+        new_start = self.transform(node.start)
+        new_end = self.transform(node.end)
+        saved = dict(self._var_lengths)
+        try:
+            # The loop binder is an ``Int`` -- shadow any outer same-named
+            # BitString length so a slice on the binder doesn't resolve against
+            # the stale outer length.
+            self._var_lengths.pop(node.name, None)
+            new_block = self.transform(node.block)
+        finally:
+            self._var_lengths = saved
+        return frog_ast.NumericFor(node.name, new_start, new_end, new_block)
+
+    def transform_generic_for(self, node: frog_ast.GenericFor) -> frog_ast.GenericFor:
+        new_over = self.transform(node.over)
+        saved = dict(self._var_lengths)
+        try:
+            self._record_declaration(node.var_name, node.var_type)
+            new_block = self.transform(node.block)
+        finally:
+            self._var_lengths = saved
+        return frog_ast.GenericFor(node.var_type, node.var_name, new_over, new_block)
 
     @staticmethod
     def _exprs_equal(a: frog_ast.Expression, b: frog_ast.Expression) -> bool:

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -89,11 +89,19 @@ class SimplifySpliceTransformer(BlockTransformer):
 
             # Step 1, find type of variables (to get lengths)
 
+            # The relevant declaration is the one in effect at the concat site:
+            # the LAST typed declaration of the component before this statement,
+            # not the first match in the whole block. A same-scope
+            # redeclaration with a different bit length before the concat would
+            # otherwise be missed and the splice would use a stale length
+            # (F-067). Visiting the prior statements in reverse makes the first
+            # match the most recent declaration.
+            prior_reversed = frog_ast.Block(list(reversed(block.statements[:index])))
             lengths: list[Symbol] = []
             for var in concatenated_var_names:
                 declaration = SearchVisitor(
                     functools.partial(find_declaration, var.name)
-                ).visit(block)
+                ).visit(prior_reversed)
                 if declaration is None:
                     break
                 assert isinstance(declaration, (frog_ast.Assignment, frog_ast.Sample))

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -1230,7 +1230,18 @@ def _localize_init_only_field_samples(game: frog_ast.Game) -> frog_ast.Game:
         if sample_count != 1 or init_sample_idx is None:
             continue
 
-        # Check: field NOT referenced in any non-Initialize method
+        # Gap A1: the sample must be the field's FIRST access inside Initialize.
+        # If any earlier statement reads the field, it reads the field's
+        # declared initializer value (SEMANTICS §6.2 step 1); deleting the
+        # field declaration would dangle that read.
+        read_before_sample = any(
+            _references_name(stmt, field.name)
+            for stmt in init_method.block.statements[:init_sample_idx]
+        )
+        if read_before_sample:
+            continue
+
+        # Check: field NOT referenced in any non-Initialize method body.
         used_outside = False
         for method in game.methods:
             if method.signature.name == "Initialize":
@@ -1238,8 +1249,29 @@ def _localize_init_only_field_samples(game: frog_ast.Game) -> frog_ast.Game:
             if _references_name(method.block, field.name):
                 used_outside = True
                 break
+            # Gap A3 (defense): a reference in a non-Initialize method's
+            # signature (parameter/return type parameterization) also keeps the
+            # field live.
+            if any(
+                _references_name(param.type, field.name)
+                for param in method.signature.parameters
+            ) or _references_name(method.signature.return_type, field.name):
+                used_outside = True
+                break
 
         if used_outside:
+            continue
+
+        # Gap A2: the field may be referenced only in ANOTHER field's
+        # initializer expression (set before Initialize runs).  Deleting the
+        # field would dangle that initializer.
+        referenced_in_initializer = any(
+            other.value is not None
+            and other.name != field.name
+            and _references_name(other.value, field.name)
+            for other in game.fields
+        )
+        if referenced_in_initializer:
             continue
 
         eligible.append((field, init_sample_idx))

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -1116,6 +1116,12 @@ def _single_call_field_to_local(game: frog_ast.Game) -> frog_ast.Game:
         if init_sample is None or init_sample_count > 1 or field_used_elsewhere_in_init:
             continue
 
+        # Reject if any oracle shadows the field name with a parameter/local:
+        # name-only reference detection cannot tell field from binding, and the
+        # prepended local sample would clobber the binding (F-055).
+        if _name_shadowed_in_any_oracle(game, field.name):
+            continue
+
         # Step 2: Find which non-Initialize methods reference this field
         using_methods: list[str] = []
         for method in game.methods:
@@ -1181,6 +1187,49 @@ def _references_name(node: frog_ast.ASTNode, name: str) -> bool:
         return isinstance(n, frog_ast.Variable) and n.name == name
 
     return SearchVisitor(check).visit(node) is not None
+
+
+def _method_binds_name(method: frog_ast.Method, name: str) -> bool:
+    """True if *method* binds *name* as a parameter or declares it as a local
+    (typed sample/assignment/declaration, or a loop binder), shadowing a
+    same-named game field within the method.
+
+    ``_references_name`` is name-only and cannot tell a field reference from a
+    same-named parameter/local. When a method shadows the field name, its
+    ``name`` occurrences are the binding, not the field -- and prepending a
+    localized ``name <- ...`` sample there would clobber the binding (F-050,
+    F-055). The field-to-local passes must not localize such a field."""
+    if any(p.name == name for p in method.signature.parameters):
+        return True
+
+    found = [False]
+
+    def _visit(n: frog_ast.ASTNode) -> bool:
+        if isinstance(n, frog_ast.VariableDeclaration) and n.name == name:
+            found[0] = True
+        elif (
+            isinstance(n, (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample))
+            and n.the_type is not None
+            and isinstance(n.var, frog_ast.Variable)
+            and n.var.name == name
+        ):
+            found[0] = True
+        elif isinstance(n, frog_ast.NumericFor) and n.name == name:
+            found[0] = True
+        elif isinstance(n, frog_ast.GenericFor) and n.var_name == name:
+            found[0] = True
+        return False
+
+    SearchVisitor(_visit).visit(method.block)
+    return found[0]
+
+
+def _name_shadowed_in_any_oracle(game: frog_ast.Game, name: str) -> bool:
+    """True if any non-Initialize method binds *name* (see _method_binds_name)."""
+    return any(
+        m.signature.name != "Initialize" and _method_binds_name(m, name)
+        for m in game.methods
+    )
 
 
 class SingleCallFieldToLocal(TransformPass):
@@ -1550,6 +1599,12 @@ def _counter_guarded_field_to_local(game: frog_ast.Game) -> frog_ast.Game:
 
         # Reject if no sample, multiple samples, or field used elsewhere
         if init_sample is None or init_sample_count > 1 or field_used_elsewhere_in_init:
+            continue
+
+        # Reject if any oracle shadows the field name with a parameter/local
+        # (F-050): name-only reference detection conflates the field with the
+        # binding, and the prepended local sample would clobber it.
+        if _name_shadowed_in_any_oracle(game, field.name):
             continue
 
         # Step 2: Find which non-Initialize methods reference this field

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1173,15 +1173,15 @@ def build_game_type_map(
 def assigns_variable(
     used_variables: list[frog_ast.Variable], node: frog_ast.ASTNode
 ) -> bool:
-    return isinstance(
+    if not isinstance(
         node, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
-    ) and (
-        (node.var in used_variables)
-        or (
-            isinstance(node.var, frog_ast.ArrayAccess)
-            and node.var.the_array in used_variables
-        )
-    )
+    ):
+        return False
+    # Peel element/slice/field accesses so nested element writes (`M[0][0]=v`)
+    # and field writes (`X.f=v`) -- not just depth-1 `M[k]=v` -- count as a
+    # write to the base variable.
+    base = lvalue_base_name(node.var)
+    return base is not None and base in {v.name for v in used_variables}
 
 
 def lvalue_base_name(target: frog_ast.ASTNode) -> Optional[str]:
@@ -1223,6 +1223,30 @@ def referenced_variable_names(node: frog_ast.ASTNode) -> set[str]:
 
     SearchVisitor(_collect).visit(node)
     return names
+
+
+def referenced_variables_in_order(
+    node: frog_ast.ASTNode,
+) -> list[frog_ast.Variable]:
+    """Variables referenced in *node* in first-appearance (pre-order) order,
+    deduplicated by name -- the FieldAccess-complete analogue of
+    :class:`VariableCollectionVisitor`.  Used where iteration order is
+    observable (e.g. dependency-edge order)."""
+
+    class _OrderedReferenceVisitor(Visitor[list[frog_ast.Variable]]):
+        def __init__(self) -> None:
+            self.variables: list[frog_ast.Variable] = []
+            self.seen: set[str] = set()
+
+        def result(self) -> list[frog_ast.Variable]:
+            return self.variables
+
+        def visit_variable(self, inner: frog_ast.Variable) -> None:
+            if inner.name not in self.seen:
+                self.seen.add(inner.name)
+                self.variables.append(inner)
+
+    return _OrderedReferenceVisitor().visit(node)
 
 
 def reassigns_or_rebinds(names: set[str], node: frog_ast.ASTNode) -> bool:

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -862,6 +862,22 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
         else:
             self.stack.append(None)
 
+    def leave_slice(self, node: frog_ast.Slice) -> None:
+        # Bit-slicing is not modelled in Z3 here. Previously the Slice node had
+        # NO handler at all, so its three visited children (array, start, end)
+        # were left on the stack and `result()` returned the topmost -- the
+        # END expression -- as the slice's "formula". Two slices of the same
+        # width (`(a||b)[0:2n]` and `(a||c)[0:2n]`) then collapsed to the same
+        # atom and compared *equal*, a soundness hole. Pop the three children
+        # and intern the WHOLE slice as a single opaque atom: structurally
+        # distinct slices get distinct atoms (sound; merely incomplete -- the
+        # genuine `(a||b)[0:|a|]=a` identity is handled by the AST pass).
+        children = [self.stack.pop() if self.stack else None for _ in range(3)]
+        if self.opaque_func_call_fallback and not any(c is None for c in children):
+            self.stack.append(self._intern_opaque(node))
+        else:
+            self.stack.append(None)
+
     def leave_unary_operation(self, operation: frog_ast.UnaryOperation) -> None:
         if not self.stack or operation.operator == frog_ast.UnaryOperators.SIZE:
             self.stack.append(None)

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1184,6 +1184,89 @@ def assigns_variable(
     )
 
 
+def lvalue_base_name(target: frog_ast.ASTNode) -> Optional[str]:
+    """Base variable name written by an l-value, peeling element, slice, and
+    field accesses.
+
+    Returns ``M`` for ``M``, ``M[k]``, ``M[i][j]``, ``a[i : j]``, ``X.f``, and
+    ``X.f[k]``; returns ``None`` when the l-value bottoms out in a non-Variable
+    (e.g. a tuple-literal destructuring target).  This is the single source of
+    truth for "which variable does this assignment/sample target ultimately
+    mutate", so element/slice/field writes are not mistaken for no-ops.
+    """
+    while True:
+        if isinstance(target, (frog_ast.ArrayAccess, frog_ast.Slice)):
+            target = target.the_array
+        elif isinstance(target, frog_ast.FieldAccess):
+            target = target.the_object
+        else:
+            break
+    return target.name if isinstance(target, frog_ast.Variable) else None
+
+
+def referenced_variable_names(node: frog_ast.ASTNode) -> set[str]:
+    """Names of every ``Variable`` referenced anywhere in *node*, including the
+    base object of field/array/slice accesses (``M`` in ``M.keys`` / ``M[k]``).
+
+    Unlike :class:`VariableCollectionVisitor` this does **not** skip
+    field-access subtrees: a guard such as ``k in M.keys`` genuinely reads
+    ``M``, so soundness checks that need the complete read-set of an expression
+    must use this rather than ``VariableCollectionVisitor`` (which suppresses
+    collection inside any ``FieldAccess``).
+    """
+    names: set[str] = set()
+
+    def _collect(inner: frog_ast.ASTNode) -> bool:
+        if isinstance(inner, frog_ast.Variable):
+            names.add(inner.name)
+        return False
+
+    SearchVisitor(_collect).visit(node)
+    return names
+
+
+def reassigns_or_rebinds(names: set[str], node: frog_ast.ASTNode) -> bool:
+    """True if *node* contains a statement that could change the value or
+    binding of any name in *names*.
+
+    Node-kind-complete write/rebind detection: an occurrence counts when it is
+
+    - a write (``Assignment`` / ``Sample`` / ``UniqueSample``) whose l-value
+      base (see :func:`lvalue_base_name`) is one of *names* -- including
+      element, slice, and field writes (``M[k] = v``, ``a[i : j] = v``,
+      ``X.f = v``);
+    - an insertion into an exclusion set: ``x <-uniq[S] T`` where ``S``
+      references one of *names* (the draw implicitly adds ``x`` to ``S``); the
+      pure set-difference surface form ``x <- T \\ S`` performs no insertion and
+      is therefore not treated as a write;
+    - a loop binder (``for (Int i = ...)`` / ``for (T e in ...)``) that rebinds
+      one of *names*, shadowing it.
+
+    Conservative by design: any such occurrence anywhere in *node* -- including
+    nested branches and loop bodies -- counts, because callers substitute
+    structurally and are not scope-aware.
+    """
+
+    def _mutates(inner: frog_ast.ASTNode) -> bool:
+        if isinstance(
+            inner, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
+        ) and (lvalue_base_name(inner.var) in names):
+            return True
+        if (
+            isinstance(inner, frog_ast.UniqueSample)
+            and inner.surface_form == "uniq"
+            and bool(referenced_variable_names(inner.unique_set) & names)
+        ):
+            return True
+        if isinstance(inner, frog_ast.NumericFor) and inner.name in names:
+            return True
+        if isinstance(inner, frog_ast.GenericFor) and inner.var_name in names:
+            return True
+        return False
+
+    return SearchVisitor(_mutates).visit(node) is not None
+
+
 class SameFieldVisitor(Visitor[Optional[list[frog_ast.Statement]]]):
     def __init__(self, field_name_pair: tuple[str, str]):
         self.field_name_pair = field_name_pair

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -694,3 +694,116 @@ def test_refactor_group_elem_field_exp_multicall() -> None:
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
+
+
+# --------------------------------------------------------------------------
+# Negative distinguishers: the engine must REJECT genuinely distinguishable
+# pairs.  Each pair below differs only in the ORDER of a state read relative
+# to a state write -- `... = read(state); write(state); return ...` versus
+# `write(state); return read(state)`.  These are advantage-1 distinguishable
+# (the read observes different state on the two sides), so check_equivalent
+# must return valid is False.  Before the RC1 reference/write-scan fixes the
+# canonicalizer (TopologicalSort dependency model, RemoveUnnecessaryFields
+# liveness, SimplifyReturn / the inliners) moved the read past the write on
+# one side and wrongly accepted the pair.  (audit findings F-126 + the
+# RC-front movers behind it.)
+# --------------------------------------------------------------------------
+
+
+def test_reject_read_moved_past_uniq_insertion() -> None:
+    """`<-uniq[S]` inserts the draw into S, so `|S|` read before vs after the
+    draw differs.  Must not be accepted as equivalent."""
+    real = frog_parser.parse_game(
+        """
+        Game Real() {
+            Set<BitString<2>> S;
+            BitString<2> t;
+            Void Initialize() { t = 0b00; }
+            [Int, Int] O() {
+                [Int, Int] s = [|S|, 0];
+                BitString<2> x <-uniq[S] BitString<2>;
+                t = x;
+                return s;
+            }
+            BitString<2> Peek() { return t; }
+        }
+        """
+    )
+    random = frog_parser.parse_game(
+        """
+        Game Random() {
+            Set<BitString<2>> S;
+            BitString<2> t;
+            Void Initialize() { t = 0b00; }
+            [Int, Int] O() {
+                BitString<2> x <-uniq[S] BitString<2>;
+                t = x;
+                return [|S|, 0];
+            }
+            BitString<2> Peek() { return t; }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(real, random).valid
+
+
+def test_reject_read_moved_past_map_write_via_fieldaccess_view() -> None:
+    """`|M.keys|` reaches M only through a FieldAccess view; moving it past the
+    element write `M[0]=1` changes its value.  Must not be accepted."""
+    real = frog_parser.parse_game(
+        """
+        Game Real() {
+            Map<Int, Int> M;
+            [Int, Int] O() {
+                [Int, Int] s = [|M.keys|, 0];
+                M[0] = 1;
+                return s;
+            }
+            Int Size() { return M[0]; }
+        }
+        """
+    )
+    random = frog_parser.parse_game(
+        """
+        Game Random() {
+            Map<Int, Int> M;
+            [Int, Int] O() {
+                M[0] = 1;
+                return [|M.keys|, 0];
+            }
+            Int Size() { return M[0]; }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(real, random).valid
+
+
+def test_reject_read_moved_past_nested_element_write() -> None:
+    """A read of `M[0]` moved past the nested element write `M[0][1]=1`
+    observes the mutated value.  Must not be accepted."""
+    real = frog_parser.parse_game(
+        """
+        Game Real() {
+            Map<Int, [Int, Int]> M;
+            Void Initialize() { M[0] = [0, 0]; }
+            [Int, Int] O() {
+                [Int, Int] s = M[0];
+                M[0][1] = 1;
+                return s;
+            }
+        }
+        """
+    )
+    random = frog_parser.parse_game(
+        """
+        Game Random() {
+            Map<Int, [Int, Int]> M;
+            Void Initialize() { M[0] = [0, 0]; }
+            [Int, Int] O() {
+                M[0][1] = 1;
+                return M[0];
+            }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(real, random).valid

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -937,3 +937,40 @@ def test_slice_of_concat_sound_identity_still_fires() -> None:
         """
     )
     assert _engine_with().check_equivalent(real, post).valid
+
+
+def test_guarded_field_element_write_not_dropped() -> None:
+    """F-075 / mover sweep: a field element-write nested in a guarded branch is
+    observable across calls (via a later read), so it must not be dropped. The
+    bug: TopologicalSort hoisted the constant `return 0` above the
+    `if (x == F) { F[k] = 99; }` branch because `mutates_field` only inspected
+    top-level statement kinds and missed the write nested in the if; the branch
+    then looked dead and was removed, equating a persistent field mutation
+    (Real) with a write to a local parameter (Random)."""
+    real = frog_parser.parse_game(
+        """
+        Game Real() {
+            Map<Int, Int> F;
+            Void SetF(Int k, Int v) { F[k] = v; }
+            Int Get(Int k) { return F[k]; }
+            Int Test(Map<Int, Int> x, Int k) {
+                if (x == F) { F[k] = 99; }
+                return 0;
+            }
+        }
+        """
+    )
+    random = frog_parser.parse_game(
+        """
+        Game Random() {
+            Map<Int, Int> F;
+            Void SetF(Int k, Int v) { F[k] = v; }
+            Int Get(Int k) { return F[k]; }
+            Int Test(Map<Int, Int> x, Int k) {
+                if (x == F) { x[k] = 99; }
+                return 0;
+            }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(real, random).valid

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -807,3 +807,133 @@ def test_reject_read_moved_past_nested_element_write() -> None:
         """
     )
     assert not _engine_with().check_equivalent(real, random).valid
+
+
+# --------------------------------------------------------------------------
+# F-029 (SliceOfInlineConcat) — end-to-end soundness.
+#
+# `(a || b)[start:end]` may be rewritten to an operand ONLY when the slice
+# bounds match that operand's TRUE length at the slice site. Several engine
+# paths previously conspired to lose that length (a scope-blind length table
+# in the pass, a bare-declaration drop in TopologicalSort / RemoveUnnecessary,
+# a cross-scope CollapseAssignment merge, and a Z3 residual that modelled a
+# slice as its width alone). Each game pair below is distinguishable; the
+# engine must REJECT it. A sound control follows.
+# --------------------------------------------------------------------------
+
+
+def test_slice_of_concat_z3_residual_distinct_operands() -> None:
+    """Z3 residual: a full-width slice `(s || b)[0:2n]` of a concat must not
+    compare equal to `(s || s)[0:2n]`. The slice was previously modelled by
+    its width alone (`@@@opaque@...@2 * n`), collapsing distinct operands to
+    one atom. No shadowing here -- this is the bare equivalence-layer hole."""
+    real = frog_parser.parse_game(
+        """
+        Game Real(Int n) {
+            BitString<2 * n> Oracle(BitString<n> b) {
+                BitString<n> s <- BitString<n>;
+                return (s || b)[0 : 2 * n];
+            }
+        }
+        """
+    )
+    random = frog_parser.parse_game(
+        """
+        Game Random(Int n) {
+            BitString<2 * n> Oracle(BitString<n> b) {
+                BitString<n> s <- BitString<n>;
+                return (s || s)[0 : 2 * n];
+            }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(real, random).valid
+
+
+def test_slice_of_concat_decl_shadow_param() -> None:
+    """Attack 1: a decl-only local `BitString<n> x;` shadows the 2n-bit
+    parameter `x`. The bare declaration must survive TopologicalSort /
+    RemoveUnnecessary so `x` keeps its n-bit binding, and the slice must not
+    be rewritten to `x` (dropping `b`)."""
+    real = frog_parser.parse_game(
+        """
+        Game Real(Int n) {
+            BitString<2 * n> Oracle(BitString<2 * n> x, BitString<n> b) {
+                BitString<n> x;
+                x <- BitString<n>;
+                return (x || b)[0 : 2 * n];
+            }
+        }
+        """
+    )
+    random = frog_parser.parse_game(
+        """
+        Game Random(Int n) {
+            BitString<2 * n> Oracle(BitString<2 * n> x, BitString<n> b) {
+                BitString<n> x;
+                x <- BitString<n>;
+                return (x || x)[0 : 2 * n];
+            }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(real, random).valid
+
+
+def test_slice_of_concat_nested_redecl_case2() -> None:
+    """Attack 3b: a nested-block redeclaration `BitString<k + m> a` shadows
+    the outer `BitString<k> a`. SinkUniformSample + CollapseAssignment must
+    not merge the two `a`s across the scope boundary into a mistyped
+    `BitString<k> a <- BitString<k + m>`, which would let the Case 2 slice
+    fold to `b`."""
+    real = frog_parser.parse_game(
+        """
+        Game Real(Int k, Int m) {
+            [BitString<m>, BitString<m>] Oracle(Bool cond, BitString<m> b) {
+                BitString<k> a <- BitString<k>;
+                if (cond) {
+                    BitString<k + m> a <- BitString<k + m>;
+                    return [(a || b)[k : k + m], b];
+                }
+                return [b, b];
+            }
+        }
+        """
+    )
+    random = frog_parser.parse_game(
+        """
+        Game Random(Int k, Int m) {
+            [BitString<m>, BitString<m>] Oracle(Bool cond, BitString<m> b) {
+                return [b, b];
+            }
+        }
+        """
+    )
+    engine = _engine_with()
+    engine.variables["k"] = Symbol("k", positive=True, integer=True)
+    engine.variables["m"] = Symbol("m", positive=True, integer=True)
+    assert not engine.check_equivalent(real, random).valid
+
+
+def test_slice_of_concat_sound_identity_still_fires() -> None:
+    """Control: the genuine identity `(a || b)[0 : |a|] = a` must STILL be
+    recognized -- the fixes restrict the unsound cases, not the sound one."""
+    real = frog_parser.parse_game(
+        """
+        Game Real(Int n) {
+            BitString<n> Oracle(BitString<n> a, BitString<n> b) {
+                return (a || b)[0 : n];
+            }
+        }
+        """
+    )
+    post = frog_parser.parse_game(
+        """
+        Game Post(Int n) {
+            BitString<n> Oracle(BitString<n> a, BitString<n> b) {
+                return a;
+            }
+        }
+        """
+    )
+    assert _engine_with().check_equivalent(real, post).valid

--- a/tests/unit/transforms/test_counter_guarded_field_to_local.py
+++ b/tests/unit/transforms/test_counter_guarded_field_to_local.py
@@ -621,3 +621,27 @@ def test_counter_guarded_rejects_unsound_cases(game: str) -> None:
     transformed_ast = _counter_guarded_field_to_local(game_ast)
     # The transform should be a no-op — the game should be unchanged
     assert transformed_ast == game_ast
+
+
+def test_param_shadowed_field_not_localized() -> None:
+    """F-050: an oracle has a parameter named like the counter-guarded field.
+    The name-only reference scan conflates field and parameter; the pass must
+    DECLINE rather than prepend a sample that clobbers the parameter."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            BitString<8> v;
+            Int ctr;
+            Void Initialize() {
+                ctr = 0;
+                v <- BitString<8>;
+            }
+            BitString<8> O(BitString<8> v) {
+                if (ctr == 0) {
+                    ctr = ctr + 1;
+                    return v;
+                }
+                return v;
+            }
+        }
+        """)
+    assert _counter_guarded_field_to_local(game) == game

--- a/tests/unit/transforms/test_dead_guarded_assignment_elimination.py
+++ b/tests/unit/transforms/test_dead_guarded_assignment_elimination.py
@@ -1,0 +1,100 @@
+"""Tests for DeadGuardedAssignmentElimination.
+
+The pass replaces an assignment ``v = E`` with ``v = false`` when ``v`` is read
+solely by a guard ``if (v) { if (G) { return R } }`` whose fall-through is the
+same ``R`` -- under ``G`` the result is ``R`` regardless of ``v``. The
+soundness condition is that the killed value is never otherwise observed. A
+game FIELD persists across oracle calls, so its value can be observed in a
+sibling/later oracle (F-099 A2b) or carried from a previous call into the guard
+when the assignment is conditional (F-099 A2).
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.control_flow import DeadGuardedAssignmentElimination
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _make_ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _apply(source: str):
+    game = frog_parser.parse_game(source)
+    return game, DeadGuardedAssignmentElimination().apply(game, _make_ctx())
+
+
+def test_local_guarded_assignment_killed() -> None:
+    """Positive control: a method-LOCAL boolean read solely by the guard is a
+    dead store -- the pass fires (value replaced by false)."""
+    game, result = _apply(
+        """
+        Game G() {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                if (x == 1) {
+                    v = c;
+                }
+                if (v) {
+                    if (x == 1) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """
+    )
+    assert result != game, "local dead guarded assignment should be killed"
+
+
+def test_field_read_in_sibling_oracle_not_killed() -> None:
+    """F-099 A2b: the field is also read by a separate Leak oracle, so its
+    value is observable -- must DECLINE."""
+    game, result = _apply(
+        """
+        Game G() {
+            Bool v;
+            Void Initialize() { v = false; }
+            Int O(Int x, Bool c) {
+                if (x == 1) { v = c; }
+                if (v) {
+                    if (x == 1) { return 0; }
+                    return 1;
+                }
+                return 0;
+            }
+            Bool Leak() { return v; }
+        }
+        """
+    )
+    assert result == game, "field read by a sibling oracle must not be killed"
+
+
+def test_field_conditionally_assigned_persists_not_killed() -> None:
+    """F-099 A2: the field is only conditionally assigned (if (x == 1)), so on
+    other calls the guard reads the persisted previous-call value -- must
+    DECLINE even though the field is read only by the guard."""
+    game, result = _apply(
+        """
+        Game G() {
+            Bool v;
+            Void Initialize() { v = false; }
+            Int O(Int x, Bool c) {
+                if (x == 1) { v = c; }
+                if (v) {
+                    if (x == 1) { return 0; }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """
+    )
+    assert result == game, "conditionally-assigned field must not be killed"

--- a/tests/unit/transforms/test_fold_equivalent_return_branch.py
+++ b/tests/unit/transforms/test_fold_equivalent_return_branch.py
@@ -1,0 +1,75 @@
+"""Soundness regression tests for FoldEquivalentReturnBranch.
+
+RC1 / F-119: ``_count_field_assigns_recursive`` counted only writes whose
+l-value is a bare ``Variable``, so an element-mutated container field
+(``F1[k] = v1``) was miscounted as single-write and the pass folded a branch
+that returned it -- collapsing two genuinely-different container fields.  The
+counter now peels element/slice/field accesses via ``lvalue_base_name``, so an
+element-written field counts as written and the fold is declined.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.control_flow import FoldEquivalentReturnBranch
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _apply(source: str) -> tuple[object, object]:
+    game = frog_parser.parse_game(source)
+    result = FoldEquivalentReturnBranch().apply(game, _ctx())
+    return game, result
+
+
+def test_element_mutated_container_fields_not_folded() -> None:
+    """Two container fields that are element-written with *different* values
+    must not be folded into a single return branch."""
+    game, result = _apply(
+        """
+        Game Containers(Dict D) {
+            Map<Int, D.V> F1;
+            Map<Int, D.V> F2;
+
+            Void Initialize() {
+                F1 = D.empty();
+                F2 = D.empty();
+            }
+
+            Map<Int, D.V> Oracle(Bool flag, Int k, D.V v1, D.V v2) {
+                F1[k] = v1;
+                F2[k] = v2;
+                if (flag) {
+                    return F1;
+                }
+                return F2;
+            }
+        }
+        """
+    )
+    assert result == game, f"branch wrongly folded:\n{result}"
+
+
+def test_positive_fold_still_fires() -> None:
+    """Control: the intended sound use -- ``if (a == b) return a; return b;``
+    -- must still fold."""
+    game, result = _apply(
+        """
+        Game Positive() {
+            Int Oracle(Int a, Int b) {
+                if (a == b) {
+                    return a;
+                }
+                return b;
+            }
+        }
+        """
+    )
+    assert result != game, "intended fold did not fire"

--- a/tests/unit/transforms/test_guard_condition_simplification.py
+++ b/tests/unit/transforms/test_guard_condition_simplification.py
@@ -1,0 +1,199 @@
+"""Soundness regression tests for GuardConditionSimplification.
+
+GuardConditionSimplification replaces an if-condition by its known truth value
+inside its branches.  That is sound only when the condition's value is invariant
+across the branch.  The audit (transform-soundness round 2, RC1) showed the
+reassignment check was node-kind-incomplete: it saw only ``Assignment`` whose
+``.var`` is a bare ``Variable`` named in the (FieldAccess-blind) condition
+read-set.  Four attack shapes slipped past it (findings F-080, F-082, plus the
+``<-uniq`` and loop-binder surfaces shared with RC2/RC4):
+
+- GCS-1: element write ``M[k] = v`` (l-value is ``ArrayAccess``) mutates the
+  guard set invisibly.
+- GCS-2: ``x <-uniq[S] T`` implicitly inserts ``x`` into ``S`` (no AST write).
+- GCS-3: ``cond_vars`` omitted variables under ``FieldAccess`` (``M`` in
+  ``k in M.keys``), so even a whole-variable write ``M = N`` went undetected.
+- GCS-4: a loop binder (``for (Int x = ...)``) shadowing a guard variable is
+  not an ``Assignment`` and is not scope-aware-substituted.
+
+Each attack must leave the inner re-test intact (pass declines).  The positive
+controls must still fold (the read/write scanner is complete, not blunt).
+"""
+
+import pytest
+from proof_frog import frog_parser
+from proof_frog.transforms.control_flow import GuardConditionSimplificationTransformer
+
+
+def _run(src: str) -> str:
+    method_ast = frog_parser.parse_method(src)
+    return str(GuardConditionSimplificationTransformer().transform(method_ast))
+
+
+# --- Attacks: the pass MUST decline (inner guard not frozen to a constant) ---
+
+ATTACKS = {
+    # GCS-1 (F-080): element write M[k] = 1 mutates the guard set `M`.
+    "element_write": """
+        Int O(Int k, Map<Int, Int> M) {
+            if (k in M) {
+                return 0;
+            } else {
+                M[k] = 1;
+                if (k in M) {
+                    return 100;
+                } else {
+                    return 200;
+                }
+            }
+        }
+    """,
+    # GCS-2: <-uniq[S] inserts the draw into the guard set `S`.
+    "uniq_insertion": """
+        Int O(BitString<1> e, Set<BitString<1>> S) {
+            if (e in S) {
+                return 0;
+            } else {
+                BitString<1> y <-uniq[S] BitString<1>;
+                if (e in S) {
+                    return 1;
+                } else {
+                    return 2;
+                }
+            }
+        }
+    """,
+    # GCS-3 (F-082): guard reads `M` through FieldAccess `M.keys`; the whole-
+    # variable write `M = N` must be seen.
+    "field_access_read": """
+        Int O(Int k, Map<Int, Int> M) {
+            if (k in M.keys) {
+                return 0;
+            } else {
+                Map<Int, Int> N;
+                N[k] = 1;
+                M = N;
+                if (k in M.keys) {
+                    return 1;
+                } else {
+                    return 2;
+                }
+            }
+        }
+    """,
+    # GCS-4: loop binder `x` shadows the guard variable `x`.
+    "loop_binder_shadow": """
+        Int O(Int x, Set<Int> S) {
+            if (x in S) {
+                Int acc = 0;
+                for (Int x = 0 to 1) {
+                    if (x in S) {
+                        acc = acc + 1;
+                    }
+                }
+                return acc;
+            } else {
+                return 99;
+            }
+        }
+    """,
+    # GCS-6 (already blocked): direct whole-variable reassignment of guard set.
+    "whole_var_reassign": """
+        Int O(Int e, Set<Int> S) {
+            if (e in S) {
+                return 0;
+            } else {
+                S = S union {e};
+                if (e in S) {
+                    return 1;
+                } else {
+                    return 2;
+                }
+            }
+        }
+    """,
+}
+
+
+@pytest.mark.parametrize("name", sorted(ATTACKS))
+def test_attack_declines(name: str) -> None:
+    src = ATTACKS[name]
+    before = str(frog_parser.parse_method(src))
+    after = _run(src)
+    # The pass must not freeze the inner re-test to a constant.
+    assert "if (true)" not in after and "if (false)" not in after, (
+        f"{name}: guard wrongly substituted\n{after}"
+    )
+    assert before == after, f"{name}: pass mutated an unstable-guard branch\n{after}"
+
+
+# --- Positive controls: the pass MUST still fire ---
+
+CONTROLS = {
+    # Plain redundant re-test, no writes at all.
+    "redundant_retest": """
+        Int f(Int x, Set<Int> S) {
+            if (x in S) {
+                if (x in S) {
+                    return 1;
+                }
+                return 2;
+            } else {
+                if (x in S) {
+                    return 3;
+                }
+                return 4;
+            }
+        }
+    """,
+    # FieldAccess guard with NO reassignment: the complete read-set must not
+    # over-decline.  `k in M.keys` re-tested with M untouched should fold.
+    "field_access_stable": """
+        Int O(Int k, Map<Int, Int> M) {
+            if (k in M.keys) {
+                if (k in M.keys) {
+                    return 1;
+                }
+                return 2;
+            }
+            return 0;
+        }
+    """,
+    # Element write to an UNRELATED map must not block the fold.
+    "unrelated_element_write": """
+        Int O(Int k, Set<Int> S, Map<Int, Int> T) {
+            if (k in S) {
+                T[k] = 1;
+                if (k in S) {
+                    return 1;
+                }
+                return 2;
+            }
+            return 0;
+        }
+    """,
+    # <-uniq into an UNRELATED set must not block the fold.
+    "unrelated_uniq": """
+        Int O(BitString<1> e, Set<BitString<1>> S, Set<BitString<1>> U) {
+            if (e in S) {
+                BitString<1> y <-uniq[U] BitString<1>;
+                if (e in S) {
+                    return 1;
+                }
+                return 2;
+            }
+            return 0;
+        }
+    """,
+}
+
+
+@pytest.mark.parametrize("name", sorted(CONTROLS))
+def test_control_fires(name: str) -> None:
+    src = CONTROLS[name]
+    before = str(frog_parser.parse_method(src))
+    after = _run(src)
+    assert before != after, f"{name}: pass failed to fold a stable guard\n{after}"
+    assert "if (true)" in after or "if (false)" in after, (
+        f"{name}: inner guard not substituted\n{after}"
+    )

--- a/tests/unit/transforms/test_if_condition_alias.py
+++ b/tests/unit/transforms/test_if_condition_alias.py
@@ -493,3 +493,67 @@ def test_no_substitution_after_field_reassignment_in_branch() -> None:
     assert (
         result == game
     ), "Field references after field reassignment in branch should not be substituted"
+
+
+def test_no_substitution_after_nested_field_reassignment() -> None:
+    """F-075 A2: the comparison field is reassigned inside a NESTED block of
+    the branch. The Phase-2 stop must see the nested write and not substitute
+    references that follow it."""
+    source = """
+    Game Test() {
+        Int field1;
+        Int f(Int v, Bool c) {
+            if (v == field1) {
+                if (c) {
+                    field1 = 99;
+                }
+                return field1;
+            }
+            return 0;
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = IfConditionAliasSubstitutionTransformer().transform(game)
+    assert result == game, "nested field reassignment must stop substitution (A2)"
+
+
+def test_no_substitution_after_element_write() -> None:
+    """F-075 A3: an element/key write `F[k] = v` to the comparison field is a
+    mutation the Phase-2 stop must see (its l-value is an ArrayAccess, not a
+    bare Variable)."""
+    source = """
+    Game Test() {
+        Map<Int, Int> field1;
+        Int f(Map<Int, Int> x, Int k) {
+            if (x == field1) {
+                field1[k] = 99;
+                return field1[k];
+            }
+            return 0;
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = IfConditionAliasSubstitutionTransformer().transform(game)
+    assert result == game, "element write to the field must stop substitution (A3)"
+
+
+def test_no_substitution_after_replacement_reassignment() -> None:
+    """F-075 A4: reassigning the replacement local breaks `field == local`, so
+    substitution must stop once the replacement side is written."""
+    source = """
+    Game Test() {
+        Int field1;
+        Int f(Int v) {
+            if (v == field1) {
+                v = 7;
+                return field1;
+            }
+            return 0;
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = IfConditionAliasSubstitutionTransformer().transform(game)
+    assert result == game, "replacement reassignment must stop substitution (A4)"

--- a/tests/unit/transforms/test_lazy_map_pair_to_sampled_function.py
+++ b/tests/unit/transforms/test_lazy_map_pair_to_sampled_function.py
@@ -351,3 +351,49 @@ def test_invariant_violation_initialize_populates_m1() -> None:
         }
         """,
     )
+
+
+def test_declines_sample_aliases_key_parameter() -> None:
+    """F-008: when the freshly-sampled local reuses the key parameter's name
+    (`k`), the sample declaration shadows the parameter.  The guard reads the
+    parameter binding while the write `M1[k] = s` and `return s` use the
+    sampled local -- two different bindings the collapsed `return F(k)` cannot
+    reproduce.  The matcher's anti-alias guard must decline (mirrors the
+    single-map sibling)."""
+    _apply_and_expect_unchanged(
+        """
+        Game G() {
+            Map<BitString<8>, BitString<8>> M1;
+            Map<BitString<8>, BitString<8>> M2;
+            BitString<8> Oracle(BitString<8> k) {
+                if (k in M1) { return M1[k]; }
+                else if (k in M2) { return M2[k]; }
+                BitString<8> k <- BitString<8>;
+                M1[k] = k;
+                return k;
+            }
+        }
+        """,
+    )
+
+
+def test_declines_map_field_initializer() -> None:
+    """F-009: a field-level initializer (`Map<...> M1 = preset;`, Field.value)
+    is never scanned by the Initialize-body precondition and is dropped by the
+    rebuild (merged field gets initializer None), silently replacing a preset
+    map with a fresh empty sampled Function.  The pass must decline."""
+    _apply_and_expect_unchanged(
+        """
+        Game G(Map<BitString<8>, BitString<8>> preset) {
+            Map<BitString<8>, BitString<8>> M1 = preset;
+            Map<BitString<8>, BitString<8>> M2;
+            BitString<8> Oracle(BitString<8> k) {
+                if (k in M1) { return M1[k]; }
+                else if (k in M2) { return M2[k]; }
+                BitString<8> s <- BitString<8>;
+                M1[k] = s;
+                return s;
+            }
+        }
+        """,
+    )

--- a/tests/unit/transforms/test_lazy_map_to_sampled_function.py
+++ b/tests/unit/transforms/test_lazy_map_to_sampled_function.py
@@ -399,6 +399,97 @@ def test_integration_via_core_pipeline() -> None:
     assert len(hash_method.block.statements) == 1
 
 
+def test_self_referential_key_fails() -> None:
+    """F-005: a key expression that reads the map itself (`(k in M)`) is
+    history-dependent -- the assign-site write `M[key] = x` changes what the
+    key reads on later calls -- so the idiom must not collapse to
+    `return M(k in M);` (which is ill-typed besides)."""
+    _apply_and_expect_unchanged(
+        """
+        Game G() {
+            Map<Bool, BitString<8>> M;
+            BitString<8> Lookup(Bool k) {
+                if ((k in M) in M) {
+                    return M[k in M];
+                }
+                BitString<8> x <- BitString<8>;
+                M[k in M] = x;
+                return x;
+            }
+        }
+        """
+    )
+
+
+def test_field_initializer_fails() -> None:
+    """Same blind spot as F-009 (pair sibling): a field-level initializer
+    (`Map<...> M = preset;`) is missed by the Initialize-body scan and dropped
+    by the rebuild, so a preset map must disqualify the rewrite."""
+    _apply_and_expect_unchanged(
+        """
+        Game G(Map<BitString<8>, BitString<8>> preset) {
+            Map<BitString<8>, BitString<8>> M = preset;
+            BitString<8> Lookup(BitString<8> k) {
+                if (k in M) {
+                    return M[k];
+                }
+                BitString<8> x <- BitString<8>;
+                M[k] = x;
+                return x;
+            }
+        }
+        """
+    )
+
+
+def test_dotted_out_of_idiom_write_fails() -> None:
+    """F-006: an out-of-idiom write spelled as a FieldAccess (`this.M[k] = v`)
+    is still a write to the map field and must disqualify the rewrite, even
+    though it contains no bare `Variable(M)` node."""
+    _apply_and_expect_unchanged(
+        """
+        Game G() {
+            Map<BitString<8>, BitString<8>> M;
+            BitString<8> Lookup(BitString<8> k) {
+                if (k in M) {
+                    return M[k];
+                }
+                BitString<8> x <- BitString<8>;
+                M[k] = x;
+                return x;
+            }
+            Void Poison(BitString<8> k, BitString<8> v) {
+                this.M[k] = v;
+            }
+        }
+        """
+    )
+
+
+def test_dotted_initialize_prepopulation_fails() -> None:
+    """F-006: a dotted pre-population write in Initialize (`this.M[c] = v`)
+    must disqualify the rewrite; the map is not empty at the start of the
+    oracle phase."""
+    _apply_and_expect_unchanged(
+        """
+        Game G() {
+            Map<BitString<8>, BitString<8>> M;
+            Void Initialize() {
+                this.M[0b00000000] = 0b10101010;
+            }
+            BitString<8> Lookup(BitString<8> k) {
+                if (k in M) {
+                    return M[k];
+                }
+                BitString<8> x <- BitString<8>;
+                M[k] = x;
+                return x;
+            }
+        }
+        """
+    )
+
+
 def test_defensive_guard_sample_var_in_key_expr() -> None:
     """AST-level defense: if the sample variable name `s` appears
     syntactically inside `key_expr`, the three structural occurrences of

--- a/tests/unit/transforms/test_local_rf_to_uniform.py
+++ b/tests/unit/transforms/test_local_rf_to_uniform.py
@@ -8,6 +8,51 @@ from proof_frog.transforms.random_functions import LocalRFToUniformTransformer
 @pytest.mark.parametrize(
     "method,expected",
     [
+        # F-026: a bare-variable copy of the RF value (`RF2 = RF`) is a second
+        # reference that lets the function escape and be evaluated again. The
+        # single-evaluation rewrite must DECLINE (expected == input), or the
+        # two evaluations `RF(0)` and `RF2(0)` -- equal in the input -- would be
+        # made independent.
+        (
+            """
+            [BitString<16>, BitString<16>] f() {
+                Function<BitString<8>, BitString<16>> RF <- Function<BitString<8>, BitString<16>>;
+                Function<BitString<8>, BitString<16>> RF2 = RF;
+                BitString<16> a = RF(0^8);
+                BitString<16> b = RF2(0^8);
+                return [a, b];
+            }
+            """,
+            """
+            [BitString<16>, BitString<16>] f() {
+                Function<BitString<8>, BitString<16>> RF <- Function<BitString<8>, BitString<16>>;
+                Function<BitString<8>, BitString<16>> RF2 = RF;
+                BitString<16> a = RF(0^8);
+                BitString<16> b = RF2(0^8);
+                return [a, b];
+            }
+            """,
+        ),
+        # F-026: the RF value passed as a method argument is likewise a
+        # non-call reference that must block the rewrite.
+        (
+            """
+            BitString<16> f(BitString<8> x) {
+                Function<BitString<8>, BitString<16>> RF <- Function<BitString<8>, BitString<16>>;
+                BitString<16> z = RF(x);
+                use(RF);
+                return z;
+            }
+            """,
+            """
+            BitString<16> f(BitString<8> x) {
+                Function<BitString<8>, BitString<16>> RF <- Function<BitString<8>, BitString<16>>;
+                BitString<16> z = RF(x);
+                use(RF);
+                return z;
+            }
+            """,
+        ),
         # Basic: local RF sampled then called once -> uniform sample
         (
             """

--- a/tests/unit/transforms/test_localize_init_only_field_sample.py
+++ b/tests/unit/transforms/test_localize_init_only_field_sample.py
@@ -26,6 +26,38 @@ def _apply(source: str) -> str:
 @pytest.mark.parametrize(
     "source,expected_has_field",
     [
+        # F-044 A1: the field is read BEFORE its sample inside Initialize
+        # (reading its initializer value). Localizing would delete the field
+        # and dangle the pre-sample read -> must DECLINE (field survives).
+        (
+            """
+            Game Test() {
+                BitString<1> myfield = 0b1;
+                BitString<1> Initialize() {
+                    BitString<1> x = myfield;
+                    myfield <- BitString<1>;
+                    return x;
+                }
+            }
+            """,
+            True,
+        ),
+        # F-044 A2: the field is referenced only from another field's
+        # initializer expression -> deleting it would dangle that initializer
+        # -> must DECLINE.
+        (
+            """
+            Game Test() {
+                BitString<1> myfield = 0b1;
+                BitString<1> g = myfield;
+                BitString<1> Initialize() {
+                    myfield <- BitString<1>;
+                    return g;
+                }
+            }
+            """,
+            True,
+        ),
         # Field only used in Initialize — should become local
         (
             """
@@ -74,7 +106,13 @@ def _apply(source: str) -> str:
             False,
         ),
     ],
-    ids=["init-only", "used-in-oracle", "init-return"],
+    ids=[
+        "f044-read-before-sample",
+        "f044-other-field-initializer",
+        "init-only",
+        "used-in-oracle",
+        "init-return",
+    ],
 )
 def test_localize_init_only_field_sample(source: str, expected_has_field: bool) -> None:
     game = frog_parser.parse_game(source)

--- a/tests/unit/transforms/test_map_key_reindex_soundness.py
+++ b/tests/unit/transforms/test_map_key_reindex_soundness.py
@@ -1,0 +1,147 @@
+"""RC1 soundness regressions for MapKeyReindex (F-134, F-135, F-136).
+
+MapKeyReindex re-keys a map under an injective wrapper. It is sound only when
+the wrapper is consistently applied at every access AND the reindexing cannot
+change an observable: a direct ``M.keys`` view exposes the original keys
+(F-134), an element write to a "read-only" context-arg field violates the
+read-only assumption (F-135), and a group-exponent wrapper needs a genuinely
+nonzero exponent field (F-136).
+"""
+
+from __future__ import annotations
+
+from proof_frog import frog_ast, frog_parser, visitors
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.transforms.map_reindex import MapKeyReindex
+from proof_frog.transforms._requirements import is_known_nonzero
+
+_PRIM = """
+Primitive T() {
+    deterministic injective BitString<8> Eval(BitString<8> x);
+}
+"""
+
+
+def _ctx(namespace: dict | None = None) -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=visitors.NameTypeMap(),
+        proof_namespace=namespace or {},
+        subsets_pairs=[],
+    )
+
+
+def test_keys_view_blocks_reindex() -> None:
+    """F-134: a ``M.keys`` view read exposes the raw keys, so reindexing under
+    ``Eval`` would change the observed key set. The pass must decline."""
+    prim = frog_parser.parse_string(_PRIM, frog_ast.FileType.PRIMITIVE)
+    game = frog_parser.parse_game("""
+        Game Pre(T TT) {
+            Map<BitString<8>, BitString<16>> M;
+            Void Store(BitString<8> a, BitString<16> s) {
+                M[a] = s;
+            }
+            BitString<16>? Lookup(BitString<8> a2) {
+                if (TT.Eval(a2) in M) {
+                    return M[TT.Eval(a2)];
+                }
+                return None;
+            }
+            BitString<8> Leak() {
+                for (BitString<8> k in M.keys) {
+                    return k;
+                }
+                return 0b00000000;
+            }
+        }
+        """)
+    result = MapKeyReindex().apply(game, _ctx({"T": prim, "TT": prim}))
+    assert result == game, "a M.keys view must block key reindexing (F-134)"
+
+
+def test_context_arg_element_write_blocks_reindex() -> None:
+    """F-135: an element write ``sk[0] = v`` to a context-arg field mutates a
+    value the wrapper treats as read-only; the readonly check must catch the
+    element write (not just a whole-variable assignment) and decline."""
+    prim = frog_parser.parse_string(_PRIM, frog_ast.FileType.PRIMITIVE)
+    game = frog_parser.parse_game("""
+        Game Pre(T TT) {
+            Map<BitString<8>, BitString<16>> M;
+            Array<BitString<8>, 1> sk;
+            Void Initialize() {
+                sk[0] = 0b00000000;
+            }
+            Void Store(BitString<8> a, BitString<16> s) {
+                M[TT.Eval(sk[0])] = s;
+            }
+            Void Rotate(BitString<8> v) {
+                sk[0] = v;
+            }
+            BitString<16>? Lookup(BitString<8> a2) {
+                if (TT.Eval(sk[0]) in M) {
+                    return M[TT.Eval(sk[0])];
+                }
+                return None;
+            }
+        }
+        """)
+    result = MapKeyReindex().apply(game, _ctx({"T": prim, "TT": prim}))
+    assert result == game, "element write to a context arg must block reindex (F-135)"
+
+
+def _nonzero_game(body: str) -> frog_ast.Game:
+    return frog_parser.parse_game(f"""
+        Game Pre(Group G) {{
+            ModInt<G.order> k;
+            {body}
+        }}
+        """)
+
+
+def test_is_known_nonzero_positive() -> None:
+    """A field sampled nonzero in Initialize and never overwritten is known
+    nonzero."""
+    game = _nonzero_game("""
+        Void Initialize() {
+            k <-uniq[{0}] ModInt<G.order>;
+        }
+        """)
+    assert is_known_nonzero("k", game)
+
+
+def test_is_known_nonzero_reassigned_to_zero() -> None:
+    """F-136 variant A: a later ``k = 0`` voids the nonzero guarantee."""
+    game = _nonzero_game("""
+        Void Initialize() {
+            k <-uniq[{0}] ModInt<G.order>;
+            k = 0;
+        }
+        """)
+    assert not is_known_nonzero("k", game)
+
+
+def test_is_known_nonzero_sample_outside_initialize() -> None:
+    """F-136 variant B: a uniq sample in a non-Initialize oracle (which may
+    never run) does not establish the field as nonzero."""
+    game = _nonzero_game("""
+        Void Unrelated() {
+            k <-uniq[{0}] ModInt<G.order>;
+        }
+        """)
+    assert not is_known_nonzero("k", game)
+
+
+def test_is_known_nonzero_rejects_parameter() -> None:
+    """An adversary-supplied parameter of the same name is not known nonzero."""
+    game = frog_parser.parse_game("""
+        Game Pre(Group G) {
+            ModInt<G.order> k;
+            Void Initialize() {
+                k <-uniq[{0}] ModInt<G.order>;
+            }
+            ModInt<G.order> Use(ModInt<G.order> k) {
+                return k;
+            }
+        }
+        """)
+    assert not is_known_nonzero("k", game)

--- a/tests/unit/transforms/test_near_misses.py
+++ b/tests/unit/transforms/test_near_misses.py
@@ -9,7 +9,10 @@ from proof_frog.transforms.algebraic import (
     UniformModIntSimplification,
     XorCancellation,
 )
-from proof_frog.transforms.control_flow import BranchElimination
+from proof_frog.transforms.control_flow import (
+    BranchElimination,
+    GuardConditionSimplification,
+)
 from proof_frog.transforms.inlining import (
     InlineSingleUseVariable,
     InlineSingleUseField,
@@ -1588,3 +1591,56 @@ def test_rgfe_no_near_miss_when_only_one_candidate_field() -> None:
     ctx = _rgfe_ctx()
     RefactorGroupElemFieldExp().apply(game, ctx)
     assert not [nm for nm in ctx.near_misses if nm.transform_name == _RGFE_NAME]
+
+
+_GCS_NAME = "Guard Condition Simplification"
+
+
+def test_gcs_near_miss_when_guard_set_mutated() -> None:
+    """Guard not folded when an element write mutates the guard set: a
+    near-miss is recorded at the decline point."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            Map<Int, Int> M;
+
+            Int O(Int k) {
+                if (k in M) {
+                    return 0;
+                } else {
+                    M[k] = 1;
+                    if (k in M) {
+                        return 100;
+                    } else {
+                        return 200;
+                    }
+                }
+            }
+        }
+        """)
+    ctx = _make_ctx()
+    GuardConditionSimplification().apply(game, ctx)
+    gcs = [nm for nm in ctx.near_misses if nm.transform_name == _GCS_NAME]
+    assert len(gcs) >= 1
+    assert "k in M" in gcs[0].variable
+
+
+def test_gcs_no_near_miss_when_guard_stable() -> None:
+    """Stable guard re-tested with no intervening write: the pass fires and
+    emits no near-miss."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            Int O(Int k, Set<Int> S) {
+                if (k in S) {
+                    if (k in S) {
+                        return 1;
+                    }
+                    return 2;
+                }
+                return 0;
+            }
+        }
+        """)
+    ctx = _make_ctx()
+    GuardConditionSimplification().apply(game, ctx)
+    gcs = [nm for nm in ctx.near_misses if nm.transform_name == _GCS_NAME]
+    assert len(gcs) == 0

--- a/tests/unit/transforms/test_simplify_return.py
+++ b/tests/unit/transforms/test_simplify_return.py
@@ -198,3 +198,96 @@ def test_simplify_return_field_dependency(
     transformed_ast = SimplifyReturnTransformer().transform_game(game_ast)
     print(transformed_ast)
     assert expected_ast == transformed_ast
+
+
+# RC1 soundness: SimplifyReturn moves a read past the intervening statements.
+# The intervening-modification guard was node-kind-incomplete (FieldAccess-blind
+# read-set; depth-1-ArrayAccess / Variable-only write-set; blind to <-uniq
+# insertion), so these distinguishable shapes were wrongly collapsed (findings
+# F-126: A1 uniq-insertion, A2 map-view FieldAccess, A3 nested element write).
+@pytest.mark.parametrize(
+    "game",
+    [
+        # A1: `x <-uniq[S] T` inserts into S, so moving `|S|` past it changes
+        # the value.  The write is on unique_set, not node.var.
+        """
+        Game G() {
+            Set<BitString<1>> S;
+            Int O() {
+                Int s = |S|;
+                BitString<1> x <-uniq[S] BitString<1>;
+                return s;
+            }
+        }
+        """,
+        # A2: the read reaches M only through the FieldAccess view `M.keys`;
+        # the write `M[0b0] = 0b0` must still be seen.
+        """
+        Game G() {
+            Map<BitString<1>, BitString<1>> M;
+            Int O() {
+                Int s = |M.keys|;
+                M[0b0] = 0b0;
+                return s;
+            }
+        }
+        """,
+        # A3: nested element write `M[0][1] = 1` mutates `M[0]`, which the
+        # read `M[0]` depends on; the l-value base is two levels deep.
+        """
+        Game G() {
+            Map<Int, [Int, Int]> M;
+            [Int, Int] O() {
+                [Int, Int] s = M[0];
+                M[0][1] = 1;
+                return s;
+            }
+        }
+        """,
+    ],
+)
+def test_simplify_return_soundness_declines(game: str) -> None:
+    """SimplifyReturn must not move a read past an intervening mutation of a
+    variable the read depends on, regardless of how the write/read is spelled."""
+    game_ast = frog_parser.parse_game(game)
+    transformed = SimplifyReturnTransformer().transform_game(game_ast)
+    assert str(game_ast) == str(transformed), (
+        f"read was wrongly moved past an intervening mutation:\n{transformed}"
+    )
+
+
+@pytest.mark.parametrize(
+    "game,expected",
+    [
+        # FieldAccess read with NO intervening write to M: the complete
+        # read-set must not over-block -- the move must still fire.
+        (
+            """
+            Game G() {
+                Map<Int, Int> M;
+                Int O() {
+                    Int s = |M.keys|;
+                    Int t = 5;
+                    return s;
+                }
+            }
+            """,
+            """
+            Game G() {
+                Map<Int, Int> M;
+                Int O() {
+                    Int t = 5;
+                    return |M.keys|;
+                }
+            }
+            """,
+        ),
+    ],
+)
+def test_simplify_return_soundness_still_fires(game: str, expected: str) -> None:
+    """The node-kind-complete read-set must not over-decline: a FieldAccess
+    read with no intervening write is still inlined into the return."""
+    transformed = SimplifyReturnTransformer().transform_game(
+        frog_parser.parse_game(game)
+    )
+    assert frog_parser.parse_game(expected) == transformed

--- a/tests/unit/transforms/test_single_call_field_to_local.py
+++ b/tests/unit/transforms/test_single_call_field_to_local.py
@@ -373,3 +373,22 @@ def test_single_call_field_to_local(
     print("EXPECTED", expected_ast)
     print("TRANSFORMED", transformed_ast)
     assert transformed_ast == expected_ast
+
+
+def test_param_shadowed_field_not_localized() -> None:
+    """F-055: a non-Initialize method has a parameter named like the field.
+    Name-only reference detection cannot tell the field from the parameter, and
+    prepending a localized sample would clobber the adversary's argument -- the
+    pass must DECLINE (game unchanged)."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            BitString<8> x;
+            Void Initialize() {
+                x <- BitString<8>;
+            }
+            BitString<8> Echo(BitString<8> x) {
+                return x;
+            }
+        }
+        """)
+    assert _single_call_field_to_local(game) == game

--- a/tests/unit/transforms/test_slice_of_inline_concat.py
+++ b/tests/unit/transforms/test_slice_of_inline_concat.py
@@ -160,3 +160,70 @@ def test_slice_of_inline_concat(game: str, expected: str) -> None:
     expected_ast = frog_parser.parse_game(expected)
     transformed = SliceOfInlineConcatTransformer().transform_game(game_ast)
     assert transformed == expected_ast
+
+
+# ---------------------------------------------------------------------------
+# F-029: the operand length used at the slice site must be the operand's TRUE
+# length in its own scope, not a stale flat name-keyed table.  The pass must
+# DECLINE (leave the slice unchanged) when a stale length would otherwise make
+# a wrong boundary match.  Each game below is a soundness attack from the
+# SliceOfInlineConcat prosecution.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "game",
+    [
+        # Attack 1 (Gap B): a decl-only local `BitString<n> x;` + untyped
+        # resample shadows the 2n-bit parameter `x`.  The old flat scan kept
+        # the parameter length (2n) for `x`, so `(x || b)[0 : 2n]` matched
+        # Case 1 against the stale 2n and returned the n-bit local `x`,
+        # dropping `b`.  Scope-aware tracking records `x = n`, so Case 1's
+        # `end (2n) == |x| (n)` is false and the slice is left intact.
+        """
+        Game G(Int n) {
+            BitString<2 * n> Oracle(BitString<2 * n> x, BitString<n> b) {
+                BitString<n> x;
+                x <- BitString<n>;
+                return (x || b)[0 : 2 * n];
+            }
+        }
+        """,
+        # Attack 2 (Gap A): a nested-block redeclaration `BitString<2n> a`
+        # shadows the outer `BitString<n> a`.  The flat top-level scan never
+        # saw the inner declaration, so the slice on the inner (2n-bit) `a`
+        # fired Case 1 against the outer length n.  Scope-aware tracking
+        # records `a = 2n` inside the if-block, so the slice is left intact.
+        """
+        Game G(Int n) {
+            BitString<n> Oracle(Bool cond, BitString<n> b) {
+                BitString<n> a <- BitString<n>;
+                if (cond) {
+                    BitString<2 * n> a <- BitString<2 * n>;
+                    return (a || b)[0 : n];
+                }
+                return a;
+            }
+        }
+        """,
+        # Attack 3 (Gap A, Case 2): same nested redeclaration, exercising the
+        # Case 2 boundary `[|a| : |a| + |b|]`.  The slice reads a middle window
+        # of the inner 2n-bit `a` and must not be rewritten to `b`.
+        """
+        Game G(Int n) {
+            [BitString<n>, BitString<n>] Oracle(Bool cond, BitString<n> b) {
+                BitString<n> a <- BitString<n>;
+                if (cond) {
+                    BitString<2 * n> a <- BitString<2 * n>;
+                    return [(a || b)[n : n + n], b];
+                }
+                return [b, b];
+            }
+        }
+        """,
+    ],
+)
+def test_slice_of_inline_concat_declines_on_stale_length(game: str) -> None:
+    game_ast = frog_parser.parse_game(game)
+    transformed = SliceOfInlineConcatTransformer().transform_game(game_ast)
+    assert transformed == game_ast, "pass must decline when the operand length is shadowed"

--- a/tests/unit/transforms/test_slice_simplification.py
+++ b/tests/unit/transforms/test_slice_simplification.py
@@ -134,3 +134,27 @@ def test_slice_simplification(
     print("EXPECTED", expected_ast)
     print("TRANSFORMED", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def test_stale_length_after_redeclaration_not_simplified() -> None:
+    """F-067: a component is redeclared with a different bit length before the
+    concatenation. The splice must use the length in effect at the concat (the
+    LAST declaration), not the first one found in the block. Here `a` is
+    redeclared 2*lambda-wide, so `z[lambda : 2*lambda]` is the second half of
+    `a`, NOT `b`; the pass must not rewrite it to `b`."""
+    method = """
+    BitString<lambda> f(BitString<lambda> b) {
+        BitString<lambda> a <- BitString<lambda>;
+        BitString<2 * lambda> a <- BitString<2 * lambda>;
+        BitString<3 * lambda> z = a || b;
+        return z[lambda : 2 * lambda];
+    }
+    """
+    game_ast = frog_parser.parse_method(method)
+    transformed = SimplifySpliceTransformer({"lambda": Symbol("lambda")}).transform(
+        game_ast
+    )
+    # The slice must NOT be rewritten to `b` (the stale-length bug); with the
+    # correct 2*lambda length for `a`, z[lambda:2*lambda] does not align with a
+    # component boundary, so the splice is left intact.
+    assert "return b;" not in str(transformed), str(transformed)

--- a/tests/unit/transforms/test_unique_rf_simplification.py
+++ b/tests/unit/transforms/test_unique_rf_simplification.py
@@ -245,3 +245,75 @@ def test_duplicate_rf_arg_not_simplified() -> None:
     assert (
         result == game
     ), "RF with duplicate argument variable should not be simplified"
+
+
+def test_aliased_rf_not_simplified() -> None:
+    """F-019: copying the function field into a local (``g = RF``) lets it be
+    re-queried through the alias on an adversary-chosen input. The call-site
+    walk only sees direct ``RF(...)`` calls, so the escape must be detected
+    separately and block the rewrite -- otherwise the guarded site becomes an
+    independent sample while the aliased query survives."""
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Function<BitString<n>, BitString<n>> RF;
+            Set<BitString<n>> S;
+            Void Initialize() {
+                RF <- Function<BitString<n>, BitString<n>>;
+            }
+            [BitString<n>, BitString<n>] Chal() {
+                BitString<n> r <-uniq[S] BitString<n>;
+                BitString<n> z = RF(r);
+                return [r, z];
+            }
+            BitString<n> Probe(BitString<n> x) {
+                Function<BitString<n>, BitString<n>> g = RF;
+                BitString<n> y = g(x);
+                return y;
+            }
+        }
+        """)
+    result = UniqueRFSimplification().apply(game, _make_ctx())
+    assert result == game, "aliased RF must not be simplified (F-019)"
+
+
+def test_rf_passed_as_argument_not_simplified() -> None:
+    """F-019: passing the function field as a method argument is also an
+    escape that the call-site walk cannot follow."""
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Function<BitString<n>, BitString<n>> RF;
+            Set<BitString<n>> S;
+            Void Initialize() {
+                RF <- Function<BitString<n>, BitString<n>>;
+            }
+            BitString<n> Chal() {
+                BitString<n> r <-uniq[S] BitString<n>;
+                BitString<n> z = RF(r);
+                sink(RF);
+                return z;
+            }
+        }
+        """)
+    result = UniqueRFSimplification().apply(game, _make_ctx())
+    assert result == game, "RF passed as an argument must not be simplified (F-019)"
+
+
+def test_dotted_nondomain_exclusion_set_modified_not_simplified() -> None:
+    """F-020: a non-``.domain`` dotted exclusion set is NOT auto-maintained, so
+    an explicit field assignment to it must still be detected. Previously every
+    dotted set name was exempted unconditionally."""
+    from proof_frog.transforms.random_functions import _exclusion_set_modified
+
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Set<BitString<n>> S;
+            BitString<n> Query(BitString<n> v) {
+                S.field = v;
+                return v;
+            }
+        }
+        """)
+    # A `.domain` set is auto-maintained -> not flagged.
+    assert not _exclusion_set_modified(game, "RF.domain")
+    # A non-`.domain` dotted set with an explicit field assignment IS flagged.
+    assert _exclusion_set_modified(game, "S.field")

--- a/tests/unit/transforms/test_unreachable_transformer.py
+++ b/tests/unit/transforms/test_unreachable_transformer.py
@@ -599,3 +599,86 @@ def test_unreachable_transformer(
     transformed_ast = RemoveUnreachableTransformer(method_ast).transform(method_ast)
     print("TRANSFORMED: ", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def _count_ifs(node) -> int:
+    from proof_frog import frog_ast
+
+    count = 0
+    stack = [node]
+    seen: set[int] = set()
+    while stack:
+        n = stack.pop()
+        if id(n) in seen:
+            continue
+        seen.add(id(n))
+        if isinstance(n, frog_ast.IfStatement):
+            count += 1
+        if isinstance(n, frog_ast.ASTNode):
+            for attr in vars(n).values():
+                if isinstance(attr, frog_ast.ASTNode):
+                    stack.append(attr)
+                elif isinstance(attr, (list, tuple)):
+                    stack.extend(a for a in attr if isinstance(a, frog_ast.ASTNode))
+    return count
+
+
+def test_remove_unreachable_nested_element_write_bumps_version() -> None:
+    """RC1 / F-104: a nested element write `M[0][0] = 0` mutates `M[0][0]`,
+    so the second `if (M[0][0] == 0)` is a fresh test, not a dead duplicate
+    of the first.  A depth-1-only write scan left `M` looking unmodified and
+    Case-B dedup wrongly deleted the reachable second if."""
+    method = frog_parser.parse_method(
+        """
+        Int O(Map<Int, Map<Int, Int>> M) {
+            if (M[0][0] == 0) { return 1; }
+            M[0][0] = 0;
+            if (M[0][0] == 0) { return 2; }
+            return 3;
+        }
+        """
+    )
+    transformed = RemoveUnreachableTransformer(method).transform(method)
+    assert _count_ifs(transformed) == 2, (
+        f"second if wrongly deleted after nested element write:\n{transformed}"
+    )
+
+
+def test_remove_unreachable_unique_sample_bumps_version() -> None:
+    """RC1: a `<-uniq` re-sample of a condition variable mutates it, so a
+    later structurally identical condition is not a dead duplicate.  The
+    write scan must recognise `UniqueSample.var` as a write."""
+    method = frog_parser.parse_method(
+        """
+        Int O() {
+            BitString<2> x <- BitString<2>;
+            if (x == 0b00) { return 1; }
+            x <-uniq[{x}] BitString<2>;
+            if (x == 0b00) { return 2; }
+            return 3;
+        }
+        """
+    )
+    transformed = RemoveUnreachableTransformer(method).transform(method)
+    assert _count_ifs(transformed) == 2, (
+        f"second if wrongly deleted after <-uniq re-sample:\n{transformed}"
+    )
+
+
+def test_remove_unreachable_still_dedups_genuine_duplicate() -> None:
+    """Positive control: with NO intervening write, two identical
+    conditions are genuinely redundant and the second must still be
+    removed (the version-tracking fix must not over-preserve)."""
+    method = frog_parser.parse_method(
+        """
+        Int O(Int x) {
+            if (x == 0) { return 1; }
+            if (x == 0) { return 2; }
+            return 3;
+        }
+        """
+    )
+    transformed = RemoveUnreachableTransformer(method).transform(method)
+    assert _count_ifs(transformed) == 1, (
+        f"genuinely dead duplicate if was not removed:\n{transformed}"
+    )


### PR DESCRIPTION
Several canonicalization passes decided whether a transform was safe using
reference- and write-detection that missed certain AST shapes (writes through
`M[k]`, `X.f`, `<-uniq` set insertion; the backing variable inside a field
access) or ignored scope (a parameter/local shadowing a field, a variable
redeclared in the same block). When the detection missed a write or a use, the
pass fired across a mutation or observation it couldn't see and changed the
game's behavior. This branch makes each affected check see the full set of node
kinds and respect scope.

Each fix targets the underlying condition, not a single example, keeps an
existing positive case working, and adds a regression test.

Passes fixed:

- GuardConditionSimplification: only treated a plain `x = e` as modifying `x`,
  so an element write `M[k]=v`, a field write, a `<-uniq[S]` insertion into `S`,
  or a loop variable shadowing the guard variable were all missed. Now uses
  complete write/rebind detection. (F-080/081/082/083)
- RemoveUnreachable / FoldEquivalentReturnBranch / SimplifyReturn: SSA version
  tracking and write-counting peel `M[k]`/`X.f`/slice l-values to the base
  variable, so a container field mutated through an element write is no longer
  seen as unwritten. SimplifyReturn also required the same complete scans in the
  statement-reordering and field-liveness movers it runs alongside.
  (F-104, F-119, F-126)
- LazyMap{,Pair}ToSampledFunction: recognized the backing map only as a bare
  variable, so `this.M[k]` reads/writes were invisible; also now rejects a
  history-dependent self-referential key, an aliased sample, and a map field
  initializer. (F-005/006/008/009)
- SliceOfInlineConcat: `(a || b)[i:j] -> a` used a flat name->length table that
  ignored scope, so a nested redeclaration or a declaration-only local shadowing
  a parameter left a stale length and the wrong operand could be returned.
  Lengths are now tracked scope-aware. (F-029)
- LocalRFToUniform: replaces a random function called once with a uniform
  sample, but counted only call and field-access references; a copy `g = RF` or
  passing `RF` as an argument hid a second evaluation. Now any non-call
  reference blocks the rewrite. (F-026)
- UniqueRFSimplification: copying the function value let it be re-queried after
  one guarded call; and every dotted exclusion-set name was exempted from the
  "set not explicitly modified" check rather than just `.domain`. (F-019/020)
- LocalizeInitOnlyFieldSample: moves a field sampled only in Initialize to a
  local and deletes the field, but never inspected the field's initializer
  expression, a sibling field's initializer, or a read of the field before its
  sample — any of which the deletion would dangle. (F-044)
- IfConditionAliasSubstitution: inside `if (x == field)` it rewrites `field` to
  `x`, stopping at a plain reassignment of the field but not at a nested write,
  an element write, or a reassignment of `x` itself. (F-075)
- DeadGuardedAssignmentElimination: replaced an assignment read only by a
  following guard with `false`, counting reads within one method. A game field
  persists across calls, so its value can be read by another oracle, or carried
  from a previous call when the assignment is conditional. The field case now
  uses a whole-game read count and requires the field to be definitely assigned
  before the guard. (F-099)
- MapKeyReindex: re-keys a map under an injective wrapper. A direct `M.keys`
  read (which exposes the original keys) was silently skipped instead of
  blocking; the "context argument is read-only" check missed an element write
  `sk[0]=v`; and the "exponent is nonzero" check matched any same-named uniq
  sample, ignoring a later `k = 0` or a sample in an oracle that may not run.
  (F-134/135/136)
- Counter/SingleCallFieldToLocal: localize a field used in a single oracle by
  prepending its sample to that oracle. Name-only detection can't distinguish
  the field from a same-named parameter, and the prepended sample would clobber
  the parameter; these now decline when an oracle binds the field's name.
  (F-050/055)
- SimplifySplice: `z = a || b; z[i:j]` recovered each component's length from
  the first declaration found in the whole block, so a same-scope redeclaration
  at a different width used a stale length. It now uses the declaration in scope
  at the concatenation. (F-067)

Two supporting fixes were needed to make the above hold end-to-end:

- Z3FormulaVisitor had no handler for a slice, so the equivalence fallback
  modelled a slice by its width alone and treated two different full-width
  slices of a concatenation as equal. Added a slice handler that interns the
  whole slice as one opaque atom keyed by its structure.
- The dependency graph used for statement reordering only inspected top-level
  statements when deciding whether a statement mutates a field, so a field write
  nested in an `if` was invisible and a later `return` could be reordered ahead
  of it. It now finds nested field writes.

Testing: full suite passes (2348 tests, including 15 new regression tests);
`make lint` is 10.00/10 (black, mypy, pylint, and the VS Code extension's
`tsc`); all example proofs still verify, including the CFRG hybrid-KEM proofs
that depend on MapKeyReindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
