### PR TITLE
Soundness: gate delete/dedup/duplicate/fold/move passes on non-determinism (RC3)

### DIFF
--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -453,6 +453,14 @@ class NameResolutionVisitor(VariableTypeVisitor):
     def visit_scheme(self, scheme: frog_ast.Scheme) -> None:
         super().visit_scheme(scheme)
         self._check_duplicate_names(scheme)
+        for sample_node, method_name in _deterministic_methods_with_sampling(scheme):
+            print_error(
+                sample_node,
+                f"method '{method_name}' is declared 'deterministic' but its "
+                f"body samples randomness; a deterministic method must be "
+                f"sampling-free (same inputs must always yield the same output)",
+                self.file_name,
+            )
         if scheme.primitive_name not in self.import_namespace:
             suggestion = _suggestions.suggest_identifier(
                 scheme.primitive_name, list(self.import_namespace.keys())
@@ -2560,6 +2568,31 @@ def _ast_to_sympy(  # pylint: disable=too-many-return-statements
                 return -val
         return None
     return None
+
+
+def _deterministic_methods_with_sampling(
+    scheme: frog_ast.Scheme,
+) -> list[tuple[frog_ast.ASTNode, str]]:
+    """Find ``deterministic`` scheme methods whose bodies sample randomness.
+
+    A method annotated ``deterministic`` promises the engine that it always
+    returns the same output for the same inputs; many canonicalization passes
+    (expression aliasing, call deduplication, field hoisting) trust that promise
+    via ``has_nondeterministic_call``. A body containing a ``<-`` / ``<-uniq``
+    sample violates it, so the annotation must not be accepted. Returns a list
+    of ``(sampling_node, method_name)`` for each violation (one entry per
+    sampling statement, in source order).
+    """
+    violations: list[tuple[frog_ast.ASTNode, str]] = []
+    for method in scheme.methods:
+        if not method.signature.deterministic:
+            continue
+        sample_node = visitors.SearchVisitor[frog_ast.Statement](
+            lambda n: isinstance(n, (frog_ast.Sample, frog_ast.UniqueSample))
+        ).visit(method.block)
+        if sample_node is not None:
+            violations.append((sample_node, method.signature.name))
+    return violations
 
 
 def _check_scheme_against_primitive(

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -152,7 +152,18 @@ class UniqExclusionBranchEliminationTransformer(BlockTransformer):
     been mutated since, the structural equality ``v == s`` is provably
     ``false``.  This is the same reasoning that justifies
     ``FreshInputRFToUniform`` (see TRANSFORMS.md).
+
+    Determinism precondition: an exclusion element that contains a
+    non-deterministic call (e.g. an unannotated ``F.eval()``) denotes an
+    independent draw.  A later, structurally-identical ``v == F.eval()``
+    re-evaluates the call, so the two values are NOT provably distinct and
+    the fold to ``false`` would be unsound.  ``_exclusion_elements`` drops
+    any such element (and records a near-miss) so it is never tracked as a
+    constraint.
     """
+
+    def __init__(self, ctx: PipelineContext | None = None) -> None:
+        self.ctx = ctx
 
     @staticmethod
     def _free_variable_names(expr: frog_ast.Expression) -> set[str]:
@@ -171,23 +182,48 @@ class UniqExclusionBranchEliminationTransformer(BlockTransformer):
         SearchVisitor(_collect).visit(expr)
         return names
 
-    @classmethod
     def _exclusion_elements(
-        cls, unique_set: frog_ast.Expression
+        self, unique_set: frog_ast.Expression
     ) -> tuple[list[frog_ast.Expression], set[str]] | None:
         """Extract the list of exclusion elements from a ``<-uniq[S]`` set.
 
         Currently handles literal sets ``{a, b, ...}``.  Returns the list
         of elements together with the union of their free-variable names
         (used for invalidation tracking).  Returns ``None`` if the set is
-        not a literal.
+        not a literal or if any element contains a non-deterministic call
+        (such an element re-evaluates differently when re-stated in a
+        later comparison, so the exclusion does not justify folding).
         """
         if not isinstance(unique_set, frog_ast.Set):
             return None
+        namespace = self.ctx.proof_namespace if self.ctx else {}
+        let_types = self.ctx.proof_let_types if self.ctx else None
         all_free: set[str] = set()
         for el in unique_set.elements:
-            all_free |= cls._free_variable_names(el)
+            if has_nondeterministic_call(el, namespace, let_types):
+                self._note_nondeterministic_element(el)
+                return None
+            all_free |= self._free_variable_names(el)
         return list(unique_set.elements), all_free
+
+    def _note_nondeterministic_element(self, element: frog_ast.Expression) -> None:
+        if self.ctx is None:
+            return
+        self.ctx.near_misses.append(
+            NearMiss(
+                transform_name="Uniq Exclusion Branch Elimination",
+                reason=(
+                    "Exclusion-set element contains a non-deterministic call, "
+                    "so a later structurally-identical comparison re-evaluates "
+                    "it to an independent value; the equality cannot be folded "
+                    "to false"
+                ),
+                location=None,
+                suggestion=None,
+                variable=str(element),
+                method=None,
+            )
+        )
 
     @staticmethod
     def _written_var_names(stmt: frog_ast.Statement) -> set[str]:
@@ -682,10 +718,36 @@ class RemoveUnreachableTransformer(BlockTransformer):
        proving that no execution can reach subsequent statements.
     """
 
-    def __init__(self, ast: frog_ast.ASTNode):
+    def __init__(
+        self, ast: frog_ast.ASTNode, ctx: PipelineContext | None = None
+    ) -> None:
         self.ast = ast
+        self.ctx = ctx
         self._block_path: dict[int, list[z3.AstRef]] = {}
         self._block_versions: dict[int, dict[str, int]] = {}
+
+    def _condition_is_nondeterministic(self, cond: frog_ast.Expression) -> bool:
+        namespace = self.ctx.proof_namespace if self.ctx else {}
+        let_types = self.ctx.proof_let_types if self.ctx else None
+        if has_nondeterministic_call(cond, namespace, let_types):
+            if self.ctx is not None:
+                self.ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Remove unreachable blocks of code",
+                        reason=(
+                            "Return-condition dedup declined: the condition "
+                            "contains a non-deterministic call, so a later "
+                            "structurally-identical condition re-evaluates to "
+                            "an independent value and is not subsumed"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=str(cond),
+                        method=None,
+                    )
+                )
+            return True
+        return False
 
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         # Any statement following an unconditional top-level return is
@@ -885,9 +947,15 @@ class RemoveUnreachableTransformer(BlockTransformer):
                     )
                 condition_formulae.append(individual_formula)
 
-            # Track conditions that lead to unconditional returns
+            # Track conditions that lead to unconditional returns. A
+            # non-deterministic condition is NOT tracked: a later,
+            # structurally-identical condition re-evaluates the call to an
+            # independent value, so the earlier return does not subsume it
+            # and deduping it (Case B above) would delete a live draw.
             for condition_index, condition in enumerate(statement.conditions):
                 if contains_unconditional_return(statement.blocks[condition_index]):
+                    if self._condition_is_nondeterministic(condition):
+                        continue
                     seen_return_conditions.append(condition)
 
             # Tag inner blocks with accumulated path constraints
@@ -1235,7 +1303,15 @@ class RedundantConditionalReturnTransformer(BlockTransformer):
     collapses to ``if (Verify(..)) return ss; return None;``. (This arises
     after IfConditionAliasSubstitution rewrites a redundant case-split branch
     into the same form as its fall-through.)
+
+    Determinism precondition: dropping the guard discards an evaluation of
+    ``cond``.  If ``cond`` contains a non-deterministic call, evaluating it
+    has an observable effect (e.g. consuming a fresh draw / advancing a
+    counter), so the guard is NOT redundant and the fold is declined.
     """
+
+    def __init__(self, ctx: PipelineContext | None = None) -> None:
+        self.ctx = ctx
 
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         for index, statement in enumerate(block.statements):
@@ -1244,6 +1320,11 @@ class RedundantConditionalReturnTransformer(BlockTransformer):
             if statement.has_else_block():
                 continue
             if len(statement.conditions) != 1:
+                continue
+            # Dropping the if discards an evaluation of its condition. A
+            # non-deterministic condition is observable, so the guard is
+            # not redundant -- decline the fold.
+            if self._condition_is_nondeterministic(statement.conditions[0]):
                 continue
             if_body = statement.blocks[0]
             if not if_body.statements:
@@ -1266,6 +1347,28 @@ class RedundantConditionalReturnTransformer(BlockTransformer):
                 + frog_ast.Block(block.statements[index + 1 :])
             )
         return block
+
+    def _condition_is_nondeterministic(self, cond: frog_ast.Expression) -> bool:
+        namespace = self.ctx.proof_namespace if self.ctx else {}
+        let_types = self.ctx.proof_let_types if self.ctx else None
+        if has_nondeterministic_call(cond, namespace, let_types):
+            if self.ctx is not None:
+                self.ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Redundant Conditional Return",
+                        reason=(
+                            "Redundant-guard fold declined: the if-condition "
+                            "contains a non-deterministic call whose evaluation "
+                            "is observable, so the guard is not redundant"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=str(cond),
+                        method=None,
+                    )
+                )
+            return True
+        return False
 
 
 class AbsorbRedundantEarlyReturnTransformer(BlockTransformer):
@@ -1307,7 +1410,8 @@ class AbsorbRedundantEarlyReturnTransformer(BlockTransformer):
     ``!P`` that no other transform can drop.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, ctx: PipelineContext | None = None) -> None:
+        self.ctx = ctx
         self._nesting_depth = 0
 
     def transform_if_statement(
@@ -1356,6 +1460,13 @@ class AbsorbRedundantEarlyReturnTransformer(BlockTransformer):
                 continue
             assert isinstance(statement, frog_ast.IfStatement)
             early_p = statement.conditions[0]
+            # Determinism precondition: the rewrite duplicates ``!P`` into
+            # every intervening guard. If ``P`` contains a non-deterministic
+            # call, those k copies denote independent evaluations (and the
+            # original evaluated ``P`` exactly once), so absorbing it is
+            # unsound -- decline.
+            if self._early_p_is_nondeterministic(early_p):
+                continue
             return_stmt = statement.blocks[0].statements[0]
             assert isinstance(return_stmt, frog_ast.ReturnStatement)
             early_x = return_stmt.expression
@@ -1396,6 +1507,29 @@ class AbsorbRedundantEarlyReturnTransformer(BlockTransformer):
             )
             return self.transform_block(frog_ast.Block(new_stmts))
         return block
+
+    def _early_p_is_nondeterministic(self, early_p: frog_ast.Expression) -> bool:
+        namespace = self.ctx.proof_namespace if self.ctx else {}
+        let_types = self.ctx.proof_let_types if self.ctx else None
+        if has_nondeterministic_call(early_p, namespace, let_types):
+            if self.ctx is not None:
+                self.ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Absorb Redundant Early Return",
+                        reason=(
+                            "Early-return absorption declined: the early-return "
+                            "guard contains a non-deterministic call, so "
+                            "duplicating its negation into the intervening "
+                            "guards would create independent re-evaluations"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=str(early_p),
+                        method=None,
+                    )
+                )
+            return True
+        return False
 
 
 def _is_simple_early_return_if(stmt: frog_ast.Statement) -> bool:
@@ -1526,6 +1660,13 @@ class IfFalseReturnToConjunctionTransformer(BlockTransformer):
                 and inner.expression.bool is False
             ):
                 continue
+            # Determinism precondition: the guard ``P`` is moved into the
+            # trailing conjunction (``BoolExpr && !P``), so it is re-evaluated
+            # on the path where the original short-circuited at the early
+            # ``return false``. A non-deterministic ``P`` is observable; the
+            # rewrite would run it where the original did not -- decline.
+            if self._guard_is_nondeterministic(stmt.conditions[0]):
+                continue
             # Trailing return must be the last statement in the block,
             # with only side-effect-free typed-local declarations between
             # the if and it.
@@ -1535,6 +1676,12 @@ class IfFalseReturnToConjunctionTransformer(BlockTransformer):
             trailing = block.statements[trailing_idx]
             assert isinstance(trailing, frog_ast.ReturnStatement)
             if trailing.expression is None:
+                continue
+            # Determinism precondition: the trailing expression ``Q`` is
+            # conjoined and thus EVALUATED on the ``P``-true path that the
+            # original skipped (the original returned ``false`` immediately).
+            # A non-deterministic ``Q`` is observable there -- decline.
+            if self._guard_is_nondeterministic(trailing.expression):
                 continue
             neg_p = _negate_condition(stmt.conditions[0])
             # Place the original return expression FIRST and the
@@ -1589,6 +1736,28 @@ class IfFalseReturnToConjunctionTransformer(BlockTransformer):
             return None
         return None
 
+    def _guard_is_nondeterministic(self, expr: frog_ast.Expression) -> bool:
+        if has_nondeterministic_call(
+            expr, self.ctx.proof_namespace, self.ctx.proof_let_types
+        ):
+            self.ctx.near_misses.append(
+                NearMiss(
+                    transform_name="If False Return To Conjunction",
+                    reason=(
+                        "If-false-to-conjunction declined: the guard or the "
+                        "trailing return expression contains a non-deterministic "
+                        "call, which the rewrite would evaluate on the path that "
+                        "the original early-return short-circuited"
+                    ),
+                    location=None,
+                    suggestion=None,
+                    variable=str(expr),
+                    method=None,
+                )
+            )
+            return True
+        return False
+
 
 class FoldEquivalentReturnBranchTransformer(BlockTransformer):
     """Folds ``if (P) { return X; } return Y;`` to ``return Y;`` when Z3
@@ -1642,13 +1811,18 @@ class FoldEquivalentReturnBranchTransformer(BlockTransformer):
         if isinstance(ast, frog_ast.Game):
             self._init_field_rhs = self._collect_init_field_rhs(ast)
 
-    @staticmethod
     def _collect_init_field_rhs(
+        self,
         game: frog_ast.Game,
     ) -> list[tuple[frog_ast.Variable, frog_ast.Expression]]:
         """Collect ``F → rhs`` substitutions for fields F that are
         single-write in Initialize with a deterministic FuncCall RHS and
         no other writes in the game.
+
+        A FuncCall RHS containing a non-deterministic call is rejected: the
+        substitution would expand the field to a textual copy of the call,
+        and a later comparison treats the two copies as the same value even
+        though each invocation draws independently.
         """
         field_names = {f.name for f in game.fields}
         # Count assignments per field across all methods.
@@ -1673,6 +1847,29 @@ class FoldEquivalentReturnBranchTransformer(BlockTransformer):
             if counts.get(stmt.var.name, 0) != 1:
                 continue
             if not isinstance(stmt.value, frog_ast.FuncCall):
+                continue
+            # Reject a non-deterministic FuncCall RHS: expanding the field
+            # to a textual copy of the call would let the comparison fold
+            # two independent invocations into one.
+            if has_nondeterministic_call(
+                stmt.value,
+                self.ctx.proof_namespace,
+                self.ctx.proof_let_types,
+            ):
+                self.ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Fold Equivalent Return Branch",
+                        reason=(
+                            "Init-only field RHS not expanded: the field is "
+                            "assigned a non-deterministic call, so substituting "
+                            "the call text would equate independent draws"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=stmt.var.name,
+                        method=None,
+                    )
+                )
                 continue
             result.append((stmt.var, stmt.value))
         return result
@@ -1792,6 +1989,12 @@ class FoldEquivalentReturnBranchTransformer(BlockTransformer):
                 type_map + (self.ctx.proof_let_types or NameTypeMap()),
                 variable_version_map={},
                 opaque_func_call_fallback=True,
+                # Enable the in-visitor non-determinism backstop: any P/X/Y
+                # containing a non-deterministic call must not be modelled as
+                # an opaque atom (which would fold independent draws). The
+                # primary Gap-F guard above already refuses such inputs; this
+                # is defense-in-depth on the substituted expressions.
+                proof_namespace=self.ctx.proof_namespace,
             )
             p_formula = visitor.visit(p_expr)
             x_formula = visitor.visit(x_sub)
@@ -2107,9 +2310,17 @@ class DeadGuardedAssignmentEliminationTransformer(BlockTransformer):
     rejection (``if (pk == pkS && c notin C) ...``) dominates a real-
     verification call that the simulated game performs only on recorded
     ciphertexts.
+
+    Determinism precondition: the kill matches the inner guard ``G`` (by
+    normalized string equality) against path facts derived from earlier
+    conditions.  If ``G`` contains a non-deterministic call, the path fact
+    records ONE evaluation while the inner guard performs a SECOND,
+    independent one; string equality wrongly treats them as the same value.
+    The kill is declined when ``G`` is non-deterministic.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, ctx: PipelineContext | None = None) -> None:
+        self.ctx = ctx
         # Field names and their read counts across the WHOLE game, populated by
         # ``transform_game``.  Empty when the transformer is driven on a bare
         # block (unit tests): then every name is treated as a method-local and
@@ -2137,6 +2348,12 @@ class DeadGuardedAssignmentEliminationTransformer(BlockTransformer):
             if use is None:
                 continue
             v_name, guard = use
+            # Determinism precondition: the kill compares the inner guard
+            # against earlier path facts by normalized string equality. A
+            # non-deterministic guard re-evaluates independently of the path
+            # fact, so the entailment does not hold -- decline the kill.
+            if self._guard_is_nondeterministic(guard):
+                continue
             # Soundness: the assignment's value may only be killed if `v` is
             # read solely by the matched `if (v)` guard. Any other read of `v`
             # would observe the rewritten `false` value. Count reads (variable
@@ -2172,6 +2389,29 @@ class DeadGuardedAssignmentEliminationTransformer(BlockTransformer):
                     frog_ast.Block(new_prefix + list(block.statements[index:]))
                 )
         return block
+
+    def _guard_is_nondeterministic(self, guard: frog_ast.Expression) -> bool:
+        namespace = self.ctx.proof_namespace if self.ctx else {}
+        let_types = self.ctx.proof_let_types if self.ctx else None
+        if has_nondeterministic_call(guard, namespace, let_types):
+            if self.ctx is not None:
+                self.ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Dead Guarded Assignment Elimination",
+                        reason=(
+                            "Dead-store kill declined: the dominating guard "
+                            "contains a non-deterministic call, so the path "
+                            "fact from an earlier evaluation does not entail "
+                            "the guard's independent re-evaluation"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=str(guard),
+                        method=None,
+                    )
+                )
+            return True
+        return False
 
     @staticmethod
     def _read_count(block: frog_ast.Block, name: str) -> int:
@@ -2305,14 +2545,14 @@ class RedundantConditionalReturn(TransformPass):
     name = "Redundant Conditional Return"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return RedundantConditionalReturnTransformer().transform(game)
+        return RedundantConditionalReturnTransformer(ctx).transform(game)
 
 
 class AbsorbRedundantEarlyReturn(TransformPass):
     name = "Absorb Redundant Early Return"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return AbsorbRedundantEarlyReturnTransformer().transform(game)
+        return AbsorbRedundantEarlyReturnTransformer(ctx).transform(game)
 
 
 class FactorCommonGuard(TransformPass):
@@ -2333,7 +2573,7 @@ class DeadGuardedAssignmentElimination(TransformPass):
     name = "Dead Guarded Assignment Elimination"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return DeadGuardedAssignmentEliminationTransformer().transform(game)
+        return DeadGuardedAssignmentEliminationTransformer(ctx).transform(game)
 
 
 class IfFalseReturnToConjunction(TransformPass):
@@ -2361,7 +2601,7 @@ class UniqExclusionBranchElimination(TransformPass):
     name = "Uniq Exclusion Branch Elimination"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return UniqExclusionBranchEliminationTransformer().transform(game)
+        return UniqExclusionBranchEliminationTransformer(ctx).transform(game)
 
 
 class ElseUnwrap(TransformPass):
@@ -2389,4 +2629,4 @@ class RemoveUnreachable(TransformPass):
     name = "Remove unreachable blocks of code"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return RemoveUnreachableTransformer(game).transform(game)
+        return RemoveUnreachableTransformer(game, ctx).transform(game)

--- a/proof_frog/transforms/map_iteration.py
+++ b/proof_frog/transforms/map_iteration.py
@@ -26,7 +26,13 @@ from typing import Optional, Union
 
 from .. import frog_ast
 from ..visitors import SearchVisitor, Transformer
-from ._base import NearMiss, PipelineContext, TransformPass, _lookup_primitive_method
+from ._base import (
+    NearMiss,
+    PipelineContext,
+    TransformPass,
+    _lookup_primitive_method,
+    has_nondeterministic_call,
+)
 
 _LAZY_MAP_SCAN_NAME = "Lazy Map Scan"
 
@@ -220,6 +226,17 @@ def _match_scan_body(
     if key_expr is not None:
         if _references_var(key_expr, e_name):
             return "key expression references the loop variable"
+        # Soundness gate (verdict §8, P6): the rewrite re-evaluates ``key``
+        # at independent fresh sites (membership test, ``M[key]`` lookup, and
+        # every substituted ``e[0]``), whereas the input loop evaluates it once
+        # per iteration. If ``key`` contains a non-deterministic call (a scheme/
+        # game method or an unannotated primitive method), those sites draw
+        # independently and the output distribution differs. Decline -- mirrors
+        # the injective-call branch's ``method.deterministic`` gate (L182-183).
+        if has_nondeterministic_call(
+            key_expr, ctx.proof_namespace, ctx.proof_let_types
+        ):
+            return "key expression contains a non-deterministic call"
         return _LiteralEqualityMatch(key_expr, body_expr)
     inj = _try_match_injective_call(cond, e_name, ctx)
     if isinstance(inj, _InjectiveCallMatch):

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -1885,6 +1885,56 @@ def _rf_args_structurally_differ(
     return _check_exprs(init_arg, oracle_arg)
 
 
+def _sampled_function_fields_in_init(
+    game: frog_ast.Game,
+) -> set[str]:
+    """Return names of ``Function`` fields that are genuinely SAMPLED.
+
+    A function field is a *sampled random function* (re-samplable / ROM) only
+    when it is bound via ``H <- Function<...>`` in ``Initialize``.  A field
+    bound by an ordinary assignment ``H = F;`` (a known/standard-model
+    function) is NOT a random function, so the RF-to-uniform rewrite is invalid
+    for it (verdict vector (a)).
+    """
+    sampled: set[str] = set()
+    for method in game.methods:
+        if method.signature.name != "Initialize":
+            continue
+        for stmt in method.block.statements:
+            if (
+                isinstance(stmt, frog_ast.Sample)
+                and isinstance(stmt.var, frog_ast.Variable)
+                and isinstance(stmt.sampled_from, frog_ast.FunctionType)
+            ):
+                sampled.add(stmt.var.name)
+    return sampled
+
+
+def _count_rf_calls_in_block(block: frog_ast.Block, rf_name: str) -> int:
+    """Count every ``rf_name(...)`` FuncCall in *block* (recursing everywhere).
+
+    Unlike :func:`_collect_rf_call_sites` this returns just the count; it is
+    used to detect a SECOND init call to the RF embedded in a larger
+    expression (verdict vector (d)), which ``init_calls`` (standalone
+    assignments only) does not see.
+    """
+    return len(_collect_rf_call_sites(block, rf_name))
+
+
+def _rf_aliased_in_game(game: frog_ast.Game, rf_name: str) -> bool:
+    """True if the function field *rf_name* is copied into a local alias.
+
+    A local alias ``G = H;`` (where ``H`` is the RF) makes any subsequent
+    ``G(...)`` an RF query that the call-site scan -- which matches only by the
+    name ``rf_name`` -- cannot see (verdict vector (c)).  More generally, any
+    occurrence of ``Variable(rf_name)`` outside a direct call / property-access /
+    its own initialization lets the function value escape.  Reuses the existing
+    escape predicate so the soundness condition matches
+    :class:`UniqueRFSimplification`.
+    """
+    return _rf_value_escapes(game, rf_name)
+
+
 class ChallengeExclusionRFToUniformTransformer:
     """Replace an RF field call in Initialize with a uniform sample when the
     call's input is guaranteed distinct from all oracle RF calls by a
@@ -1894,7 +1944,7 @@ class ChallengeExclusionRFToUniformTransformer:
     design and soundness argument.
     """
 
-    def transform(
+    def transform(  # pylint: disable=too-many-branches
         self,
         game: frog_ast.Game,
         proof_namespace: frog_ast.Namespace | None = None,
@@ -1905,9 +1955,36 @@ class ChallengeExclusionRFToUniformTransformer:
             proof_namespace = {}
         field_names = [f.name for f in game.fields]
         field_types: dict[str, frog_ast.Type] = {f.name: f.type for f in game.fields}
+        # Vector (a): only genuinely SAMPLED random functions are eligible.  A
+        # field bound by ``H = F;`` (a known function) denotes a fixed value the
+        # adversary can recompute, so H(cf) is not an independent uniform draw.
+        sampled_fields = _sampled_function_fields_in_init(game)
         rf_fields: dict[str, frog_ast.FunctionType] = {}
         for f in game.fields:
             if isinstance(f.type, frog_ast.FunctionType):
+                if f.name not in sampled_fields:
+                    if ctx is not None:
+                        ctx.near_misses.append(
+                            NearMiss(
+                                transform_name="Challenge Exclusion RF To Uniform",
+                                reason=(
+                                    f"Function field '{f.name}' is not a sampled "
+                                    "random function (it is bound to a known / "
+                                    "standard-model function, not '<- Function<"
+                                    "...>'), so RF(cf) is a fixed value, not an "
+                                    "independent uniform draw"
+                                ),
+                                location=None,
+                                suggestion=(
+                                    f"Only sample-bound functions ('{f.name} <- "
+                                    "Function<...>') may be simplified to a "
+                                    "uniform draw"
+                                ),
+                                variable=f.name,
+                                method=None,
+                            )
+                        )
+                    continue
                 rf_fields[f.name] = f.type
 
         if not rf_fields:
@@ -1939,6 +2016,58 @@ class ChallengeExclusionRFToUniformTransformer:
                     init_calls.append((idx, stmt))
 
             if len(init_calls) != 1:
+                continue
+
+            # Vector (c): if the RF value is copied into a local alias (or
+            # otherwise escapes), an aliased call ``G(cf)`` re-queries the init
+            # point but is invisible to the by-name call-site scan.  Decline.
+            if _rf_aliased_in_game(game, rf_name):
+                if ctx is not None:
+                    ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Challenge Exclusion RF To Uniform",
+                            reason=(
+                                f"Random function '{rf_name}' is copied, aliased, "
+                                "or passed as an argument; an RF query through the "
+                                "alias is invisible to the call-site scan and may "
+                                "re-query the challenge input"
+                            ),
+                            location=None,
+                            suggestion=(
+                                "Call the random function directly at every use "
+                                "site; do not bind it to another variable"
+                            ),
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
+                continue
+
+            # Vector (d): the single standalone ``field = H(arg)`` must be the
+            # ONLY call to the RF in Initialize.  A second evaluation embedded
+            # in a larger expression (e.g. ``leak = H(cf) || cf;``) is not
+            # counted by ``init_calls`` and would survive the rewrite, leaving
+            # ``field`` and ``leak`` incorrectly correlated.
+            if _count_rf_calls_in_block(init_method.block, rf_name) != 1:
+                if ctx is not None:
+                    ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Challenge Exclusion RF To Uniform",
+                            reason=(
+                                f"Initialize evaluates '{rf_name}' more than once; "
+                                "a second evaluation (possibly embedded in a "
+                                "larger expression) would survive the rewrite and "
+                                "stay correlated with the sampled field"
+                            ),
+                            location=None,
+                            suggestion=(
+                                "Ensure Initialize evaluates the random function "
+                                "exactly once, as a standalone assignment"
+                            ),
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
                 continue
 
             init_idx, init_stmt = init_calls[0]

--- a/tests/integration/test_rc3_control_flow.py
+++ b/tests/integration/test_rc3_control_flow.py
@@ -1,0 +1,389 @@
+"""RC3 determinism-guard distinguisher tests for control_flow.py passes.
+
+Each finding (F-071, F-087, F-100, F-107, F-111, F-116, F-118) corresponds
+to a control-flow canonicalization pass that DELETED / DEDUPED / DUPLICATED
+/ FOLDED code containing a non-deterministic call without a purity check.
+Two textual copies of a non-deterministic call denote independent draws, so
+those rewrites are unsound.
+
+For each finding we assert two things end-to-end through
+``ProofEngine.check_equivalent`` (CORE_PIPELINE + standardization + Z3
+residual):
+
+* the NEGATIVE distinguisher (the attack game pair) is REJECTED -- the two
+  games are genuinely distinguishable, so a sound engine must refuse to
+  certify them equivalent; and
+* a POSITIVE control whose corresponding deterministic twin still fires, so
+  the guard is principled (declines on non-determinism only, not always).
+
+These are deliberately small hand-built FrogLang fragments taken from
+``extras/docs/transforms/audit-2026-06/attacks/<PassName>/``.
+"""
+
+from __future__ import annotations
+
+from sympy import Symbol
+
+from proof_frog import frog_parser
+from proof_frog.proof_engine import ProofEngine
+
+
+def _engine_with(**namespace) -> ProofEngine:
+    engine = ProofEngine()
+    engine.variables["n"] = Symbol("n", positive=True, integer=True)
+    for name, root in namespace.items():
+        engine.proof_namespace[name] = root
+    return engine
+
+
+def _nondet_prim() -> object:
+    """Unannotated primitive: ``eval``/``f``/``F`` are non-deterministic."""
+    return frog_parser.parse_primitive_file("""
+        Primitive P(Int n) {
+            BitString<n> eval();
+            Bool f(Int x);
+            Int call(Int x);
+        }
+        """)
+
+
+def _det_prim() -> object:
+    """Primitive with deterministic methods (purity-guard positive control)."""
+    return frog_parser.parse_primitive_file("""
+        Primitive D(Int n) {
+            deterministic BitString<n> eval(BitString<n> x);
+            deterministic Bool f(Int x);
+            deterministic Int call(Int x);
+        }
+        """)
+
+
+# ---------------------------------------------------------------------------
+# F-071 UniqExclusionBranchElimination
+# ---------------------------------------------------------------------------
+
+
+def test_f071_uniq_exclusion_nondet_element_rejected() -> None:
+    """Real folds ``b == F.eval()`` to false using a <-uniq exclusion whose
+    element is a non-deterministic call. The second ``F.eval()`` is an
+    independent draw, so Real returns true with probability 2^-n while
+    Random never does -- engine must REJECT."""
+    real = frog_parser.parse_game("""
+        Game Real(P F, Int n) {
+            Bool Oracle() {
+                BitString<n> b <-uniq[{F.eval()}] BitString<n>;
+                if (b == F.eval()) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """)
+    random = frog_parser.parse_game("""
+        Game Random(P F, Int n) {
+            Bool Oracle() {
+                BitString<n> b <-uniq[{F.eval()}] BitString<n>;
+                return false;
+            }
+        }
+        """)
+    engine = _engine_with(P=_nondet_prim(), F=_nondet_prim())
+    assert not engine.check_equivalent(real, random).valid
+
+
+def test_f071_uniq_exclusion_deterministic_still_fires() -> None:
+    """Positive control: ``b <-uniq[{a}]`` with a plain sampled ``a`` lets
+    the pass fold ``a == b`` to false; the two games are equivalent."""
+    real = frog_parser.parse_game("""
+        Game Real(Int n) {
+            Bool Oracle() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <-uniq[{a}] BitString<n>;
+                if (a == b) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """)
+    random = frog_parser.parse_game("""
+        Game Random(Int n) {
+            Bool Oracle() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <-uniq[{a}] BitString<n>;
+                return false;
+            }
+        }
+        """)
+    engine = _engine_with()
+    assert engine.check_equivalent(real, random).valid
+
+
+# ---------------------------------------------------------------------------
+# F-087 RedundantConditionalReturn
+# ---------------------------------------------------------------------------
+
+
+def test_f087_redundant_conditional_return_nondet_guard_rejected() -> None:
+    """``if (F.f(x)) { return 1; } return 1;`` has the body match the
+    fall-through, but dropping the guard discards an evaluation of the
+    non-deterministic ``F.f(x)``. Real evaluates the call; Ideal never
+    does -- engine must REJECT."""
+    real = frog_parser.parse_game("""
+        Game Real(P F, Int n) {
+            Int Oracle(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                return 1;
+            }
+        }
+        """)
+    ideal = frog_parser.parse_game("""
+        Game Ideal(P F, Int n) {
+            Int Oracle(Int x) {
+                return 1;
+            }
+        }
+        """)
+    engine = _engine_with(P=_nondet_prim(), F=_nondet_prim())
+    assert not engine.check_equivalent(real, ideal).valid
+
+
+def test_f087_redundant_conditional_return_deterministic_still_fires() -> None:
+    """Positive control: a deterministic guard ``D.f(x)`` evaluated in the
+    dropped if has no observable effect, so the redundant guard folds."""
+    real = frog_parser.parse_game("""
+        Game Real(D F, Int n) {
+            Int Oracle(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                return 1;
+            }
+        }
+        """)
+    ideal = frog_parser.parse_game("""
+        Game Ideal(D F, Int n) {
+            Int Oracle(Int x) {
+                return 1;
+            }
+        }
+        """)
+    engine = _engine_with(D=_det_prim(), F=_det_prim())
+    assert engine.check_equivalent(real, ideal).valid
+
+
+# ---------------------------------------------------------------------------
+# F-100 DeadGuardedAssignmentElimination
+# ---------------------------------------------------------------------------
+
+
+def test_f100_dead_guarded_assignment_nondet_guard_rejected() -> None:
+    """Left's inner guard ``F.f(x)`` is non-deterministic; the path fact
+    from the first evaluation is wrongly treated as entailing the second,
+    independent one, so ``v = c`` would be killed to ``v = false``. Right is
+    that post-kill image. The games are distinguishable -- engine REJECTS."""
+    left = frog_parser.parse_game("""
+        Game Left(P F, Int n) {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                if (F.f(x)) {
+                    v = c;
+                }
+                if (v) {
+                    if (F.f(x)) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """)
+    right = frog_parser.parse_game("""
+        Game Right(P F, Int n) {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                if (F.f(x)) {
+                    v = false;
+                }
+                if (v) {
+                    if (F.f(x)) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """)
+    engine = _engine_with(P=_nondet_prim(), F=_nondet_prim())
+    assert not engine.check_equivalent(left, right).valid
+
+
+# ---------------------------------------------------------------------------
+# F-107 RemoveUnreachable (Case B dedup)
+# ---------------------------------------------------------------------------
+
+
+def test_f107_remove_unreachable_nondet_condition_rejected() -> None:
+    """Two structurally-identical return-conditions ``F.f(x)`` each guard an
+    independent draw; deduping the second deletes a live evaluation. Left has
+    both ifs; Right deletes the second -- engine must REJECT."""
+    left = frog_parser.parse_game("""
+        Game Left(P F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                if (F.f(x)) {
+                    return 2;
+                }
+                return 3;
+            }
+        }
+        """)
+    right = frog_parser.parse_game("""
+        Game Right(P F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                return 3;
+            }
+        }
+        """)
+    engine = _engine_with(P=_nondet_prim(), F=_nondet_prim())
+    assert not engine.check_equivalent(left, right).valid
+
+
+# ---------------------------------------------------------------------------
+# F-111 AbsorbRedundantEarlyReturn
+# ---------------------------------------------------------------------------
+
+
+def test_f111_absorb_early_return_nondet_guard_rejected() -> None:
+    """Left's early ``if (F.f(x)) { return 7; }`` guard is non-deterministic;
+    absorbing it duplicates ``!F.f(x)`` into the intervening guard, creating
+    independent re-evaluations. Right is the absorbed image -- engine
+    REJECTS."""
+    left = frog_parser.parse_game("""
+        Game Left(P F, Int n) {
+            Int O(Int x, Bool q) {
+                if (F.f(x)) {
+                    return 7;
+                }
+                if (q) {
+                    return 5;
+                }
+                return 7;
+            }
+        }
+        """)
+    right = frog_parser.parse_game("""
+        Game Right(P F, Int n) {
+            Int O(Int x, Bool q) {
+                if (!F.f(x) && q) {
+                    return 5;
+                }
+                return 7;
+            }
+        }
+        """)
+    engine = _engine_with(P=_nondet_prim(), F=_nondet_prim())
+    assert not engine.check_equivalent(left, right).valid
+
+
+# ---------------------------------------------------------------------------
+# F-116 IfFalseReturnToConjunction
+# ---------------------------------------------------------------------------
+
+
+def test_f116_if_false_return_nondet_trailing_rejected() -> None:
+    """Left skips the non-deterministic ``F.f(x)`` when ``x == 0`` (returns
+    false immediately); Right (the conjunction image ``F.f(x) && x != 0``)
+    always evaluates it. Distinguishable -- engine REJECTS."""
+    left = frog_parser.parse_game("""
+        Game Left(P F, Int n) {
+            Bool Test(Int x) {
+                if (x == 0) {
+                    return false;
+                }
+                return F.f(x);
+            }
+        }
+        """)
+    right = frog_parser.parse_game("""
+        Game Right(P F, Int n) {
+            Bool Test(Int x) {
+                return F.f(x) && x != 0;
+            }
+        }
+        """)
+    engine = _engine_with(P=_nondet_prim(), F=_nondet_prim())
+    assert not engine.check_equivalent(left, right).valid
+
+
+def test_f116_if_false_return_deterministic_still_fires() -> None:
+    """Positive control: with a deterministic ``D.f(x)`` the conjunction
+    rewrite is exact, so the two games are equivalent."""
+    left = frog_parser.parse_game("""
+        Game Left(D F, Int n) {
+            Bool Test(Int x) {
+                if (x == 0) {
+                    return false;
+                }
+                return F.f(x);
+            }
+        }
+        """)
+    right = frog_parser.parse_game("""
+        Game Right(D F, Int n) {
+            Bool Test(Int x) {
+                return F.f(x) && x != 0;
+            }
+        }
+        """)
+    engine = _engine_with(D=_det_prim(), F=_det_prim())
+    assert engine.check_equivalent(left, right).valid
+
+
+# ---------------------------------------------------------------------------
+# F-118 FoldEquivalentReturnBranch
+# ---------------------------------------------------------------------------
+
+
+def test_f118_fold_equivalent_return_nondet_field_rhs_rejected() -> None:
+    """Both sides initialize a field from a non-deterministic call. Collapse
+    keeps an ``if (a == k) { return F.eval(); } return a;`` case-split that
+    is NOT equivalent to the branchless ``return a;`` once the engine refuses
+    to expand the field to a textual copy of the non-deterministic call --
+    engine must REJECT."""
+    collapse = frog_parser.parse_game("""
+        Game Collapse(P F, Int n) {
+            BitString<n> a;
+            Void Initialize() {
+                a = F.eval();
+            }
+            BitString<n> O(BitString<n> k) {
+                if (a == k) {
+                    return F.eval();
+                }
+                return a;
+            }
+        }
+        """)
+    branchless = frog_parser.parse_game("""
+        Game Branchless(P F, Int n) {
+            BitString<n> a;
+            Void Initialize() {
+                a = F.eval();
+            }
+            BitString<n> O(BitString<n> k) {
+                return a;
+            }
+        }
+        """)
+    engine = _engine_with(P=_nondet_prim(), F=_nondet_prim())
+    assert not engine.check_equivalent(collapse, branchless).valid

--- a/tests/integration/test_rc3_map_iteration.py
+++ b/tests/integration/test_rc3_map_iteration.py
@@ -1,0 +1,129 @@
+"""RC3 soundness regression: LazyMapScan non-deterministic-key guard.
+
+End-to-end engine tests for the F-142 fix in
+``proof_frog.transforms.map_iteration.LazyMapScan``.
+
+The literal-equality branch of the scan rewrite
+
+    for ([K, V] e in M.entries) { if (e[0] == key) { return Body(e); } }
+        -->  if (key in M) { return Body[e[0]:=key, e[1]:=M[key]]; }
+
+re-evaluates ``key`` at independent fresh sites (the membership test, the
+``M[key]`` lookup, and every substituted ``e[0]``), whereas the input loop
+evaluates it once per iteration. If ``key`` contains a non-deterministic
+call those sites draw independently and the output distribution differs
+(verdict §8, Attacks 1 and 3). The fix declines on a non-deterministic key.
+
+These tests assert:
+  * NEGATIVE: a game whose scan key is an unannotated primitive call
+    ``NN.draw()`` is NOT proved equivalent to the direct-lookup form.
+  * POSITIVE (control, verdict §6): a deterministic key (here a plain
+    parameter) must still canonicalize to the direct-lookup form.
+"""
+
+from __future__ import annotations
+
+from sympy import Symbol
+
+from proof_frog import frog_parser
+from proof_frog.proof_engine import ProofEngine
+
+
+def _engine() -> ProofEngine:
+    engine = ProofEngine()
+    engine.variables["n"] = Symbol("n", positive=True, integer=True)
+    return engine
+
+
+_ND_PRIMITIVE = """
+Primitive ND() {
+    BitString<8> draw();
+}
+"""
+
+
+def test_nondeterministic_key_scan_not_equivalent_to_lookup() -> None:
+    """Attack 1 (verdict §8): a non-deterministic scan key must NOT be
+    accepted as equivalent to the direct membership-test + lookup form.
+
+    Input draws ``NN.draw()`` once per iteration; the candidate output draws
+    it independently at the membership test and the lookup, so the return
+    distribution differs (``p`` vs ``p^2`` plus undefined lookups)."""
+    prim = frog_parser.parse_primitive_file(_ND_PRIMITIVE)
+    real = frog_parser.parse_game("""
+        Game Real(ND NN) {
+            Map<BitString<8>, BitString<16>> M;
+            Void Store(BitString<8> k, BitString<16> v) {
+                M[k] = v;
+            }
+            BitString<16> Lookup() {
+                for ([BitString<8>, BitString<16>] e in M.entries) {
+                    if (e[0] == NN.draw()) {
+                        return e[1];
+                    }
+                }
+                return 0b0000000000000000;
+            }
+        }
+        """)
+    direct = frog_parser.parse_game("""
+        Game Direct(ND NN) {
+            Map<BitString<8>, BitString<16>> M;
+            Void Store(BitString<8> k, BitString<16> v) {
+                M[k] = v;
+            }
+            BitString<16> Lookup() {
+                if (NN.draw() in M) {
+                    return M[NN.draw()];
+                }
+                return 0b0000000000000000;
+            }
+        }
+        """)
+    engine = _engine()
+    engine.proof_namespace["ND"] = prim
+    engine.proof_namespace["NN"] = prim
+    result = engine.check_equivalent(real, direct)
+    assert not result.valid, (
+        "LazyMapScan accepted a non-deterministic scan key as equivalent to "
+        "direct lookup -- the F-142 soundness guard regressed."
+    )
+
+
+def test_deterministic_key_scan_still_equivalent_to_lookup() -> None:
+    """Positive control (verdict §6): a deterministic scan key (a plain
+    parameter) must still canonicalize to the direct-lookup form, so the
+    guard did not over-fire."""
+    pre = frog_parser.parse_game("""
+        Game Pre() {
+            Map<BitString<8>, BitString<16>> M;
+            Void Store(BitString<8> k, BitString<16> v) {
+                M[k] = v;
+            }
+            BitString<16> Lookup(BitString<8> arg) {
+                for ([BitString<8>, BitString<16>] e in M.entries) {
+                    if (e[0] == arg) {
+                        return e[1];
+                    }
+                }
+                return 0b0000000000000000;
+            }
+        }
+        """)
+    post = frog_parser.parse_game("""
+        Game Post() {
+            Map<BitString<8>, BitString<16>> M;
+            Void Store(BitString<8> k, BitString<16> v) {
+                M[k] = v;
+            }
+            BitString<16> Lookup(BitString<8> arg) {
+                if (arg in M) {
+                    return M[arg];
+                }
+                return 0b0000000000000000;
+            }
+        }
+        """)
+    engine = _engine()
+    result = engine.check_equivalent(pre, post)
+    assert result.valid, result.failure_detail

--- a/tests/integration/test_rc3_random_functions.py
+++ b/tests/integration/test_rc3_random_functions.py
@@ -1,0 +1,157 @@
+"""RC3 (determinism / purity) soundness tests for random-function passes.
+
+These end-to-end tests exercise the ``ChallengeExclusionRFToUniform`` pass
+through the full ``ProofEngine.check_equivalent`` pipeline.  They guard the
+soundness condition restored by the RC3 determinism guard: the
+``H(cf) -> cf <- R`` rewrite is valid only when ``H`` is a genuinely SAMPLED
+random function (re-samplable / ROM) and every RF query is visible to the
+call-site scan.
+
+Each test pairs a *negative* control (an unsound attack shape the engine must
+REJECT) with the corresponding *positive* control (the genuine sampled-RF
+shape, which the pass must still fire on so the games are judged equivalent).
+
+The attack shapes mirror judge vectors (a) and (c) of the
+ChallengeExclusionRFToUniform verdict.  Vector (d) (a second init RF call
+embedded in a larger expression) is covered at pass level in
+``tests/unit/transforms/`` because the engine already rejects that end-to-end
+shape for unrelated reasons, so it does not yield a meaningful
+attack-vs-control engine pair.
+
+New tests are small hand-built FrogLang games (not full proofs) so a failure
+points directly at one engine path.
+"""
+
+from __future__ import annotations
+
+from sympy import Symbol
+
+from proof_frog import frog_parser
+from proof_frog.proof_engine import ProofEngine
+
+
+def _engine() -> ProofEngine:
+    """ProofEngine with the bit-string length symbol ``n`` registered."""
+    engine = ProofEngine()
+    engine.variables["n"] = Symbol("n", positive=True, integer=True)
+    return engine
+
+
+# --------------------------------------------------------------------------
+# Vector (a): sampledness of H.
+#
+# ``field = H(cf)`` may be rewritten to ``field <- R`` only when ``H`` is a
+# SAMPLED random function.  When ``H`` is a known/standard-model function
+# (bound via ``H = F;``), ``H(cf)`` is a fixed value the adversary can
+# recompute, so the rewrite is unsound.  ``field`` is made observable via a
+# ``Reveal`` oracle so the difference is detectable.
+# --------------------------------------------------------------------------
+
+
+def _challenge_game(init_field: str, h_binding: str) -> str:
+    return f"""
+    Game G(Int n, Function<BitString<n>, BitString<n>> F) {{
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<n> Initialize() {{
+            {h_binding}
+            cf <- BitString<n>;
+            {init_field}
+            return cf;
+        }}
+        BitString<n> Reveal() {{
+            return field;
+        }}
+        BitString<n>? Query(BitString<n> param) {{
+            if (param == cf) {{
+                return None;
+            }}
+            return H(param);
+        }}
+    }}
+    """
+
+
+_SAMPLED = "H <- Function<BitString<n>, BitString<n>>;"
+_KNOWN = "H = F;"
+_REAL_FIELD = "field = H(cf);"
+_RANDOM_FIELD = "field <- BitString<n>;"
+
+
+def test_challenge_exclusion_known_function_attack_rejected() -> None:
+    """Vector (a): a KNOWN function ``H = F`` must NOT be simplified."""
+    engine = _engine()
+    real = frog_parser.parse_game(_challenge_game(_REAL_FIELD, _KNOWN))
+    random = frog_parser.parse_game(_challenge_game(_RANDOM_FIELD, _KNOWN))
+    assert not engine.check_equivalent(real, random).valid
+
+
+def test_challenge_exclusion_sampled_function_control_fires() -> None:
+    """Positive control (a): a genuinely SAMPLED RF still canonicalizes."""
+    engine = _engine()
+    real = frog_parser.parse_game(_challenge_game(_REAL_FIELD, _SAMPLED))
+    random = frog_parser.parse_game(_challenge_game(_RANDOM_FIELD, _SAMPLED))
+    result = engine.check_equivalent(real, random)
+    assert result.valid, result.failure_detail
+
+
+# --------------------------------------------------------------------------
+# Vector (c): RF reachable through a local alias.
+#
+# An oracle binds ``Galias = H`` and calls ``Galias(param)``.  This aliased
+# query is invisible to the by-name call-site scan, so the exclusion guard is
+# absent and the rewrite would be unsound.  The positive control is the same
+# game with the RF called directly (no alias), which the pass simplifies.
+# --------------------------------------------------------------------------
+
+
+def _alias_game(init_field: str, *, aliased: bool) -> str:
+    if aliased:
+        query_body = """
+            Function<BitString<n>, BitString<n>> Galias = H;
+            return Galias(param);
+        """
+    else:
+        query_body = """
+            if (param == cf) {
+                return None;
+            }
+            return H(param);
+        """
+    return f"""
+    Game G(Int n) {{
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<n> Initialize() {{
+            H <- Function<BitString<n>, BitString<n>>;
+            cf <- BitString<n>;
+            {init_field}
+            return cf;
+        }}
+        BitString<n> Reveal() {{
+            return field;
+        }}
+        BitString<n>? Query(BitString<n> param) {{
+            {query_body}
+        }}
+    }}
+    """
+
+
+def test_challenge_exclusion_aliased_rf_attack_rejected() -> None:
+    """Vector (c): an RF query through a local alias must block the rewrite."""
+    engine = _engine()
+    real = frog_parser.parse_game(_alias_game(_REAL_FIELD, aliased=True))
+    random = frog_parser.parse_game(_alias_game(_RANDOM_FIELD, aliased=True))
+    assert not engine.check_equivalent(real, random).valid
+
+
+def test_challenge_exclusion_direct_rf_control_fires() -> None:
+    """Positive control (c): the same game with a direct RF call simplifies."""
+    engine = _engine()
+    real = frog_parser.parse_game(_alias_game(_REAL_FIELD, aliased=False))
+    random = frog_parser.parse_game(_alias_game(_RANDOM_FIELD, aliased=False))
+    result = engine.check_equivalent(real, random)
+    assert result.valid, result.failure_detail

--- a/tests/unit/transforms/test_absorb_redundant_early_return.py
+++ b/tests/unit/transforms/test_absorb_redundant_early_return.py
@@ -266,3 +266,79 @@ def test_negation_normalizes_inequality_to_equality() -> None:
     expected_parsed = frog_parser.parse_method(expected)
     result = AbsorbRedundantEarlyReturnTransformer().transform(parsed)
     assert result == expected_parsed
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism guard (F-111): absorbing the early-return guard duplicates
+# its negation into the intervening guards; a non-deterministic guard would
+# be re-evaluated independently, so absorption must be declined.
+# ---------------------------------------------------------------------------
+
+from proof_frog.transforms.control_flow import AbsorbRedundantEarlyReturn
+from proof_frog.transforms._base import PipelineContext as _PipelineContext
+from proof_frog.visitors import NameTypeMap as _NameTypeMap
+
+
+def _aer_ctx(**namespace):
+    return _PipelineContext(
+        variables={},
+        proof_let_types=_NameTypeMap(),
+        proof_namespace=dict(namespace),
+        subsets_pairs=[],
+    )
+
+
+def _aer_nondet_prim():
+    return frog_parser.parse_primitive_file("Primitive P(Int n) { Bool f(Int x); }")
+
+
+def _aer_det_prim():
+    return frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic Bool f(Int x); }"
+    )
+
+
+def test_aer_declines_on_nondeterministic_guard() -> None:
+    """The early-return guard ``F.f(x)`` is non-deterministic; absorbing it
+    would duplicate ``!F.f(x)`` into the intervening guard as an independent
+    re-evaluation. The pass must decline."""
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x, Bool q) {
+                if (F.f(x)) {
+                    return 7;
+                }
+                if (q) {
+                    return 5;
+                }
+                return 7;
+            }
+        }
+        """)
+    ctx = _aer_ctx(P=_aer_nondet_prim(), F=_aer_nondet_prim())
+    result = AbsorbRedundantEarlyReturn().apply(game, ctx)
+    assert result == game  # declined
+    assert any(
+        nm.transform_name == "Absorb Redundant Early Return" for nm in ctx.near_misses
+    )
+
+
+def test_aer_fires_on_deterministic_control() -> None:
+    """Control: a deterministic early-return guard ``D.f(x)`` is absorbed into
+    the intervening guard as usual."""
+    game = frog_parser.parse_game("""
+        Game G(D F, Int n) {
+            Int O(Int x, Bool q) {
+                if (F.f(x)) {
+                    return 7;
+                }
+                if (q) {
+                    return 5;
+                }
+                return 7;
+            }
+        }
+        """)
+    ctx = _aer_ctx(D=_aer_det_prim(), F=_aer_det_prim())
+    result = AbsorbRedundantEarlyReturn().apply(game, ctx)
+    assert result != game  # the early-return guard was absorbed

--- a/tests/unit/transforms/test_challenge_exclusion_rf.py
+++ b/tests/unit/transforms/test_challenge_exclusion_rf.py
@@ -310,3 +310,116 @@ def test_rf_call_inside_guard_block_not_replaced() -> None:
     assert (
         result == game
     ), "Init RF call should not be replaced when guard block contains RF call"
+
+
+# --------------------------------------------------------------------------
+# RC3 determinism / purity guards (verdict vectors a, c, d).
+# --------------------------------------------------------------------------
+
+
+def _fired(source: str) -> bool:
+    """True if the pass rewrote the Initialize RF call (single pass)."""
+    game = frog_parser.parse_game(source)
+    return ChallengeExclusionRFToUniformTransformer().transform(game) != game
+
+
+def test_known_function_not_simplified() -> None:
+    """Vector (a): a function field bound by ``H = F`` (a known / standard-
+    model function) is NOT a sampled random function, so ``H(cf)`` is a fixed
+    value and must NOT be rewritten to a uniform sample."""
+    source = """
+    Game G(Int n, Function<BitString<n>, BitString<n>> F) {
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<n> Initialize() {
+            H = F;
+            cf <- BitString<n>;
+            field = H(cf);
+            return cf;
+        }
+        BitString<n>? Query(BitString<n> param) {
+            if (param == cf) {
+                return None;
+            }
+            return H(param);
+        }
+    }
+    """
+    assert not _fired(source)
+
+
+def test_sampled_function_positive_control_fires() -> None:
+    """Positive control for vector (a): an otherwise identical game whose
+    function is genuinely SAMPLED (``H <- Function<...>``) still fires."""
+    source = """
+    Game G(Int n) {
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<n> Initialize() {
+            H <- Function<BitString<n>, BitString<n>>;
+            cf <- BitString<n>;
+            field = H(cf);
+            return cf;
+        }
+        BitString<n>? Query(BitString<n> param) {
+            if (param == cf) {
+                return None;
+            }
+            return H(param);
+        }
+    }
+    """
+    assert _fired(source)
+
+
+def test_aliased_rf_call_not_simplified() -> None:
+    """Vector (c): an RF reachable only through a local alias ``G = H`` is
+    invisible to the by-name call-site scan, so the rewrite must decline."""
+    source = """
+    Game G(Int n) {
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<n> Initialize() {
+            H <- Function<BitString<n>, BitString<n>>;
+            cf <- BitString<n>;
+            field = H(cf);
+            return cf;
+        }
+        BitString<n> Query(BitString<n> param) {
+            Function<BitString<n>, BitString<n>> Galias = H;
+            return Galias(param);
+        }
+    }
+    """
+    assert not _fired(source)
+
+
+def test_embedded_second_init_call_not_simplified() -> None:
+    """Vector (d): a second RF evaluation embedded in a larger Initialize
+    expression (``leak = H(cf) || cf;``) would survive the rewrite and stay
+    correlated with the sampled field, so the pass must decline."""
+    source = """
+    Game G(Int n) {
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<2 * n> leak;
+        BitString<n> Initialize() {
+            H <- Function<BitString<n>, BitString<n>>;
+            cf <- BitString<n>;
+            field = H(cf);
+            leak = H(cf) || cf;
+            return cf;
+        }
+        BitString<n>? Query(BitString<n> param) {
+            if (param == cf) {
+                return None;
+            }
+            return H(param);
+        }
+    }
+    """
+    assert not _fired(source)

--- a/tests/unit/transforms/test_dead_guarded_assignment_elimination.py
+++ b/tests/unit/transforms/test_dead_guarded_assignment_elimination.py
@@ -32,8 +32,7 @@ def _apply(source: str):
 def test_local_guarded_assignment_killed() -> None:
     """Positive control: a method-LOCAL boolean read solely by the guard is a
     dead store -- the pass fires (value replaced by false)."""
-    game, result = _apply(
-        """
+    game, result = _apply("""
         Game G() {
             Int O(Int x, Bool c) {
                 Bool v = false;
@@ -49,16 +48,14 @@ def test_local_guarded_assignment_killed() -> None:
                 return 0;
             }
         }
-        """
-    )
+        """)
     assert result != game, "local dead guarded assignment should be killed"
 
 
 def test_field_read_in_sibling_oracle_not_killed() -> None:
     """F-099 A2b: the field is also read by a separate Leak oracle, so its
     value is observable -- must DECLINE."""
-    game, result = _apply(
-        """
+    game, result = _apply("""
         Game G() {
             Bool v;
             Void Initialize() { v = false; }
@@ -72,8 +69,7 @@ def test_field_read_in_sibling_oracle_not_killed() -> None:
             }
             Bool Leak() { return v; }
         }
-        """
-    )
+        """)
     assert result == game, "field read by a sibling oracle must not be killed"
 
 
@@ -81,8 +77,7 @@ def test_field_conditionally_assigned_persists_not_killed() -> None:
     """F-099 A2: the field is only conditionally assigned (if (x == 1)), so on
     other calls the guard reads the persisted previous-call value -- must
     DECLINE even though the field is read only by the guard."""
-    game, result = _apply(
-        """
+    game, result = _apply("""
         Game G() {
             Bool v;
             Void Initialize() { v = false; }
@@ -95,6 +90,86 @@ def test_field_conditionally_assigned_persists_not_killed() -> None:
                 return 0;
             }
         }
-        """
-    )
+        """)
     assert result == game, "conditionally-assigned field must not be killed"
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism guard (F-100): a non-deterministic dominating guard must
+# block the dead-store kill (the path fact from one evaluation does not
+# entail the guard's independent re-evaluation).
+# ---------------------------------------------------------------------------
+
+
+def _ctx_with(**namespace) -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace=dict(namespace),
+        subsets_pairs=[],
+    )
+
+
+def _nondet_prim():
+    return frog_parser.parse_primitive_file("Primitive P(Int n) { Bool f(Int x); }")
+
+
+def _det_prim():
+    return frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic Bool f(Int x); }"
+    )
+
+
+def test_nondeterministic_guard_blocks_kill() -> None:
+    """The inner guard ``F.f(x)`` is non-deterministic; the path fact from the
+    first evaluation does not entail the second, independent one, so the kill
+    is declined."""
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                if (F.f(x)) {
+                    v = c;
+                }
+                if (v) {
+                    if (F.f(x)) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """)
+    ctx = _ctx_with(P=_nondet_prim(), F=_nondet_prim())
+    result = DeadGuardedAssignmentElimination().apply(game, ctx)
+    assert result == game  # kill declined
+    assert any(
+        nm.transform_name == "Dead Guarded Assignment Elimination"
+        for nm in ctx.near_misses
+    )
+
+
+def test_deterministic_guard_still_kills() -> None:
+    """Control: with a deterministic guard ``D.f(x)`` the path fact entails
+    the guard's re-evaluation, so the dead store is killed."""
+    game = frog_parser.parse_game("""
+        Game G(D F, Int n) {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                if (F.f(x)) {
+                    v = c;
+                }
+                if (v) {
+                    if (F.f(x)) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """)
+    ctx = _ctx_with(D=_det_prim(), F=_det_prim())
+    result = DeadGuardedAssignmentElimination().apply(game, ctx)
+    assert result != game  # the dead store was killed

--- a/tests/unit/transforms/test_fold_equivalent_return_branch.py
+++ b/tests/unit/transforms/test_fold_equivalent_return_branch.py
@@ -32,8 +32,7 @@ def _apply(source: str) -> tuple[object, object]:
 def test_element_mutated_container_fields_not_folded() -> None:
     """Two container fields that are element-written with *different* values
     must not be folded into a single return branch."""
-    game, result = _apply(
-        """
+    game, result = _apply("""
         Game Containers(Dict D) {
             Map<Int, D.V> F1;
             Map<Int, D.V> F2;
@@ -52,16 +51,14 @@ def test_element_mutated_container_fields_not_folded() -> None:
                 return F2;
             }
         }
-        """
-    )
+        """)
     assert result == game, f"branch wrongly folded:\n{result}"
 
 
 def test_positive_fold_still_fires() -> None:
     """Control: the intended sound use -- ``if (a == b) return a; return b;``
     -- must still fold."""
-    game, result = _apply(
-        """
+    game, result = _apply("""
         Game Positive() {
             Int Oracle(Int a, Int b) {
                 if (a == b) {
@@ -70,6 +67,77 @@ def test_positive_fold_still_fires() -> None:
                 return b;
             }
         }
-        """
-    )
+        """)
     assert result != game, "intended fold did not fire"
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism guard (F-118): a field initialized from a non-deterministic
+# call must not be expanded to a textual copy of that call (which would let
+# the fold equate two independent draws).
+# ---------------------------------------------------------------------------
+
+
+def _ctx_with(**namespace) -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace=dict(namespace),
+        subsets_pairs=[],
+    )
+
+
+def test_nondeterministic_init_field_rhs_not_folded() -> None:
+    """``a = F.eval()`` in Initialize is a non-deterministic field write; the
+    pass must not expand ``a`` to ``F.eval()`` and fold the case-split (the
+    if-body re-evaluates ``F.eval()`` independently)."""
+    prim = frog_parser.parse_primitive_file(
+        "Primitive P(Int n) { BitString<n> eval(); }"
+    )
+    game = frog_parser.parse_game("""
+        Game Collapse(P F, Int n) {
+            BitString<n> a;
+            Void Initialize() {
+                a = F.eval();
+            }
+            BitString<n> O(BitString<n> k) {
+                if (a == k) {
+                    return F.eval();
+                }
+                return a;
+            }
+        }
+        """)
+    ctx = _ctx_with(P=prim, F=prim)
+    result = FoldEquivalentReturnBranch().apply(game, ctx)
+    assert result == game  # branch not folded
+    assert any(
+        nm.transform_name == "Fold Equivalent Return Branch" for nm in ctx.near_misses
+    )
+
+
+def test_deterministic_init_field_rhs_enables_fold() -> None:
+    """Control: a field set from a deterministic call CAN be expanded so the
+    case-split ``if (a == k) return D.eval(k); return a;`` folds under the
+    Z3 model (``a == k`` makes ``D.eval(k)`` equal to ``a`` when ``a`` is the
+    same deterministic call -- here we use a directly self-consistent case)."""
+    prim = frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic BitString<n> eval(BitString<n> x); }"
+    )
+    game = frog_parser.parse_game("""
+        Game Collapse(D F, Int n) {
+            BitString<n> a;
+            Void Initialize() {
+                a = F.eval(a);
+            }
+            BitString<n> O(BitString<n> k) {
+                if (a == k) {
+                    return a;
+                }
+                return a;
+            }
+        }
+        """)
+    ctx = _ctx_with(D=prim, F=prim)
+    result = FoldEquivalentReturnBranch().apply(game, ctx)
+    assert result != game  # the trivially-equal branch folded

--- a/tests/unit/transforms/test_if_false_return_to_conjunction.py
+++ b/tests/unit/transforms/test_if_false_return_to_conjunction.py
@@ -20,9 +20,7 @@ def _ctx(namespace: frog_ast.Namespace | None = None) -> PipelineContext:
     )
 
 
-def _apply(
-    source: str, namespace: frog_ast.Namespace | None = None
-) -> frog_ast.Game:
+def _apply(source: str, namespace: frog_ast.Namespace | None = None) -> frog_ast.Game:
     game = frog_parser.parse_game(source)
     return IfFalseReturnToConjunction().apply(game, _ctx(namespace))
 
@@ -152,3 +150,81 @@ def test_does_not_fire_when_if_has_else_block() -> None:
     }
     """
     assert _apply(source) == frog_parser.parse_game(source)
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism guard (F-116): the guard P and the trailing return Q are
+# evaluated on the P-true path that the original short-circuited; a
+# non-deterministic call in either must block the rewrite.
+# ---------------------------------------------------------------------------
+
+
+def _nondet_namespace() -> frog_ast.Namespace:
+    prim = frog_parser.parse_primitive_file("Primitive P(Int n) { Bool f(Int x); }")
+    return {"P": prim, "F": prim}
+
+
+def _det_namespace() -> frog_ast.Namespace:
+    prim = frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic Bool f(Int x); }"
+    )
+    return {"D": prim, "F": prim}
+
+
+def test_does_not_fire_with_nondeterministic_trailing_return() -> None:
+    """The trailing ``return F.f(x)`` is non-deterministic; conjoining it
+    would evaluate the call on the ``x == 0`` (P-true) path that the
+    original skipped, so the pass must decline."""
+    source = """
+    Game G(P F, Int n) {
+        Bool Test(Int x) {
+            if (x == 0) {
+                return false;
+            }
+            return F.f(x);
+        }
+    }
+    """
+    ns = _nondet_namespace()
+    game = frog_parser.parse_game(source)
+    ctx = _ctx(ns)
+    result = IfFalseReturnToConjunction().apply(game, ctx)
+    assert result == game  # declined
+    assert any(
+        nm.transform_name == "If False Return To Conjunction" for nm in ctx.near_misses
+    )
+
+
+def test_does_not_fire_with_nondeterministic_guard() -> None:
+    """The guard ``F.f(x)`` is re-evaluated in ``Q && !F.f(x)``; a
+    non-deterministic guard blocks the rewrite."""
+    source = """
+    Game G(P F, Int n) {
+        Bool Test(Int x, Bool q) {
+            if (F.f(x)) {
+                return false;
+            }
+            return q;
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    assert IfFalseReturnToConjunction().apply(game, _ctx(_nondet_namespace())) == game
+
+
+def test_fires_with_deterministic_trailing_return() -> None:
+    """Control: a deterministic ``D.f(x)`` trailing return is conjoined as
+    usual."""
+    source = """
+    Game G(D F, Int n) {
+        Bool Test(Int x) {
+            if (x == 0) {
+                return false;
+            }
+            return F.f(x);
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = IfFalseReturnToConjunction().apply(game, _ctx(_det_namespace()))
+    assert result != game  # fired

--- a/tests/unit/transforms/test_lazy_map_scan.py
+++ b/tests/unit/transforms/test_lazy_map_scan.py
@@ -67,14 +67,29 @@ def _apply_with_ctx(
     game = frog_parser.parse_game(game_src)
     ctx = _ctx()
     if primitive_src:
-        prim = frog_parser.parse_string(
-            primitive_src, frog_ast.FileType.PRIMITIVE
-        )
+        prim = frog_parser.parse_string(primitive_src, frog_ast.FileType.PRIMITIVE)
         ctx.proof_namespace[prim.name] = prim
         # Also register under the conventional game-parameter alias "TT" used
         # in these unit tests (the real pipeline populates proof_namespace from
         # the proof's let: block).
         ctx.proof_namespace["TT"] = prim
+    result = LazyMapScan().apply(game, ctx)
+    return result, ctx
+
+
+def _apply_with_ctx_named(
+    game_src: str,
+    primitive_src: str,
+    prim_alias: str,
+    instance_alias: str,
+) -> tuple[frog_ast.Game, PipelineContext]:
+    """Apply LazyMapScan with a Primitive installed under both its declared
+    name and a chosen game-parameter instance alias in proof_namespace."""
+    game = frog_parser.parse_game(game_src)
+    ctx = _ctx()
+    prim = frog_parser.parse_string(primitive_src, frog_ast.FileType.PRIMITIVE)
+    ctx.proof_namespace[prim_alias] = prim
+    ctx.proof_namespace[instance_alias] = prim
     result = LazyMapScan().apply(game, ctx)
     return result, ctx
 
@@ -234,8 +249,7 @@ def test_two_maps_only_one_iterated() -> None:
 
 
 def test_body_has_multiple_statements_fails() -> None:
-    _apply_and_expect_unchanged(
-        """
+    _apply_and_expect_unchanged("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             BitString<16> Oracle(BitString<8> arg) {
@@ -248,13 +262,11 @@ def test_body_has_multiple_statements_fails() -> None:
                 return 0b0000000000000000;
             }
         }
-        """
-    )
+        """)
 
 
 def test_if_has_else_fails() -> None:
-    _apply_and_expect_unchanged(
-        """
+    _apply_and_expect_unchanged("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             BitString<16> Oracle(BitString<8> arg) {
@@ -268,13 +280,11 @@ def test_if_has_else_fails() -> None:
                 return 0b0000000000000000;
             }
         }
-        """
-    )
+        """)
 
 
 def test_non_equality_predicate_fails() -> None:
-    _apply_and_expect_unchanged(
-        """
+    _apply_and_expect_unchanged("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             Set<BitString<8>> S;
@@ -287,13 +297,11 @@ def test_non_equality_predicate_fails() -> None:
                 return 0b0000000000000000;
             }
         }
-        """
-    )
+        """)
 
 
 def test_key_references_loop_var_fails() -> None:
-    _apply_and_expect_unchanged(
-        """
+    _apply_and_expect_unchanged("""
         Game G() {
             Map<BitString<8>, BitString<8>> M;
             BitString<8> Oracle() {
@@ -305,13 +313,11 @@ def test_key_references_loop_var_fails() -> None:
                 return 0b00000000;
             }
         }
-        """
-    )
+        """)
 
 
 def test_bare_loop_var_in_body_fails() -> None:
-    _apply_and_expect_unchanged(
-        """
+    _apply_and_expect_unchanged("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             [BitString<8>, BitString<16>] Oracle(BitString<8> arg) {
@@ -323,13 +329,11 @@ def test_bare_loop_var_in_body_fails() -> None:
                 return [0b00000000, 0b0000000000000000];
             }
         }
-        """
-    )
+        """)
 
 
 def test_iteration_over_keys_not_entries_fails() -> None:
-    _apply_and_expect_unchanged(
-        """
+    _apply_and_expect_unchanged("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             Bool Oracle(BitString<8> arg) {
@@ -341,13 +345,11 @@ def test_iteration_over_keys_not_entries_fails() -> None:
                 return false;
             }
         }
-        """
-    )
+        """)
 
 
 def test_iteration_over_non_map_field_fails() -> None:
-    _apply_and_expect_unchanged(
-        """
+    _apply_and_expect_unchanged("""
         Game G() {
             Set<BitString<8>> S;
             Bool Oracle(BitString<8> arg) {
@@ -359,8 +361,82 @@ def test_iteration_over_non_map_field_fails() -> None:
                 return false;
             }
         }
-        """
+        """)
+
+
+_NONDET_KEY_PRIMITIVE = """
+Primitive ND() {
+    BitString<8> draw();
+}
+"""
+
+
+_DETERMINISTIC_KEY_PRIMITIVE = """
+Primitive PF() {
+    deterministic BitString<8> eval(BitString<8> x);
+}
+"""
+
+
+def test_literal_equality_declines_on_nondeterministic_key() -> None:
+    """Soundness guard (verdict F-142, §8): a scan whose key is a
+    non-deterministic call (here an unannotated primitive method) must NOT
+    be rewritten, because the output re-evaluates the key at independent
+    fresh sites. Mirrors the injective-call branch's determinism gate."""
+    game_src = """
+        Game G(ND NN) {
+            Map<BitString<8>, BitString<16>> M;
+            BitString<16> Oracle() {
+                for ([BitString<8>, BitString<16>] e in M.entries) {
+                    if (e[0] == NN.draw()) {
+                        return e[1];
+                    }
+                }
+                return 0b0000000000000000;
+            }
+        }
+    """
+    result, ctx = _apply_with_ctx_named(game_src, _NONDET_KEY_PRIMITIVE, "ND", "NN")
+    assert result == frog_parser.parse_game(game_src)
+    assert any(
+        nm.transform_name == "Lazy Map Scan" and "non-deterministic call" in nm.reason
+        for nm in ctx.near_misses
     )
+
+
+def test_literal_equality_fires_on_deterministic_call_key() -> None:
+    """The guard must not over-fire: a key that is a ``deterministic``
+    primitive call is pure, so the scan still rewrites to direct lookup."""
+    before = """
+        Game G(PF FF) {
+            Map<BitString<8>, BitString<16>> M;
+            BitString<16> Oracle(BitString<8> arg) {
+                for ([BitString<8>, BitString<16>] e in M.entries) {
+                    if (e[0] == FF.eval(arg)) {
+                        return e[1];
+                    }
+                }
+                return 0b0000000000000000;
+            }
+        }
+    """
+    after = """
+        Game G(PF FF) {
+            Map<BitString<8>, BitString<16>> M;
+            BitString<16> Oracle(BitString<8> arg) {
+                if (FF.eval(arg) in M) {
+                    return M[FF.eval(arg)];
+                }
+                return 0b0000000000000000;
+            }
+        }
+    """
+    result, ctx = _apply_with_ctx_named(
+        before, _DETERMINISTIC_KEY_PRIMITIVE, "PF", "FF"
+    )
+    expected = frog_parser.parse_game(after)
+    assert result == expected, f"\nGOT:\n{result}\n\nEXPECTED:\n{expected}"
+    _assert_no_near_miss(ctx)
 
 
 def test_integration_via_core_pipeline() -> None:
@@ -371,8 +447,7 @@ def test_integration_via_core_pipeline() -> None:
     from proof_frog.transforms.pipelines import CORE_PIPELINE
     from proof_frog.visitors import SearchVisitor
 
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             BitString<16> Oracle(BitString<8> arg) {
@@ -384,12 +459,9 @@ def test_integration_via_core_pipeline() -> None:
                 return 0b0000000000000000;
             }
         }
-        """
-    )
+        """)
     result = run_pipeline(game, CORE_PIPELINE, _ctx())
-    found = SearchVisitor(
-        lambda n: isinstance(n, frog_ast.GenericFor)
-    ).visit(result)
+    found = SearchVisitor(lambda n: isinstance(n, frog_ast.GenericFor)).visit(result)
     assert found is None, f"GenericFor should be eliminated, got:\n{result}"
 
 
@@ -529,8 +601,7 @@ def test_injective_call_fails_when_method_not_injective() -> None:
     result, ctx = _apply_with_ctx(game_src, _NON_INJECTIVE_PRIMITIVE)
     assert result == frog_parser.parse_game(game_src)
     assert any(
-        nm.transform_name == "Lazy Map Scan"
-        and "not annotated injective" in nm.reason
+        nm.transform_name == "Lazy Map Scan" and "not annotated injective" in nm.reason
         for nm in ctx.near_misses
     )
 
@@ -598,8 +669,7 @@ def test_injective_call_fails_when_callee_is_not_primitive_method() -> None:
     result, ctx = _apply_with_ctx(game_src)  # no primitive registered
     assert result == frog_parser.parse_game(game_src)
     assert any(
-        nm.transform_name == "Lazy Map Scan"
-        and "not a primitive method" in nm.reason
+        nm.transform_name == "Lazy Map Scan" and "not a primitive method" in nm.reason
         for nm in ctx.near_misses
     )
 

--- a/tests/unit/transforms/test_near_misses.py
+++ b/tests/unit/transforms/test_near_misses.py
@@ -27,6 +27,7 @@ from proof_frog.transforms.random_functions import (
     LocalFunctionFieldToLet,
 )
 from proof_frog.transforms.structural import UniformBijectionElimination
+from proof_frog.transforms.map_iteration import LazyMapScan
 from proof_frog.visitors import NameTypeMap
 
 
@@ -674,8 +675,7 @@ def _lazy_map_ctx() -> PipelineContext:
 
 
 def test_lazy_map_near_miss_cardinality_use() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<16>> T;
             Int Size() {
@@ -690,8 +690,7 @@ def test_lazy_map_near_miss_cardinality_use() -> None:
                 return s;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_map_ctx()
     result = LazyMapToSampledFunction().apply(game, ctx)
     assert result == game
@@ -704,8 +703,7 @@ def test_lazy_map_near_miss_cardinality_use() -> None:
 
 
 def test_lazy_map_near_miss_explicit_initialize() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<16>> T;
             Void Initialize() {
@@ -720,8 +718,7 @@ def test_lazy_map_near_miss_explicit_initialize() -> None:
                 return s;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_map_ctx()
     LazyMapToSampledFunction().apply(game, ctx)
     assert any(
@@ -733,21 +730,18 @@ def test_lazy_map_near_miss_explicit_initialize() -> None:
 
 
 def test_lazy_map_no_near_miss_when_no_idiom() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<16>> T;
             Int Size() {
                 return |T|;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_map_ctx()
     LazyMapToSampledFunction().apply(game, ctx)
     assert not any(
-        nm.transform_name == "Lazy Map To Sampled Function"
-        for nm in ctx.near_misses
+        nm.transform_name == "Lazy Map To Sampled Function" for nm in ctx.near_misses
     )
 
 
@@ -764,8 +758,7 @@ def _lazy_scan_ctx() -> PipelineContext:
 
 
 def test_lazy_scan_near_miss_if_with_else() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             BitString<16> Oracle(BitString<8> arg) {
@@ -779,8 +772,7 @@ def test_lazy_scan_near_miss_if_with_else() -> None:
                 return 0b0000000000000000;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_scan_ctx()
     result = LazyMapScan().apply(game, ctx)
     assert result == game
@@ -794,8 +786,7 @@ def test_lazy_scan_near_miss_if_with_else() -> None:
 
 
 def test_lazy_scan_near_miss_key_references_loop_var() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<8>> M;
             BitString<8> Oracle() {
@@ -807,8 +798,7 @@ def test_lazy_scan_near_miss_key_references_loop_var() -> None:
                 return 0b00000000;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_scan_ctx()
     LazyMapScan().apply(game, ctx)
     assert any(
@@ -820,22 +810,17 @@ def test_lazy_scan_near_miss_key_references_loop_var() -> None:
 
 
 def test_lazy_scan_no_near_miss_when_no_scan() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<16>> M;
             Int Size() {
                 return |M|;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_scan_ctx()
     LazyMapScan().apply(game, ctx)
-    assert not any(
-        nm.transform_name == "Lazy Map Scan" for nm in ctx.near_misses
-    )
-
+    assert not any(nm.transform_name == "Lazy Map Scan" for nm in ctx.near_misses)
 
 
 _TRAPDOOR_TEST_PRIMITIVE_SRC = """
@@ -863,8 +848,7 @@ def _register_primitive(ctx: PipelineContext, src: str) -> None:
 
 
 def test_lazy_scan_injective_near_miss_not_injective() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G(T TT) {
             Map<TT.Image, BitString<8>> M;
             BitString<8> Oracle(TT.Input c) {
@@ -876,8 +860,7 @@ def test_lazy_scan_injective_near_miss_not_injective() -> None:
                 return 0b00000000;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_scan_ctx()
     _register_primitive(ctx, _NON_INJECTIVE_PRIMITIVE_SRC)
     LazyMapScan().apply(game, ctx)
@@ -891,8 +874,7 @@ def test_lazy_scan_injective_near_miss_not_injective() -> None:
 
 
 def test_lazy_scan_injective_near_miss_callee_not_primitive() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Map<BitString<8>, BitString<8>> M;
             BitString<8> Oracle(BitString<8> c) {
@@ -904,8 +886,7 @@ def test_lazy_scan_injective_near_miss_callee_not_primitive() -> None:
                 return 0b00000000;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_scan_ctx()
     LazyMapScan().apply(game, ctx)
     assert any(
@@ -917,8 +898,7 @@ def test_lazy_scan_injective_near_miss_callee_not_primitive() -> None:
 
 
 def test_lazy_scan_injective_no_near_miss_when_valid() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G(T TT) {
             Map<TT.Image, BitString<8>> M;
             BitString<8> Oracle(TT.Input c) {
@@ -930,14 +910,11 @@ def test_lazy_scan_injective_no_near_miss_when_valid() -> None:
                 return 0b00000000;
             }
         }
-        """
-    )
+        """)
     ctx = _lazy_scan_ctx()
     _register_primitive(ctx, _TRAPDOOR_TEST_PRIMITIVE_SRC)
     LazyMapScan().apply(game, ctx)
-    assert not any(
-        nm.transform_name == "Lazy Map Scan" for nm in ctx.near_misses
-    )
+    assert not any(nm.transform_name == "Lazy Map Scan" for nm in ctx.near_misses)
 
 
 # --- MapKeyReindex near-miss tests --------------------------------------------
@@ -1100,9 +1077,7 @@ def test_lazy_map_pair_near_miss_missing_guard():
         if nm.transform_name == "Lazy Map Pair to Sampled Function"
     ]
     assert misses
-    assert any(
-        "disjointness" in nm.reason or "guard" in nm.reason for nm in misses
-    )
+    assert any("disjointness" in nm.reason or "guard" in nm.reason for nm in misses)
 
 
 def test_lazy_map_pair_near_miss_mismatched_types():
@@ -1173,8 +1148,7 @@ def _local_fn_misses(ctx: PipelineContext) -> list:
 
 
 def test_local_fn_near_miss_reassigned() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Function<BitString<8>, BitString<16>> F;
             Void Initialize() {
@@ -1185,8 +1159,7 @@ def test_local_fn_near_miss_reassigned() -> None:
                 return F(x);
             }
         }
-        """
-    )
+        """)
     ctx = _local_fn_ctx(sampled={"H"})
     LocalFunctionFieldToLet().apply(game, ctx)
     misses = _local_fn_misses(ctx)
@@ -1195,8 +1168,7 @@ def test_local_fn_near_miss_reassigned() -> None:
 
 
 def test_local_fn_near_miss_non_call_use() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Function<BitString<8>, BitString<16>> F;
             Void Initialize() {
@@ -1207,8 +1179,7 @@ def test_local_fn_near_miss_non_call_use() -> None:
             }
             BitString<16> Hash(BitString<8> x) { return F(x); }
         }
-        """
-    )
+        """)
     ctx = _local_fn_ctx(sampled={"H"})
     LocalFunctionFieldToLet().apply(game, ctx)
     misses = _local_fn_misses(ctx)
@@ -1217,8 +1188,7 @@ def test_local_fn_near_miss_non_call_use() -> None:
 
 
 def test_local_fn_near_miss_h_referenced() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Function<BitString<8>, BitString<16>> F;
             Void Initialize() {
@@ -1227,8 +1197,7 @@ def test_local_fn_near_miss_h_referenced() -> None:
             BitString<16> Hash(BitString<8> x) { return F(x); }
             BitString<16> Other(BitString<8> y) { return H(y); }
         }
-        """
-    )
+        """)
     ctx = _local_fn_ctx(sampled={"H"})
     LocalFunctionFieldToLet().apply(game, ctx)
     misses = _local_fn_misses(ctx)
@@ -1237,8 +1206,7 @@ def test_local_fn_near_miss_h_referenced() -> None:
 
 
 def test_local_fn_near_miss_declared_not_sampled() -> None:
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Function<BitString<8>, BitString<16>> F;
             Void Initialize() {
@@ -1246,15 +1214,12 @@ def test_local_fn_near_miss_declared_not_sampled() -> None:
             }
             BitString<16> Hash(BitString<8> x) { return F(x); }
         }
-        """
-    )
+        """)
     ctx = _local_fn_ctx(declared={"H"})
     LocalFunctionFieldToLet().apply(game, ctx)
     misses = _local_fn_misses(ctx)
     assert misses
-    assert any(
-        "declared (known deterministic)" in nm.reason for nm in misses
-    )
+    assert any("declared (known deterministic)" in nm.reason for nm in misses)
 
 
 # ---------------------------------------------------------------------------
@@ -1279,21 +1244,17 @@ def _concat_ctx() -> PipelineContext:
 def test_concat_equality_decompose_near_miss_unknown_length() -> None:
     """A term without a statically-derivable BitString length should emit
     a near-miss explaining that length derivation failed."""
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Bool Q(BitString<16> x, BitString<8> a) {
                 return x == (a || unknown);
             }
         }
-        """
-    )
+        """)
     ctx = _concat_ctx()
     ConcatEqualityDecompose().apply(game, ctx)
     misses = [
-        nm
-        for nm in ctx.near_misses
-        if nm.transform_name == "Concat Equality Decompose"
+        nm for nm in ctx.near_misses if nm.transform_name == "Concat Equality Decompose"
     ]
     assert misses
     assert any("statically-derivable" in nm.reason for nm in misses)
@@ -1302,21 +1263,17 @@ def test_concat_equality_decompose_near_miss_unknown_length() -> None:
 def test_concat_equality_decompose_no_near_miss_when_fires() -> None:
     """When every term has a derivable length, the transform fires and
     emits no near-miss."""
-    game = frog_parser.parse_game(
-        """
+    game = frog_parser.parse_game("""
         Game G() {
             Bool Q(BitString<16> x, BitString<8> a, BitString<8> b) {
                 return x == (a || b);
             }
         }
-        """
-    )
+        """)
     ctx = _concat_ctx()
     ConcatEqualityDecompose().apply(game, ctx)
     misses = [
-        nm
-        for nm in ctx.near_misses
-        if nm.transform_name == "Concat Equality Decompose"
+        nm for nm in ctx.near_misses if nm.transform_name == "Concat Equality Decompose"
     ]
     assert not misses
 
@@ -1330,7 +1287,6 @@ from proof_frog.transforms.inlining import (  # noqa: E402
     HoistGroupExpToInitialize,
     RefactorGroupElemFieldExp,
 )
-
 
 _HGE_NAME = "Hoist GroupElem Exponent To Initialize"
 
@@ -1524,8 +1480,7 @@ def test_rgfe_near_miss_exponent_not_multiplication() -> None:
     RefactorGroupElemFieldExp().apply(game, ctx)
     misses = [nm for nm in ctx.near_misses if nm.transform_name == _RGFE_NAME]
     assert any(
-        nm.variable == "field1" and "multiplication" in nm.reason
-        for nm in misses
+        nm.variable == "field1" and "multiplication" in nm.reason for nm in misses
     )
     assert all(nm.method == "Initialize" for nm in misses)
 
@@ -1550,9 +1505,7 @@ def test_rgfe_near_miss_no_matching_second_field() -> None:
     ctx = _rgfe_ctx()
     RefactorGroupElemFieldExp().apply(game, ctx)
     misses = [nm for nm in ctx.near_misses if nm.transform_name == _RGFE_NAME]
-    assert any(
-        nm.variable == "field1" and "no peer" in nm.reason for nm in misses
-    )
+    assert any(nm.variable == "field1" and "no peer" in nm.reason for nm in misses)
 
 
 def test_rgfe_no_near_miss_when_fires() -> None:
@@ -1644,3 +1597,289 @@ def test_gcs_no_near_miss_when_guard_stable() -> None:
     GuardConditionSimplification().apply(game, ctx)
     gcs = [nm for nm in ctx.near_misses if nm.transform_name == _GCS_NAME]
     assert len(gcs) == 0
+
+
+# --- Lazy Map Scan near-miss tests (F-142 non-deterministic-key guard) ---
+
+
+_LMS_NAME = "Lazy Map Scan"
+
+
+def _lms_ctx(primitive_src: str) -> PipelineContext:
+    prim = frog_parser.parse_primitive_file(primitive_src)
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={"ND": prim, "NN": prim},
+        subsets_pairs=[],
+    )
+
+
+def test_lazy_map_scan_near_miss_nondeterministic_key():
+    """LazyMapScan reports a near-miss and declines when the scan key is a
+    non-deterministic call (verdict F-142, §8)."""
+    game = frog_parser.parse_game("""
+        Game G(ND NN) {
+            Map<BitString<8>, BitString<16>> M;
+            BitString<16> Oracle() {
+                for ([BitString<8>, BitString<16>] e in M.entries) {
+                    if (e[0] == NN.draw()) {
+                        return e[1];
+                    }
+                }
+                return 0b0000000000000000;
+            }
+        }
+        """)
+    ctx = _lms_ctx("""
+        Primitive ND() {
+            BitString<8> draw();
+        }
+        """)
+    result = LazyMapScan().apply(game, ctx)
+    assert result == game
+    lms = [nm for nm in ctx.near_misses if nm.transform_name == _LMS_NAME]
+    assert len(lms) >= 1
+    assert "non-deterministic call" in lms[0].reason
+
+
+def test_lazy_map_scan_no_near_miss_deterministic_key():
+    """No near-miss when the scan key is a ``deterministic`` primitive call
+    (the transform fires)."""
+    game = frog_parser.parse_game("""
+        Game G(ND NN) {
+            Map<BitString<8>, BitString<16>> M;
+            BitString<16> Oracle(BitString<8> arg) {
+                for ([BitString<8>, BitString<16>] e in M.entries) {
+                    if (e[0] == NN.eval(arg)) {
+                        return e[1];
+                    }
+                }
+                return 0b0000000000000000;
+            }
+        }
+        """)
+    ctx = _lms_ctx("""
+        Primitive ND() {
+            deterministic BitString<8> eval(BitString<8> x);
+        }
+        """)
+    result = LazyMapScan().apply(game, ctx)
+    assert result != game  # transform fired
+    lms = [nm for nm in ctx.near_misses if nm.transform_name == _LMS_NAME]
+    assert len(lms) == 0
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism-guard near-miss tests (control_flow.py).
+#
+# Each control-flow pass that declines a rewrite because the relevant
+# expression contains a non-deterministic call appends a NearMiss naming the
+# pass. These tests confirm the near-miss is emitted at the decline point.
+# ---------------------------------------------------------------------------
+
+from proof_frog.transforms.control_flow import (
+    UniqExclusionBranchElimination as _RC3_UniqExcl,
+    RedundantConditionalReturn as _RC3_RCR,
+    DeadGuardedAssignmentElimination as _RC3_DGAE,
+    RemoveUnreachable as _RC3_RU,
+    AbsorbRedundantEarlyReturn as _RC3_AER,
+    IfFalseReturnToConjunction as _RC3_IFRC,
+    FoldEquivalentReturnBranch as _RC3_FERB,
+)
+from proof_frog.transforms.random_functions import (
+    ChallengeExclusionRFToUniform as _RC3_ChalExcl,
+)
+
+
+def _rc3_ctx(**namespace) -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace=dict(namespace),
+        subsets_pairs=[],
+    )
+
+
+def _rc3_nondet_prim():
+    return frog_parser.parse_primitive_file(
+        "Primitive P(Int n) { BitString<n> eval(); Bool f(Int x); }"
+    )
+
+
+def test_rc3_uniq_exclusion_near_miss():
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Bool Oracle() {
+                BitString<n> b <-uniq[{F.eval()}] BitString<n>;
+                if (b == F.eval()) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """)
+    ctx = _rc3_ctx(P=_rc3_nondet_prim(), F=_rc3_nondet_prim())
+    _RC3_UniqExcl().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Uniq Exclusion Branch Elimination"
+        for nm in ctx.near_misses
+    )
+
+
+def test_rc3_redundant_conditional_return_near_miss():
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                return 1;
+            }
+        }
+        """)
+    ctx = _rc3_ctx(P=_rc3_nondet_prim(), F=_rc3_nondet_prim())
+    _RC3_RCR().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Redundant Conditional Return" for nm in ctx.near_misses
+    )
+
+
+def test_rc3_dead_guarded_assignment_near_miss():
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                if (F.f(x)) {
+                    v = c;
+                }
+                if (v) {
+                    if (F.f(x)) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """)
+    ctx = _rc3_ctx(P=_rc3_nondet_prim(), F=_rc3_nondet_prim())
+    _RC3_DGAE().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Dead Guarded Assignment Elimination"
+        for nm in ctx.near_misses
+    )
+
+
+def test_rc3_remove_unreachable_near_miss():
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                if (F.f(x)) {
+                    return 2;
+                }
+                return 3;
+            }
+        }
+        """)
+    ctx = _rc3_ctx(P=_rc3_nondet_prim(), F=_rc3_nondet_prim())
+    _RC3_RU().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Remove unreachable blocks of code"
+        for nm in ctx.near_misses
+    )
+
+
+def test_rc3_absorb_early_return_near_miss():
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x, Bool q) {
+                if (F.f(x)) {
+                    return 7;
+                }
+                if (q) {
+                    return 5;
+                }
+                return 7;
+            }
+        }
+        """)
+    ctx = _rc3_ctx(P=_rc3_nondet_prim(), F=_rc3_nondet_prim())
+    _RC3_AER().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Absorb Redundant Early Return" for nm in ctx.near_misses
+    )
+
+
+def test_rc3_if_false_return_near_miss():
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Bool Test(Int x) {
+                if (x == 0) {
+                    return false;
+                }
+                return F.f(x);
+            }
+        }
+        """)
+    ctx = _rc3_ctx(P=_rc3_nondet_prim(), F=_rc3_nondet_prim())
+    _RC3_IFRC().apply(game, ctx)
+    assert any(
+        nm.transform_name == "If False Return To Conjunction" for nm in ctx.near_misses
+    )
+
+
+def test_rc3_fold_equivalent_return_near_miss():
+    game = frog_parser.parse_game("""
+        Game Collapse(P F, Int n) {
+            BitString<n> a;
+            Void Initialize() {
+                a = F.eval();
+            }
+            BitString<n> O(BitString<n> k) {
+                if (a == k) {
+                    return F.eval();
+                }
+                return a;
+            }
+        }
+        """)
+    ctx = _rc3_ctx(P=_rc3_nondet_prim(), F=_rc3_nondet_prim())
+    _RC3_FERB().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Fold Equivalent Return Branch" for nm in ctx.near_misses
+    )
+
+
+def test_rc3_challenge_exclusion_known_function_near_miss():
+    """ChallengeExclusionRFToUniform declines on a KNOWN function (``H = F``,
+    not sampled) and records a near-miss (verdict vector a)."""
+    game = frog_parser.parse_game("""
+        Game G(Int n, Function<BitString<n>, BitString<n>> F) {
+            Function<BitString<n>, BitString<n>> H;
+            BitString<n> cf;
+            BitString<n> field;
+            BitString<n> Initialize() {
+                H = F;
+                cf <- BitString<n>;
+                field = H(cf);
+                return cf;
+            }
+            BitString<n>? Query(BitString<n> param) {
+                if (param == cf) {
+                    return None;
+                }
+                return H(param);
+            }
+        }
+        """)
+    ctx = _rc3_ctx()
+    _RC3_ChalExcl().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Challenge Exclusion RF To Uniform"
+        and "sampled random function" in nm.reason
+        for nm in ctx.near_misses
+    )

--- a/tests/unit/transforms/test_redundant_conditional_return.py
+++ b/tests/unit/transforms/test_redundant_conditional_return.py
@@ -159,3 +159,73 @@ def test_redundant_conditional_return(method: str, expected: str) -> None:
     expected_ast = frog_parser.parse_method(expected)
     transformed_ast = RedundantConditionalReturnTransformer().transform(method_ast)
     assert expected_ast == transformed_ast
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism guard (F-087): dropping the redundant guard discards an
+# evaluation of its condition; a non-deterministic condition is observable,
+# so the fold must be declined.
+# ---------------------------------------------------------------------------
+
+from proof_frog.transforms.control_flow import RedundantConditionalReturn
+from proof_frog.transforms._base import PipelineContext as _PipelineContext
+from proof_frog.visitors import NameTypeMap as _NameTypeMap
+
+
+def _rcr_ctx(**namespace):
+    return _PipelineContext(
+        variables={},
+        proof_let_types=_NameTypeMap(),
+        proof_namespace=dict(namespace),
+        subsets_pairs=[],
+    )
+
+
+def _rcr_nondet_prim():
+    return frog_parser.parse_primitive_file("Primitive P(Int n) { Bool f(Int x); }")
+
+
+def _rcr_det_prim():
+    return frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic Bool f(Int x); }"
+    )
+
+
+def test_rcr_declines_on_nondeterministic_condition() -> None:
+    """``if (F.f(x)) { return 1; } return 1;`` -- body matches fall-through,
+    but the guard is non-deterministic, so dropping it would discard an
+    observable evaluation. The pass must decline."""
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                return 1;
+            }
+        }
+        """)
+    ctx = _rcr_ctx(P=_rcr_nondet_prim(), F=_rcr_nondet_prim())
+    result = RedundantConditionalReturn().apply(game, ctx)
+    assert result == game  # declined
+    assert any(
+        nm.transform_name == "Redundant Conditional Return" for nm in ctx.near_misses
+    )
+
+
+def test_rcr_fires_on_deterministic_control() -> None:
+    """Control: a deterministic guard evaluation has no observable effect, so
+    the redundant guard folds."""
+    game = frog_parser.parse_game("""
+        Game G(D F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                return 1;
+            }
+        }
+        """)
+    ctx = _rcr_ctx(D=_rcr_det_prim(), F=_rcr_det_prim())
+    result = RedundantConditionalReturn().apply(game, ctx)
+    assert result != game  # the guard was folded away

--- a/tests/unit/transforms/test_uniq_exclusion_branch_elim.py
+++ b/tests/unit/transforms/test_uniq_exclusion_branch_elim.py
@@ -2,7 +2,33 @@
 
 import pytest
 from proof_frog import frog_parser
-from proof_frog.transforms.control_flow import UniqExclusionBranchEliminationTransformer
+from proof_frog.transforms.control_flow import (
+    UniqExclusionBranchElimination,
+    UniqExclusionBranchEliminationTransformer,
+)
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx_with(**namespace) -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace=dict(namespace),
+        subsets_pairs=[],
+    )
+
+
+def _nondet_prim() -> object:
+    return frog_parser.parse_primitive_file(
+        "Primitive P(Int n) { BitString<n> eval(); }"
+    )
+
+
+def _det_prim() -> object:
+    return frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic BitString<n> eval(BitString<n> x); }"
+    )
 
 
 @pytest.mark.parametrize(
@@ -265,3 +291,53 @@ def test_uniq_exclusion_branch_elim(method: str, expected: str) -> None:
     expected_ast = frog_parser.parse_method(expected)
     transformed = UniqExclusionBranchEliminationTransformer().transform(method_ast)
     assert transformed == expected_ast
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism guard (F-071): a non-deterministic exclusion element must
+# not be tracked, so the comparison is NOT folded.
+# ---------------------------------------------------------------------------
+
+
+def test_uniq_exclusion_declines_on_nondeterministic_element() -> None:
+    """An exclusion element ``F.eval()`` is a non-deterministic call; the
+    later ``b == F.eval()`` is an independent re-evaluation, so the pass must
+    NOT fold the comparison to false."""
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Bool Oracle() {
+                BitString<n> b <-uniq[{F.eval()}] BitString<n>;
+                if (b == F.eval()) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """)
+    ctx = _ctx_with(P=_nondet_prim(), F=_nondet_prim())
+    result = UniqExclusionBranchElimination().apply(game, ctx)
+    assert result == game  # unchanged: no fold
+    assert any(
+        nm.transform_name == "Uniq Exclusion Branch Elimination"
+        for nm in ctx.near_misses
+    )
+
+
+def test_uniq_exclusion_fires_on_deterministic_control() -> None:
+    """Control: a plain sampled exclusion element still lets the pass fold
+    ``a == b`` to false."""
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Bool Oracle() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <-uniq[{a}] BitString<n>;
+                if (a == b) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """)
+    ctx = _ctx_with()
+    result = UniqExclusionBranchElimination().apply(game, ctx)
+    assert result != game  # the comparison was folded to false

--- a/tests/unit/transforms/test_unreachable_transformer.py
+++ b/tests/unit/transforms/test_unreachable_transformer.py
@@ -628,28 +628,25 @@ def test_remove_unreachable_nested_element_write_bumps_version() -> None:
     so the second `if (M[0][0] == 0)` is a fresh test, not a dead duplicate
     of the first.  A depth-1-only write scan left `M` looking unmodified and
     Case-B dedup wrongly deleted the reachable second if."""
-    method = frog_parser.parse_method(
-        """
+    method = frog_parser.parse_method("""
         Int O(Map<Int, Map<Int, Int>> M) {
             if (M[0][0] == 0) { return 1; }
             M[0][0] = 0;
             if (M[0][0] == 0) { return 2; }
             return 3;
         }
-        """
-    )
+        """)
     transformed = RemoveUnreachableTransformer(method).transform(method)
-    assert _count_ifs(transformed) == 2, (
-        f"second if wrongly deleted after nested element write:\n{transformed}"
-    )
+    assert (
+        _count_ifs(transformed) == 2
+    ), f"second if wrongly deleted after nested element write:\n{transformed}"
 
 
 def test_remove_unreachable_unique_sample_bumps_version() -> None:
     """RC1: a `<-uniq` re-sample of a condition variable mutates it, so a
     later structurally identical condition is not a dead duplicate.  The
     write scan must recognise `UniqueSample.var` as a write."""
-    method = frog_parser.parse_method(
-        """
+    method = frog_parser.parse_method("""
         Int O() {
             BitString<2> x <- BitString<2>;
             if (x == 0b00) { return 1; }
@@ -657,28 +654,102 @@ def test_remove_unreachable_unique_sample_bumps_version() -> None:
             if (x == 0b00) { return 2; }
             return 3;
         }
-        """
-    )
+        """)
     transformed = RemoveUnreachableTransformer(method).transform(method)
-    assert _count_ifs(transformed) == 2, (
-        f"second if wrongly deleted after <-uniq re-sample:\n{transformed}"
-    )
+    assert (
+        _count_ifs(transformed) == 2
+    ), f"second if wrongly deleted after <-uniq re-sample:\n{transformed}"
 
 
 def test_remove_unreachable_still_dedups_genuine_duplicate() -> None:
     """Positive control: with NO intervening write, two identical
     conditions are genuinely redundant and the second must still be
     removed (the version-tracking fix must not over-preserve)."""
-    method = frog_parser.parse_method(
-        """
+    method = frog_parser.parse_method("""
         Int O(Int x) {
             if (x == 0) { return 1; }
             if (x == 0) { return 2; }
             return 3;
         }
-        """
-    )
+        """)
     transformed = RemoveUnreachableTransformer(method).transform(method)
-    assert _count_ifs(transformed) == 1, (
-        f"genuinely dead duplicate if was not removed:\n{transformed}"
+    assert (
+        _count_ifs(transformed) == 1
+    ), f"genuinely dead duplicate if was not removed:\n{transformed}"
+
+
+# ---------------------------------------------------------------------------
+# RC3 determinism guard (F-107): Case B dedups structurally-equal
+# return-conditions; a non-deterministic condition re-evaluates independently,
+# so a later structurally-identical one is NOT subsumed and must survive.
+# ---------------------------------------------------------------------------
+
+from proof_frog.transforms.control_flow import RemoveUnreachable
+from proof_frog.transforms._base import PipelineContext as _PipelineContext
+from proof_frog.visitors import NameTypeMap as _NameTypeMap
+
+
+def _ru_ctx(**namespace):
+    return _PipelineContext(
+        variables={},
+        proof_let_types=_NameTypeMap(),
+        proof_namespace=dict(namespace),
+        subsets_pairs=[],
     )
+
+
+def _ru_nondet_prim():
+    return frog_parser.parse_primitive_file("Primitive P(Int n) { Bool f(Int x); }")
+
+
+def _ru_det_prim():
+    return frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic Bool f(Int x); }"
+    )
+
+
+def test_ru_keeps_nondeterministic_duplicate_condition() -> None:
+    """Two ``if (F.f(x)) { return ...; }`` with a non-deterministic condition:
+    the second is an independent re-evaluation, so it must NOT be deduped."""
+    game = frog_parser.parse_game("""
+        Game G(P F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                if (F.f(x)) {
+                    return 2;
+                }
+                return 3;
+            }
+        }
+        """)
+    ctx = _ru_ctx(P=_ru_nondet_prim(), F=_ru_nondet_prim())
+    result = RemoveUnreachable().apply(game, ctx)
+    assert result == game  # second if survives
+    assert any(
+        nm.transform_name == "Remove unreachable blocks of code"
+        for nm in ctx.near_misses
+    )
+
+
+def test_ru_dedups_deterministic_duplicate_condition() -> None:
+    """Control: with a deterministic condition ``D.f(x)`` the second
+    structurally-identical if is dead (subsumed by the first) and is
+    removed."""
+    game = frog_parser.parse_game("""
+        Game G(D F, Int n) {
+            Int O(Int x) {
+                if (F.f(x)) {
+                    return 1;
+                }
+                if (F.f(x)) {
+                    return 2;
+                }
+                return 3;
+            }
+        }
+        """)
+    ctx = _ru_ctx(D=_ru_det_prim(), F=_ru_det_prim())
+    result = RemoveUnreachable().apply(game, ctx)
+    assert result != game  # the dead duplicate if was removed

--- a/tests/unit/typechecking/test_deterministic_sampling_free.py
+++ b/tests/unit/typechecking/test_deterministic_sampling_free.py
@@ -1,0 +1,117 @@
+"""F-007: a ``deterministic``-annotated method body must be sampling-free.
+
+Many canonicalization passes trust the ``deterministic`` modifier (via
+``has_nondeterministic_call``) to mean same-input/same-output. A scheme method
+that declares ``deterministic`` but samples randomness in its body breaks that
+promise, so the typechecker must reject it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from proof_frog import frog_parser, semantic_analysis
+
+_PRIMITIVE = """\
+Primitive P(Int n) {
+    deterministic BitString<n> Det(BitString<n> x);
+    BitString<n> Rand(BitString<n> x);
+}
+"""
+
+
+def _write_primitive(tmp_path: Path) -> None:
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "P.primitive").write_text(_PRIMITIVE)
+
+
+def _check(tmp_path: Path, scheme_body: str) -> None:
+    _write_primitive(tmp_path)
+    source = (
+        "import 'fixtures/P.primitive';\n\n"
+        "Scheme S(Int n) extends P {\n" + scheme_body + "}\n"
+    )
+    file_path = str(tmp_path / "test.scheme")
+    Path(file_path).write_text(source)
+    root = frog_parser.parse_file(file_path)
+    semantic_analysis.check_well_formed(root, file_path)
+
+
+def test_deterministic_body_with_sample_rejected(tmp_path: Path) -> None:
+    """A `deterministic` method sampling via `<-` must fail typechecking."""
+    body = (
+        "    deterministic BitString<n> Det(BitString<n> x) {\n"
+        "        BitString<n> r <- BitString<n>;\n"
+        "        return r;\n"
+        "    }\n"
+        "    BitString<n> Rand(BitString<n> x) {\n"
+        "        return x;\n"
+        "    }\n"
+    )
+    with pytest.raises(semantic_analysis.FailedTypeCheck):
+        _check(tmp_path, body)
+
+
+def test_deterministic_body_with_uniq_sample_rejected(tmp_path: Path) -> None:
+    """A `deterministic` method sampling via `<-uniq` must fail typechecking."""
+    body = (
+        "    deterministic BitString<n> Det(BitString<n> x) {\n"
+        "        Set seen = {};\n"
+        "        BitString<n> r <-uniq[seen] BitString<n>;\n"
+        "        return r;\n"
+        "    }\n"
+        "    BitString<n> Rand(BitString<n> x) {\n"
+        "        return x;\n"
+        "    }\n"
+    )
+    with pytest.raises(semantic_analysis.FailedTypeCheck):
+        _check(tmp_path, body)
+
+
+def test_deterministic_body_sampling_free_accepted(tmp_path: Path) -> None:
+    """A genuinely sampling-free `deterministic` body type-checks."""
+    body = (
+        "    deterministic BitString<n> Det(BitString<n> x) {\n"
+        "        return x;\n"
+        "    }\n"
+        "    BitString<n> Rand(BitString<n> x) {\n"
+        "        return x;\n"
+        "    }\n"
+    )
+    _check(tmp_path, body)  # should not raise
+
+
+def test_nondeterministic_body_may_sample(tmp_path: Path) -> None:
+    """A method NOT annotated `deterministic` may sample freely."""
+    body = (
+        "    deterministic BitString<n> Det(BitString<n> x) {\n"
+        "        return x;\n"
+        "    }\n"
+        "    BitString<n> Rand(BitString<n> x) {\n"
+        "        BitString<n> r <- BitString<n>;\n"
+        "        return r;\n"
+        "    }\n"
+    )
+    _check(tmp_path, body)  # should not raise
+
+
+def test_deterministic_error_message_mentions_sampling(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The error names the method and the sampling-free requirement."""
+    body = (
+        "    deterministic BitString<n> Det(BitString<n> x) {\n"
+        "        BitString<n> r <- BitString<n>;\n"
+        "        return r;\n"
+        "    }\n"
+        "    BitString<n> Rand(BitString<n> x) {\n"
+        "        return x;\n"
+        "    }\n"
+    )
+    with pytest.raises(semantic_analysis.FailedTypeCheck):
+        _check(tmp_path, body)
+    err = capsys.readouterr().err
+    assert "deterministic" in err
+    assert "sampling-free" in err
+    assert "Det" in err


### PR DESCRIPTION
Canonicalization passes that delete, deduplicate, duplicate, fold, or move code
treated a **non-deterministic call** (a scheme method, game method, or
unannotated primitive method) as if two textual copies denoted the same value.
They don't: each invocation may draw fresh randomness, so eliminating or
relocating one across another changes the distribution and the engine wrongly
certified distinguishable games as interchangeable.

Each pass now consults the existing `has_nondeterministic_call` helper at its
decision point and declines (emitting a `NearMiss`) when the relevant expression
could be non-deterministic. `ctx` is threaded into the few wrappers that
previously dropped it.

**Findings closed (10):**
- `control_flow.py`
  - F-071 UniqExclusionBranchElimination — skip a constraint whose exclusion-set
    element is non-deterministic
  - F-087 RedundantConditionalReturn — don't drop an if whose condition is
    non-deterministic
  - F-100 DeadGuardedAssignmentElimination — decline when the matched path-fact
    is non-deterministic (wrapper now threads ctx)
  - F-107 RemoveUnreachable — Case B no longer dedups a non-deterministic return
    condition (wrapper now threads ctx)
  - F-111 AbsorbRedundantEarlyReturn — don't absorb when the early-return guard
    is non-deterministic, before the per-condition deepcopy fan-out
  - F-116 IfFalseReturnToConjunction — guard both the re-evaluated guard P and
    the trailing return expression Q
  - F-118 FoldEquivalentReturnBranch — skip a non-deterministic FuncCall RHS, and
    pass `proof_namespace` to the Z3 backstop so its in-visitor non-determinism
    refusal actually runs
- `map_iteration.py`
  - F-142 LazyMapScan — the literal-equality branch now purity-checks `key_expr`,
    matching the sibling injective-call branch's deterministic gate
- `random_functions.py`
  - F-016 ChallengeExclusionRFToUniform — fire only when the function is a
    genuinely sampled random function (`H <- Function`), and decline on local RF
    aliasing or a second embedded init RF call
- `semantic_analysis.py`
  - F-007 — typechecker now rejects a scheme method declared `deterministic`
    whose body samples (`<-` / `<-uniq`); a deterministic method must be
    sampling-free (0/42 example schemes affected)

**Testing.** Regression tests assert the engine rejects each attack pair while
still certifying the sound control, plus per-pass decline/fire unit tests and
near-miss tests (`tests/integration/test_rc3_*`,
`tests/unit/typechecking/test_deterministic_sampling_free.py`,
`tests/unit/transforms/`). Full suite green, lint 10.00, zero example-proof
fallout.

**Known deferred sibling (not in this PR).** F-077 (IfConditionAliasSubstitution)
is a related determinism issue but needs a pass rebuild rather than a guard — it
is moving a `Function` call across a re-sampling barrier, which `has_nondeterministic_call`
cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)