### PR TITLE
Un-conflate UniqueSample surface forms (RC2 uniq/minus split)

### DIFF
--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -53,7 +53,16 @@ def generate_dependency_graph(
             ):
                 return False
             base = visitors.lvalue_base_name(node.var)
-            return base is not None and base in field_names
+            if base is not None and base in field_names:
+                return True
+            # `x <-uniq[S] T` implicitly does `S = S union {x}`, so it mutates
+            # the field S even though its target `x` is a local. Without this,
+            # an unused uniq draw looked side-effect-free and was pruned as
+            # disconnected dead code, erasing the observable insertion (F-004).
+            if isinstance(node, frog_ast.UniqueSample) and node.surface_form == "uniq":
+                set_base = visitors.lvalue_base_name(node.unique_set)
+                return set_base is not None and set_base in field_names
+            return False
 
         return visitors.SearchVisitor(_is_field_write).visit(stmt) is not None
 
@@ -276,9 +285,19 @@ def unnecessary_statement_info(
             required_map.set(statement, False)
         nonlocal necessary_vars
         for statement in reversed(block.statements):
-            if isinstance(
-                statement, frog_ast.ReturnStatement
-            ) or visitors.assigns_variable(necessary_vars, statement):
+            if (
+                isinstance(statement, frog_ast.ReturnStatement)
+                or visitors.assigns_variable(necessary_vars, statement)
+                # The stateful `x <-uniq[S] T` form implicitly does
+                # `S = S union {x}`, an adversary-observable mutation of S, so
+                # it is NEVER dead even when its target `x` is unused; dropping
+                # it would erase the insertion (F-004). The pure `x <- T \ E`
+                # form has no such effect and stays removable when `x` is dead.
+                or (
+                    isinstance(statement, frog_ast.UniqueSample)
+                    and statement.surface_form == "uniq"
+                )
+            ):
                 # Complete read-set: variables reached through a FieldAccess
                 # (`M` in `|M.keys|`) keep their backing writes alive too.
                 all_vars = _vars_of(statement)

--- a/proof_frog/frog_ast.py
+++ b/proof_frog/frog_ast.py
@@ -44,11 +44,16 @@ class ASTNode:
         if type(self) is not type(other):
             return False
 
-        # Compare all attributes
+        # Compare all attributes. Only true source-position / provenance
+        # metadata is non-semantic and excluded. NOTE: `surface_form` on
+        # `UniqueSample` is deliberately NOT excluded -- the `<-uniq[S]`
+        # (stateful, auto-adds the draw to S) and `x <- T \ E` (pure one-shot
+        # exclusion, no insertion) surface forms are distinct constructs with
+        # different observable semantics, so they must not compare equal.
         return all(
             (
                 True
-                if attr in {"line_num", "column_num", "origin", "surface_form"}
+                if attr in {"line_num", "column_num", "origin"}
                 else getattr(self, attr) == getattr(other, attr)
             )
             for attr in self.__dict__
@@ -611,9 +616,13 @@ class UniqueSample(Statement):
         self.var = var
         self.unique_set = unique_set
         self.sampled_from = sampled_from
-        # Purely presentational; preserves author's chosen surface syntax
-        # through parse/unparse. Not compared in __eq__ (inherited from AST
-        # base, which ignores non-semantic metadata like `origin`).
+        # Semantic: distinguishes the two distinct sampling constructs.
+        # "uniq" (`x <-uniq[S] T`) is stateful freshness -- it implicitly
+        # inserts the draw into S (S = S union {x}), an adversary-observable
+        # mutation. "minus" (`x <- T \ E`) is a pure one-shot exclusion draw
+        # with no insertion. They have different semantics, so __eq__ compares
+        # this field; any pass that reconstructs a UniqueSample MUST preserve
+        # it.
         self.surface_form = surface_form
 
     def __str__(self) -> str:

--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -2222,6 +2222,33 @@ class CheckTypeVisitor(VariableTypeVisitor):
                 "Unique sample set must be a parameterized Set<D>",
             )
             return
+        # The two surface forms are distinct constructs (see
+        # frog_ast.UniqueSample). `x <-uniq[S] T` is stateful freshness: it
+        # implicitly inserts the draw into S, so S must be a mutable Set
+        # lvalue (a Set variable/field) or a sampled Function's `.domain`
+        # (the hidden per-RF set). Literal/computed/view exclusion sets have
+        # nowhere to insert and belong to the pure one-shot form
+        # `x <- T \ E`, which carries no insertion.
+        if unique_sample.surface_form == "uniq":
+            exclusion = unique_sample.unique_set
+            is_rf_domain = (
+                isinstance(exclusion, frog_ast.FieldAccess)
+                and exclusion.name == "domain"
+            )
+            is_map_view = isinstance(
+                exclusion, frog_ast.FieldAccess
+            ) and exclusion.name in ("keys", "values", "entries")
+            is_lvalue = isinstance(exclusion, (frog_ast.Variable, frog_ast.FieldAccess))
+            if not is_rf_domain and (is_map_view or not is_lvalue):
+                self.print_error(
+                    unique_sample,
+                    "The `x <-uniq[S] T` form requires S to be a mutable Set "
+                    "variable/field or a sampled Function's `.domain`; got "
+                    f"`{exclusion}`. Use the one-shot exclusion form "
+                    "`x <- T \\ E;` for literal, computed, or view exclusion "
+                    "sets (it performs no insertion).",
+                )
+                return
         # Exclusion-set elements must be values in the sampled-from type,
         # so the sampled type plays the 'declared' role (mirrors
         # `ModInt<q> x = 0;` where ModInt accepts an Int literal).

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -225,6 +225,24 @@ class UniqExclusionBranchEliminationTransformer(BlockTransformer):
             )
         )
 
+    def _note_self_referential_element(self, var_name: str) -> None:
+        if self.ctx is None:
+            return
+        self.ctx.near_misses.append(
+            NearMiss(
+                transform_name="Uniq Exclusion Branch Elimination",
+                reason=(
+                    "Exclusion-set element references the sampled variable "
+                    "itself, so it denotes the variable's pre-draw value; a "
+                    "later equality on that variable cannot be folded to false"
+                ),
+                location=None,
+                suggestion=None,
+                variable=var_name,
+                method=None,
+            )
+        )
+
     @staticmethod
     def _written_var_names(stmt: frog_ast.Statement) -> set[str]:
         """Return the set of variable names written anywhere inside *stmt*.
@@ -246,11 +264,31 @@ class UniqExclusionBranchEliminationTransformer(BlockTransformer):
             if isinstance(
                 node, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
             ):
-                target: frog_ast.ASTNode = node.var
-                while isinstance(target, (frog_ast.ArrayAccess, frog_ast.Slice)):
-                    target = target.the_array
-                if isinstance(target, frog_ast.Variable):
-                    names.add(target.name)
+                # `lvalue_base_name` peels element/slice/field accesses to the
+                # written base name, so `M[k] = v`, `a[i:j] = v`, and the
+                # `X.f = b;` FieldAccess case (the latter previously invisible)
+                # all register a write.
+                base = lvalue_base_name(node.var)
+                if base is not None:
+                    names.add(base)
+                # The stateful `x <-uniq[S] T` form implicitly does
+                # `S = S union {x}`, an adversary-observable write to S. A
+                # constraint whose exclusion element reads S must be
+                # invalidated when a later draw mutates S; tracking only
+                # `node.var` left that constraint folding against a stale
+                # snapshot (F-072). We record the SET lvalue's base name
+                # (`S`, or the function of `F.domain`) via `lvalue_base_name`,
+                # which is None for a literal set (nothing to insert into) so
+                # element variables are not spuriously marked written. The
+                # pure `x <- T \ E` form performs no insertion, so it writes
+                # nothing beyond its target.
+                if (
+                    isinstance(node, frog_ast.UniqueSample)
+                    and node.surface_form == "uniq"
+                ):
+                    set_base = lvalue_base_name(node.unique_set)
+                    if set_base is not None:
+                        names.add(set_base)
             return False
 
         SearchVisitor(_collect).visit(stmt)
@@ -385,9 +423,26 @@ class UniqExclusionBranchEliminationTransformer(BlockTransformer):
             ):
                 extracted = self._exclusion_elements(stmt.unique_set)
                 if extracted is not None:
-                    elems, free_vars = extracted
-                    if elems:
-                        constraints[stmt.var.name] = elems
+                    elems, _ = extracted
+                    # F-070: an exclusion element that mentions the sampled
+                    # variable itself denotes that variable's PRE-draw value.
+                    # After the draw, a later `stmt.var == el` compares the new
+                    # value to the new value (true), but the element snapshot
+                    # records the dead pre-write value, so folding it to false
+                    # is unsound (e.g. `x <-uniq[{x}] T;` then `if (x == x)`).
+                    # Drop any such element; the snapshot is unreliable.
+                    kept = [
+                        el
+                        for el in elems
+                        if stmt.var.name not in self._free_variable_names(el)
+                    ]
+                    if len(kept) != len(elems):
+                        self._note_self_referential_element(stmt.var.name)
+                    if kept:
+                        free_vars: set[str] = set()
+                        for el in kept:
+                            free_vars |= self._free_variable_names(el)
+                        constraints[stmt.var.name] = kept
                         invalidators[stmt.var.name] = free_vars
                 new_stmts.append(stmt)
             else:

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2537,6 +2537,7 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                     frog_ast.Variable(new_name),
                     copy.deepcopy(old.unique_set),
                     copy.deepcopy(old.sampled_from),
+                    old.surface_form,
                 )
             elif isinstance(old, frog_ast.Assignment):
                 new_stmts[def_idx] = frog_ast.Assignment(

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -229,9 +229,14 @@ def _analyze_block(
     uniq_guards: dict[str, str] = {}
 
     for statement in block.statements:
-        # Track <-uniq bindings
-        if isinstance(statement, frog_ast.UniqueSample) and isinstance(
-            statement.var, frog_ast.Variable
+        # Track <-uniq bindings. Only the stateful `<-uniq[S]` form
+        # accumulates draws into S (S = S union {x}); the pure `x <- T \ E`
+        # form performs no insertion, so it does NOT guarantee cross-call
+        # distinctness and must not seed a uniq guard.
+        if (
+            isinstance(statement, frog_ast.UniqueSample)
+            and statement.surface_form == "uniq"
+            and isinstance(statement.var, frog_ast.Variable)
         ):
             set_name = _get_unique_set_name(statement.unique_set)
             # The unique set must be a game field (persistent across oracle
@@ -1207,6 +1212,9 @@ def _proj_tracked_in_set(
     def visit(node: frog_ast.ASTNode) -> bool:
         if (
             isinstance(node, frog_ast.UniqueSample)
+            # Only `<-uniq[S]` inserts the draw into S; `x <- T \ S` does not,
+            # so a minus-form draw is NOT guaranteed to be in set_name.
+            and node.surface_form == "uniq"
             and isinstance(node.var, frog_ast.Variable)
             and isinstance(proj, frog_ast.Variable)
             and node.var.name == proj.name

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -146,15 +146,30 @@ class SimplifySpliceTransformer(BlockTransformer):
                 slices: list[frog_ast.Slice],
                 node: frog_ast.ASTNode,
             ) -> bool:
+                # A UniqueSample (`x <-uniq[S] T` / `x <- T \ S`) rebinds
+                # `x` just like an Assignment/Sample; missing it let a re-bind
+                # of the concat result or a component between the concat and
+                # its slice go unnoticed, so the slice was rewritten to the
+                # stale (pre-rebind) value (F-066).
                 return (
-                    isinstance(node, (frog_ast.Assignment, frog_ast.Sample))
+                    isinstance(
+                        node,
+                        (
+                            frog_ast.Assignment,
+                            frog_ast.Sample,
+                            frog_ast.UniqueSample,
+                        ),
+                    )
                     and (node.var in no_touch_vars)
                 ) or node in slices
 
             made_transformation = False
             while True:
                 to_transform = SearchVisitor[
-                    frog_ast.Assignment | frog_ast.Sample | frog_ast.Slice
+                    frog_ast.Assignment
+                    | frog_ast.Sample
+                    | frog_ast.UniqueSample
+                    | frog_ast.Slice
                 ](
                     functools.partial(
                         use_or_reassignment,
@@ -166,7 +181,14 @@ class SimplifySpliceTransformer(BlockTransformer):
                 )
 
                 if (
-                    isinstance(to_transform, (frog_ast.Assignment, frog_ast.Sample))
+                    isinstance(
+                        to_transform,
+                        (
+                            frog_ast.Assignment,
+                            frog_ast.Sample,
+                            frog_ast.UniqueSample,
+                        ),
+                    )
                     or to_transform is None
                 ):
                     break

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -974,3 +974,150 @@ def test_guarded_field_element_write_not_dropped() -> None:
         """
     )
     assert not _engine_with().check_equivalent(real, random).valid
+
+
+# --------------------------------------------------------------------------
+# RC2 uniq/minus split. The two surface forms are distinct constructs:
+# `x <-uniq[S] T` inserts the draw into S (S = S union {x}, observable),
+# while `x <- T \ E` performs no insertion. The engine must not conflate
+# them, and the observable insertion must survive dead-code elimination.
+# --------------------------------------------------------------------------
+
+
+def test_uniq_sample_is_not_dead_code() -> None:
+    """F-004: an unused `x <-uniq[S]` still mutates S, so its insertion is
+    observable via |S| on a later call. Removing it (as if dead) would erase
+    that effect; the game with the sample is NOT equivalent to the one
+    without it."""
+    with_sample = frog_parser.parse_game(
+        """
+        Game WithSample() {
+            Set<BitString<8>> S;
+            Int Query() {
+                BitString<8> x <-uniq[S] BitString<8>;
+                return 0;
+            }
+            Int Size() { return |S|; }
+        }
+        """
+    )
+    without_sample = frog_parser.parse_game(
+        """
+        Game WithoutSample() {
+            Set<BitString<8>> S;
+            Int Query() {
+                return 0;
+            }
+            Int Size() { return |S|; }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(with_sample, without_sample).valid
+
+
+def test_minus_sample_with_unused_target_is_dead_code() -> None:
+    """Control: the pure `x <- T \\ E` form has no side effect, so an unused
+    draw IS dead code -- the game with it equals the game without it."""
+    with_sample = frog_parser.parse_game(
+        """
+        Game WithSample() {
+            Set<BitString<8>> S;
+            Int Query() {
+                BitString<8> x <- BitString<8> \\ S;
+                return 0;
+            }
+            Int Size() { return |S|; }
+        }
+        """
+    )
+    without_sample = frog_parser.parse_game(
+        """
+        Game WithoutSample() {
+            Set<BitString<8>> S;
+            Int Query() {
+                return 0;
+            }
+            Int Size() { return |S|; }
+        }
+        """
+    )
+    assert _engine_with().check_equivalent(with_sample, without_sample).valid
+
+
+def test_uniq_and_minus_forms_not_equivalent() -> None:
+    """F-093/conflation: a game whose not-(p&&q) path draws via the stateful
+    uniq form is NOT equivalent to one drawing via the pure minus form on the
+    fall-through path -- they differ in the observable |S| after Query(false,
+    false). Previously the engine conflated the forms and accepted the hop."""
+    nested_minus = frog_parser.parse_game(
+        """
+        Game Left() {
+            Set<BitString<8>> S;
+            Int Query(Bool p, Bool q) {
+                if (p) {
+                    if (q) { return 0; }
+                    BitString<8> x <-uniq[S] BitString<8>;
+                    return 1;
+                }
+                BitString<8> y <- BitString<8> \\ S;
+                return 1;
+            }
+            Int Size() { return |S|; }
+        }
+        """
+    )
+    merged_uniq = frog_parser.parse_game(
+        """
+        Game Right() {
+            Set<BitString<8>> S;
+            Int Query(Bool p, Bool q) {
+                if (p && q) { return 0; }
+                BitString<8> x <-uniq[S] BitString<8>;
+                return 1;
+            }
+            Int Size() { return |S|; }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(nested_minus, merged_uniq).valid
+
+
+def test_redundant_conditional_return_uniq_not_collapsed_onto_minus() -> None:
+    """F-089: RedundantConditionalReturn must not collapse a stateful
+    `<-uniq[Seen]` guarded body onto a pure `<- T \\ Seen` fall-through -- doing
+    so deletes the observable `Seen union {x}` insertion. With b always true,
+    Real grows Seen each Draw while Ideal never does, so they are not
+    equivalent (observable via |Seen|)."""
+    real = frog_parser.parse_game(
+        """
+        Game Real() {
+            Set<BitString<8>> Seen;
+            Bool b;
+            Void Initialize() { b = true; }
+            BitString<8> Draw() {
+                if (b) {
+                    BitString<8> x <-uniq[Seen] BitString<8>;
+                    return x;
+                }
+                BitString<8> y <- BitString<8> \\ Seen;
+                return y;
+            }
+            Int Count() { return |Seen|; }
+        }
+        """
+    )
+    ideal = frog_parser.parse_game(
+        """
+        Game Ideal() {
+            Set<BitString<8>> Seen;
+            Bool b;
+            Void Initialize() { b = true; }
+            BitString<8> Draw() {
+                BitString<8> y <- BitString<8> \\ Seen;
+                return y;
+            }
+            Int Count() { return |Seen|; }
+        }
+        """
+    )
+    assert not _engine_with().check_equivalent(real, ideal).valid

--- a/tests/unit/parsing/test_set_minus_sampling.py
+++ b/tests/unit/parsing/test_set_minus_sampling.py
@@ -1,4 +1,10 @@
-"""Tests for surface-sugar ``<- T \\ S`` desugaring to ``<-uniq[S] T``."""
+"""Tests for the ``<- T \\ S`` (set-minus) sampling form.
+
+``x <- T \\ S`` and ``x <-uniq[S] T`` parse to the same ``UniqueSample`` node
+kind but are DISTINCT constructs: ``<-uniq[S]`` is stateful freshness that
+implicitly inserts the draw into ``S`` (``S = S union {x}``), while ``<- T \\ S``
+is a pure one-shot exclusion draw with no insertion. They are recorded by
+``surface_form`` and are NOT equal under ``__eq__`` (RC2 uniq/minus split)."""
 
 import tempfile
 
@@ -46,16 +52,29 @@ def test_sugar_without_type_desugars_to_unique_sample() -> None:
     assert isinstance(stmt.sampled_from, frog_ast.ModIntType)
 
 
-def test_sugar_roundtrips_equal_to_uniq_form() -> None:
-    gf_sugar = _parse_game(
+def test_minus_and_uniq_forms_are_distinct() -> None:
+    # The two surface forms differ semantically (auto-add vs none), so they
+    # must NOT compare equal -- conflating them is the RC2 unsoundness
+    # (F-093/F-089). They differ only in `surface_form`.
+    gf_minus = _parse_game(
         _TEMPLATE.format(stmt="ModInt<5> x <- ModInt<5> \\ {0};")
     )
     gf_uniq = _parse_game(
         _TEMPLATE.format(stmt="ModInt<5> x <-uniq[{0}] ModInt<5>;")
     )
-    s1 = gf_sugar.games[0].methods[0].block.statements[0]
+    s1 = gf_minus.games[0].methods[0].block.statements[0]
     s2 = gf_uniq.games[0].methods[0].block.statements[0]
-    assert s1 == s2
+    assert isinstance(s1, frog_ast.UniqueSample)
+    assert isinstance(s2, frog_ast.UniqueSample)
+    assert s1.surface_form == "minus"
+    assert s2.surface_form == "uniq"
+    assert s1 != s2
+    # ... but two samples of the SAME form with equal operands are equal.
+    gf_minus2 = _parse_game(
+        _TEMPLATE.format(stmt="ModInt<5> x <- ModInt<5> \\ {0};")
+    )
+    s3 = gf_minus2.games[0].methods[0].block.statements[0]
+    assert s1 == s3
 
 
 def test_existing_sample_without_backslash_still_parses() -> None:

--- a/tests/unit/transforms/test_slice_simplification.py
+++ b/tests/unit/transforms/test_slice_simplification.py
@@ -158,3 +158,45 @@ def test_stale_length_after_redeclaration_not_simplified() -> None:
     # correct 2*lambda length for `a`, z[lambda:2*lambda] does not align with a
     # component boundary, so the splice is left intact.
     assert "return b;" not in str(transformed), str(transformed)
+
+
+def test_unique_sample_rebind_blocks_splice() -> None:
+    """F-066: a `<- T \\ S` (or `<-uniq[S]`) rebind of a concat component
+    between the concatenation and a slice use must block the splice rewrite.
+    The slice reads the value at concat time; rewriting it to the re-sampled
+    component would read the wrong (post-rebind) value. The reassignment scan
+    previously saw only Assignment/Sample, so the UniqueSample rebind was
+    invisible and the slice was wrongly rewritten."""
+    method = """
+    Void f() {
+        BitString<lambda> a = g();
+        BitString<lambda> b = g();
+        BitString<2 * lambda> x = a || b;
+        a <- BitString<lambda> \\ {a};
+        BitString<lambda> a2 = x[0 : lambda];
+    }
+    """
+    method_ast = frog_parser.parse_method(method)
+    transformed = SimplifySpliceTransformer({"lambda": Symbol("lambda")}).transform(
+        method_ast
+    )
+    # Unchanged: the slice is not rewritten to the re-sampled `a`.
+    assert transformed == frog_parser.parse_method(method)
+
+
+def test_unrelated_unique_sample_does_not_block_splice() -> None:
+    """Control: a UniqueSample rebind of an UNRELATED variable does not block
+    the splice; `a2 = x[0:lambda]` still rewrites to `a`."""
+    method = """
+    Void f() {
+        BitString<lambda> a = g();
+        BitString<lambda> b = g();
+        BitString<2 * lambda> x = a || b;
+        BitString<lambda> c <- BitString<lambda> \\ {a};
+        BitString<lambda> a2 = x[0 : lambda];
+    }
+    """
+    transformed = SimplifySpliceTransformer({"lambda": Symbol("lambda")}).transform(
+        frog_parser.parse_method(method)
+    )
+    assert "a2 = a;" in str(transformed), str(transformed)

--- a/tests/unit/transforms/test_uniq_exclusion_branch_elim.py
+++ b/tests/unit/transforms/test_uniq_exclusion_branch_elim.py
@@ -341,3 +341,108 @@ def test_uniq_exclusion_fires_on_deterministic_control() -> None:
     ctx = _ctx_with()
     result = UniqExclusionBranchElimination().apply(game, ctx)
     assert result != game  # the comparison was folded to false
+
+
+# ---------------------------------------------------------------------------
+# RC2 self-reference guard (F-070): an exclusion element that mentions the
+# sampled variable itself denotes the variable's pre-draw value, so a later
+# equality on that variable must NOT be folded (`x <- T \\ {x}; if (x == x)`).
+# ---------------------------------------------------------------------------
+
+
+def test_uniq_exclusion_self_reference_not_folded() -> None:
+    method = frog_parser.parse_method("""
+        Int f() {
+            BitString<8> x <- BitString<8>;
+            x <- BitString<8> \\ {x};
+            if (x == x) {
+                return 1;
+            }
+            return 0;
+        }
+        """)
+    ctx = _ctx_with()
+    transformer = UniqExclusionBranchEliminationTransformer(ctx)
+    transformed = transformer.transform(method)
+    assert transformed == method  # x == x not folded to false
+    assert any(
+        nm.transform_name == "Uniq Exclusion Branch Elimination"
+        and "pre-draw" in nm.reason
+        for nm in ctx.near_misses
+    )
+
+
+def test_uniq_exclusion_keeps_non_self_elements() -> None:
+    """Control: a self-referential element is dropped but a sibling
+    non-self element still folds (`c <- T \\ {a, c}` keeps the `a` exclusion)."""
+    method = frog_parser.parse_method("""
+        Int f() {
+            BitString<8> a <- BitString<8>;
+            BitString<8> c <- BitString<8> \\ {a, c};
+            if (c == a) {
+                return 1;
+            }
+            return 0;
+        }
+        """)
+    transformer = UniqExclusionBranchEliminationTransformer(_ctx_with())
+    transformed = transformer.transform(method)
+    expected = frog_parser.parse_method("""
+        Int f() {
+            BitString<8> a <- BitString<8>;
+            BitString<8> c <- BitString<8> \\ {a, c};
+            if (false) {
+                return 1;
+            }
+            return 0;
+        }
+        """)
+    assert transformed == expected
+
+
+# ---------------------------------------------------------------------------
+# RC2 auto-add tracking (F-072): the stateful `<-uniq[S]` form implicitly
+# inserts into S, so a constraint whose element reads S must be invalidated
+# when a later draw mutates S; otherwise it folds against a stale snapshot.
+# ---------------------------------------------------------------------------
+
+
+def test_uniq_exclusion_invalidated_by_later_auto_add() -> None:
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Set<BitString<8>> S;
+            Array<BitString<8>, n> A;
+            Bool Oracle() {
+                BitString<8> x <- BitString<8> \\ {A[|S|]};
+                BitString<8> z <-uniq[S] BitString<8>;
+                if (x == A[|S|]) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """)
+    ctx = _ctx_with()
+    result = UniqExclusionBranchElimination().apply(game, ctx)
+    assert result == game  # |S| changed by the auto-add: no fold
+
+
+def test_uniq_exclusion_folds_without_intervening_auto_add() -> None:
+    """Control: with no later mutation of S, the `x != A[|S|]` constraint
+    holds and the comparison folds to false."""
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Set<BitString<8>> S;
+            Array<BitString<8>, n> A;
+            Bool Oracle() {
+                BitString<8> x <- BitString<8> \\ {A[|S|]};
+                if (x == A[|S|]) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """)
+    ctx = _ctx_with()
+    result = UniqExclusionBranchElimination().apply(game, ctx)
+    assert result != game  # folded to false

--- a/tests/unit/typechecking/test_modint_type_checking.py
+++ b/tests/unit/typechecking/test_modint_type_checking.py
@@ -50,8 +50,11 @@ class TestModIntSampling:
 
 
 class TestModIntUniqSample:
-    def test_uniq_excludes_zero_literal(self) -> None:
-        _check_game("""
+    def test_uniq_literal_exclusion_rejected(self) -> None:
+        # The stateful `<-uniq[S]` form requires a mutable Set lvalue (or an
+        # RF `.domain`); a literal exclusion set has nowhere to insert and
+        # belongs to the pure `<- T \\ {0}` form (RC2 uniq/minus split).
+        _check_game_fails("""
             Game G(Int q) {
                 Void Initialize() {
                     ModInt<q> a <-uniq[{0}] ModInt<q>;
@@ -59,11 +62,22 @@ class TestModIntUniqSample:
             }
             """)
 
-    def test_uniq_excludes_multiple_literals(self) -> None:
-        _check_game("""
+    def test_uniq_multiple_literals_rejected(self) -> None:
+        _check_game_fails("""
             Game G(Int q) {
                 Void Initialize() {
                     ModInt<q> a <-uniq[{0, 1, 2}] ModInt<q>;
+                }
+            }
+            """)
+
+    def test_uniq_mutable_set_field_accepted(self) -> None:
+        # The mutable Set lvalue form is the valid `<-uniq[S]` use.
+        _check_game("""
+            Game G(Int q) {
+                Set<ModInt<q>> seen;
+                Void Initialize() {
+                    ModInt<q> a <-uniq[seen] ModInt<q>;
                 }
             }
             """)

--- a/tests/unit/typechecking/test_uniq_minus_split.py
+++ b/tests/unit/typechecking/test_uniq_minus_split.py
@@ -1,0 +1,119 @@
+"""Typechecker rules for the RC2 uniq/minus split.
+
+`x <-uniq[S] T` is the stateful freshness form: it implicitly inserts the draw
+into S, so S must be a mutable Set lvalue (a Set variable/field) or a sampled
+Function's `.domain`. `x <- T \\ E` is the pure one-shot exclusion draw: E may
+be any set-valued expression (literal, view, computed) and there is no
+insertion. See `proof_frog/semantic_analysis.py::leave_unique_sample`.
+"""
+
+import pytest
+
+from proof_frog import frog_parser, semantic_analysis
+
+
+def _check_game(source: str) -> None:
+    game = frog_parser.parse_game(source)
+    visitor = semantic_analysis.CheckTypeVisitor({}, "test", {})
+    visitor.visit(game)
+
+
+def _check_game_fails(source: str) -> None:
+    with pytest.raises(semantic_analysis.FailedTypeCheck):
+        _check_game(source)
+
+
+# --- uniq form: accepted lvalues ------------------------------------------
+
+
+def test_uniq_set_field_accepted() -> None:
+    _check_game("""
+        Game G() {
+            Set<BitString<8>> seen;
+            Void Initialize() {
+                BitString<8> a <-uniq[seen] BitString<8>;
+            }
+        }
+        """)
+
+
+def test_uniq_rf_domain_accepted() -> None:
+    _check_game("""
+        Game G() {
+            Function<BitString<8>, BitString<8>> H;
+            Void Initialize() {
+                BitString<8> a <-uniq[H.domain] BitString<8>;
+            }
+        }
+        """)
+
+
+# --- uniq form: rejected non-lvalues --------------------------------------
+
+
+def test_uniq_literal_set_rejected() -> None:
+    _check_game_fails("""
+        Game G() {
+            Void Initialize() {
+                BitString<8> a <-uniq[{0b00000000}] BitString<8>;
+            }
+        }
+        """)
+
+
+def test_uniq_map_keys_view_rejected() -> None:
+    _check_game_fails("""
+        Game G() {
+            Map<BitString<8>, BitString<8>> M;
+            Void Initialize() {
+                BitString<8> a <-uniq[M.keys] BitString<8>;
+            }
+        }
+        """)
+
+
+def test_uniq_computed_set_expression_rejected() -> None:
+    _check_game_fails("""
+        Game G() {
+            Set<BitString<8>> S;
+            Set<BitString<8>> T;
+            Void Initialize() {
+                BitString<8> a <-uniq[S union T] BitString<8>;
+            }
+        }
+        """)
+
+
+# --- minus form: any set-valued exclusion accepted -------------------------
+
+
+def test_minus_literal_accepted() -> None:
+    _check_game("""
+        Game G() {
+            Void Initialize() {
+                BitString<8> a <- BitString<8> \\ {0b00000000};
+            }
+        }
+        """)
+
+
+def test_minus_map_keys_view_accepted() -> None:
+    _check_game("""
+        Game G() {
+            Map<BitString<8>, BitString<8>> M;
+            Void Initialize() {
+                BitString<8> a <- BitString<8> \\ M.keys;
+            }
+        }
+        """)
+
+
+def test_minus_set_field_accepted() -> None:
+    _check_game("""
+        Game G() {
+            Set<BitString<8>> S;
+            Void Initialize() {
+                BitString<8> a <- BitString<8> \\ S;
+            }
+        }
+        """)


### PR DESCRIPTION
Make `x <-uniq[S] T` (stateful freshness; implicitly does S = S union {x}) and `x <- T \ E` (pure one-shot exclusion draw; no insertion) the distinct constructs they semantically are, instead of one node distinguished only by a presentational `surface_form` flag.

- frog_ast: `surface_form` is now compared in `ASTNode.__eq__`, so the two forms no longer compare equal. inlining.py's UniqueSample reconstruction now preserves the form.
- semantic_analysis: a `<-uniq[S]` exclusion set must be a mutable Set lvalue (Set variable/field) or a sampled Function's `.domain`; literal, computed, and map-view exclusion sets must use the `\` form, which carries no insertion.
- SimplifySplice: the reassignment scan now sees a UniqueSample rebind, so a re-bind of a concat result or component between the concat and a slice blocks the splice rewrite (F-066).
- UniqExclusionBranchElimination: drop an exclusion element that names the sampled variable itself (it denotes the pre-draw value, so `x == x` must not fold) (F-070); `_written_var_names` records the uniq auto-add write to the set lvalue and FieldAccess lvalues, so a constraint reading S is invalidated when a later draw mutates S (F-072).
- random_functions: cross-call distinctness reasoning requires the uniq form.
- dependencies: the dead-code movers treat a uniq-form draw as a side-effecting field write, so its observable S insertion is never pruned as dead code (unnecessary_statement_info + generate_dependency_graph.mutates_field); the minus form stays removable when its target is unused (F-004).

Closes F-066, F-070, F-072, F-089, F-093, F-103, F-004. Examples using the uniq-literal spelling are migrated to the `\` form in the examples submodule working tree (not committed here).