### PR TITLE
Add F-129 regression test for AlphaRename (SimplifyIf loop-binder capture)

### DIFF
--- a/tests/integration/test_rc4_alpha_rename.py
+++ b/tests/integration/test_rc4_alpha_rename.py
@@ -168,6 +168,48 @@ def test_simplify_if_field_read_before_decl_rejected() -> None:
     assert not _engine().check_equivalent(left, right).valid
 
 
+def test_simplify_if_loop_binder_capture_rejected() -> None:
+    # F-129 ATK-A9c: SimplifyIf's `_normalize_block_locals` renames a branch
+    # local and (buggily) rewrites a same-named generic-for BINDER use, merging
+    # two inequivalent branches.  THEN sums the loop binder `x` over D={1,2}
+    # (acc = 3); ELSE sums the sampled local `t` (acc = 2t).  Distinguisher
+    # Probe(false); GetAcc() -> 3 (odd) vs 2t (even), advantage 1.  AlphaRename
+    # renames the locals (x->fresh, t->fresh) so the THEN loop-binder use and
+    # the ELSE local use stay distinct and the buggy merge cannot fire.
+    left = frog_parser.parse_game("""
+        Game Left() {
+          ModInt<16> acc;
+          Set<ModInt<16>> D;
+          Void Initialize() { acc = 0; D = {1, 2}; }
+          Void Probe(Bool c) {
+            acc = 0;
+            if (c) {
+              ModInt<16> x <- ModInt<16>;
+              for (ModInt<16> x in D) { acc = acc + x; }
+            } else {
+              ModInt<16> t <- ModInt<16>;
+              for (ModInt<16> x in D) { acc = acc + t; }
+            }
+          }
+          ModInt<16> GetAcc() { return acc; }
+        }
+        """)
+    right = frog_parser.parse_game("""
+        Game Right() {
+          ModInt<16> acc;
+          Set<ModInt<16>> D;
+          Void Initialize() { acc = 0; D = {1, 2}; }
+          Void Probe(Bool c) {
+            acc = 0;
+            ModInt<16> x <- ModInt<16>;
+            for (ModInt<16> x in D) { acc = acc + x; }
+          }
+          ModInt<16> GetAcc() { return acc; }
+        }
+        """)
+    assert not _engine().check_equivalent(left, right).valid
+
+
 def test_simplify_if_identical_branches_control_accepted() -> None:
     # Sound: both branches genuinely read the SAME field x (just with different
     # local names), so merging the if into a single body is correct and the two


### PR DESCRIPTION
Follow-up to #229. The global `AlphaRename` pass merged there also closes **F-129** (SimplifyIf loop-binder capture), but the regression test for it landed after the merge — this adds it.

## Why F-129 is closed by AlphaRename

`SimplifyIf`'s `_normalize_block_locals` renames branch-locals by pure name substitution while a generic-for binder name (`GenericFor.var_name`, a plain `str`) escapes `SubstitutionTransformer`. When a branch-local shares the loop binder's name, the buggy normalisation rewrites the loop-body binder use too, merging two semantically inequivalent branches (attack_a9c). AlphaRename renames the sampled branch-locals (`x`, `t`) to distinct fresh names *before* `SimplifyIf` runs, so the THEN loop-binder use and the ELSE local use stay distinct and the merge cannot fire.

## The attack (a9c)

- THEN sums the generic-for binder `x` over `D = {1,2}` → `acc = 3` (odd).
- ELSE sums the sampled local `t` → `acc = 2t` (even).
- Distinguisher `Probe(false); GetAcc()` → `3` vs `2t`, advantage 1.

On main *without* the pass, `attack_a9c` is wrongly accepted; *with* it (verified against `main` and the merged pass), the inequivalent games are rejected.

## Test

`tests/integration/test_rc4_alpha_rename.py::test_simplify_if_loop_binder_capture_rejected` (campaign Principle 4 — wire the attack artifact into the suite). Full file green; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)