### PR TITLE
Fix Z3/equivalence-layer soundness holes (RC7: F-017, F-106, F-139, F-140)

### DIFF
--- a/proof_frog/transforms/_wrappers.py
+++ b/proof_frog/transforms/_wrappers.py
@@ -497,8 +497,25 @@ class _GroupExpShape(WrapperShape):
             )
         k_expr = self.k_expr
         if isinstance(k_expr, frog_ast.Integer):
-            if k_expr.num == 0:  # pylint: disable=no-member
-                misses.append("exponent k is the literal 0; x^0 is not injective")
+            # On a group of (symbolic) prime order q, `x ↦ x^k` is injective
+            # iff `q` does not divide `k` (equivalently gcd(k, q) == 1).  For
+            # a LITERAL exponent and an UNKNOWN prime q (only `q is prime` is
+            # asserted, so q ranges over every prime >= 2), the only values
+            # provably coprime to every such q are k = +/-1: any |k| >= 2 has
+            # a prime factor p, and the instantiation q = p makes x^k =
+            # G.identity for all x, collapsing every key (F-139, e.g. q = 3,
+            # k = 3).  Reject any literal other than +/-1.
+            if abs(k_expr.num) != 1:  # pylint: disable=no-member
+                if k_expr.num == 0:  # pylint: disable=no-member
+                    misses.append("exponent k is the literal 0; x^0 is not injective")
+                else:
+                    misses.append(
+                        f"exponent k is the literal {k_expr.num}; on a group of "
+                        f"symbolic prime order q the map x^k is injective only "
+                        f"when q does not divide k, which a literal |k| >= 2 "
+                        f"cannot guarantee (q = a prime factor of k collapses "
+                        f"every key)"
+                    )
         elif isinstance(k_expr, frog_ast.Variable):
             if not is_known_nonzero(k_expr.name, game):
                 misses.append(
@@ -506,6 +523,18 @@ class _GroupExpShape(WrapperShape):
                     f"sample it via `<-uniq[{{0}}] T` (or `<- T \\ {{0}}`) "
                     f"so the engine can treat x^{k_expr.name} as injective"
                 )
+        else:
+            # F-140: a compound exponent expression (e.g. `k1 * k2`, a
+            # FuncCall, ...) is neither a literal nor a single variable, so
+            # the engine cannot certify it is nonzero / coprime to q.  Without
+            # an explicit fallback such a form silently passed every check and
+            # could evaluate to 0 (e.g. a product of plain uniform samples),
+            # making x^0 = G.identity and collapsing every key.  Refuse.
+            misses.append(
+                f"exponent `{k_expr}` is a compound expression that is not "
+                f"known-nonzero; the engine can only certify x^k injective "
+                f"for a literal +/-1 or a known-nonzero variable"
+            )
         return misses
 
 

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -997,13 +997,53 @@ class _DistinctConstRFTransformer(BlockTransformer):
                     )
                 continue
 
-            # No overflow guard is needed here: the typechecker assigns
-            # every BinaryNum its concrete source-level width, every
-            # BitStringLiteral its declared length, and the well-formedness
-            # of the call site guarantees every argument typechecks against
-            # the RF's declared domain type.  Two arguments at the same call
-            # site therefore always have the same bit width, and pairwise
-            # distinct keys always represent pairwise distinct bitstrings.
+            # Distinct keys imply distinct bitstrings ONLY when the shared
+            # bit length is a concrete integer >= 1 (F-017).  At length 0 the
+            # type ``BitString<0>`` has a single inhabitant (the empty
+            # string), so EVERY literal -- including ``0^n`` and ``1^n``,
+            # whose keys ("0" vs "allones:n") are textually distinct --
+            # denotes the SAME value.  For a SYMBOLIC length ``n`` the engine
+            # cannot rule out ``n == 0`` (the positivity of a symbolic Int
+            # parameter is unruled; USER-ATTENTION 7.A), so distinct keys can
+            # no longer be trusted to mean distinct inputs and the two RF
+            # evaluations may collapse onto one point.  Require a concrete
+            # length >= 1 before treating the points as distinct.
+            assert literal_lengths  # all_literal implies a non-empty list
+            shared_length = literal_lengths[0]
+            if not (
+                isinstance(shared_length, frog_ast.Integer) and shared_length.num >= 1
+            ):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Distinct Const RF To Uniform",
+                            reason=(
+                                f"RF '{rf_name}' literal arguments have bit "
+                                f"length '{shared_length}', which is not a "
+                                "concrete integer >= 1; at length 0 all "
+                                "literals denote the empty string, so distinct "
+                                "keys cannot be trusted to mean distinct inputs"
+                            ),
+                            location=stmt.origin,
+                            suggestion=(
+                                "Use a concrete-width domain (e.g. "
+                                "BitString<1>) so distinctness of the RF "
+                                "inputs is guaranteed"
+                            ),
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
+                continue
+
+            # With a concrete length >= 1, no overflow guard is needed: the
+            # typechecker assigns every BinaryNum its concrete source-level
+            # width, every BitStringLiteral its declared length, and the
+            # well-formedness of the call site guarantees every argument
+            # typechecks against the RF's declared domain type.  Two arguments
+            # at the same call site therefore always have the same bit width,
+            # and pairwise distinct keys always represent pairwise distinct
+            # bitstrings.
 
             # Extract every RF call into a standalone assignment so that
             # _RFCallReplacer can rewrite them uniformly into fresh samples.

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -695,7 +695,16 @@ _OPAQUE_Z3_SORT = z3.DeclareSort("Opaque")
 
 def _z3_var_for_type(name: str, var_type: frog_ast.Type) -> z3.ExprRef:
     """Create a Z3 variable of the appropriate sort for a FrogLang type."""
-    if isinstance(var_type, (frog_ast.IntType, frog_ast.ModIntType)):
+    # NOTE (F-106): ``IntType`` maps to ``z3.Int`` (unbounded integers, the
+    # exact FrogLang semantics), but ``ModIntType`` does NOT.  ``ModInt<q>``
+    # arithmetic reduces mod q, which ``z3.Int`` does not model, so encoding
+    # `+`/`-`/`*` over a z3.Int makes wraparound-true conditions falsely
+    # unsat.  Modelling a ModInt value as an uninterpreted opaque constant is
+    # a sound over-approximation (Z3 treats it as a free variable, so it can
+    # only ever prove FEWER formulas UNSAT, never more): arithmetic over two
+    # opaque consts raises in Z3 and falls back to "untranslatable", while
+    # genuine same-atom equality (``x == x``) is still recognised.
+    if isinstance(var_type, frog_ast.IntType):
         return z3.Int(name)
     if isinstance(var_type, frog_ast.BoolType):
         return z3.Bool(name)
@@ -821,7 +830,10 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
         if self.variable_version_map and name in self.variable_version_map:
             name = f"{name}@z3@{self.variable_version_map[name]}"
         var_type = self.type_map.get(var.name)
-        if isinstance(var_type, (frog_ast.IntType, frog_ast.ModIntType)):
+        # ModIntType is deliberately NOT modelled as z3.Int -- see _z3_var_for_type
+        # (F-106): mod-q arithmetic differs from unbounded Int, so a ModInt is
+        # interned as an opaque const (the final ``else`` branch) instead.
+        if isinstance(var_type, frog_ast.IntType):
             self.stack.append(z3.Int(name))
         elif isinstance(var_type, frog_ast.BoolType):
             self.stack.append(z3.Bool(name))

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -51,26 +51,21 @@ def _engine_with(**namespace) -> ProofEngine:
 
 def _two_prim_namespace() -> dict:
     """Namespace with a deterministic primitive H and a non-det primitive F."""
-    h = frog_parser.parse_primitive_file(
-        """
+    h = frog_parser.parse_primitive_file("""
         Primitive H(Int n) {
             deterministic BitString<n> det(BitString<n> x);
         }
-        """
-    )
-    f = frog_parser.parse_primitive_file(
-        """
+        """)
+    f = frog_parser.parse_primitive_file("""
         Primitive F(Int n) {
             BitString<n> nondet(BitString<n> x);
         }
-        """
-    )
+        """)
     return {"H": h, "F": f, "HH": h, "FF": f}
 
 
 def _game(return_expr: str):
-    return frog_parser.parse_game(
-        f"""
+    return frog_parser.parse_game(f"""
         Game Foo(H HH, F FF) {{
             BitString<n> seed;
             Void Initialize() {{
@@ -80,8 +75,7 @@ def _game(return_expr: str):
                 return {return_expr};
             }}
         }}
-        """
-    )
+        """)
 
 
 def test_z3_residual_refuses_on_nondeterministic_return() -> None:
@@ -148,15 +142,12 @@ def test_dedup_deterministic_if_condition_multicall() -> None:
     in both an if-condition and the fall-through return, is observably
     identical to the hand-deduplicated form across repeated oracle
     invocations."""
-    prim = frog_parser.parse_primitive_file(
-        """
+    prim = frog_parser.parse_primitive_file("""
         Primitive G(Int n) {
             deterministic BitString<n> evaluate(BitString<n> x);
         }
-        """
-    )
-    pre = frog_parser.parse_game(
-        """
+        """)
+    pre = frog_parser.parse_game("""
         Game Pre(G GG) {
             BitString<n> seed;
             Void Initialize() {
@@ -169,10 +160,8 @@ def test_dedup_deterministic_if_condition_multicall() -> None:
                 return GG.evaluate(seed);
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post(G GG) {
             BitString<n> seed;
             Void Initialize() {
@@ -186,8 +175,7 @@ def test_dedup_deterministic_if_condition_multicall() -> None:
                 return v;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with(G=prim, GG=prim)
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -200,15 +188,12 @@ def test_split_opaque_tuple_field_multicall() -> None:
     component-split form. The two oracles witness the multi-call
     observation — each pins one tuple slot — so an unsound split that
     re-sampled per call would diverge."""
-    prim = frog_parser.parse_primitive_file(
-        """
+    prim = frog_parser.parse_primitive_file("""
         Primitive K(Int n) {
             deterministic [BitString<n>, BitString<n>] Gen(BitString<n> seed);
         }
-        """
-    )
-    pre = frog_parser.parse_game(
-        """
+        """)
+    pre = frog_parser.parse_game("""
         Game Pre(K KK) {
             BitString<n> seed;
             [BitString<n>, BitString<n>] keys;
@@ -223,10 +208,8 @@ def test_split_opaque_tuple_field_multicall() -> None:
                 return keys[1];
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post(K KK) {
             BitString<n> seed;
             BitString<n> keys_0;
@@ -244,8 +227,7 @@ def test_split_opaque_tuple_field_multicall() -> None:
                 return keys_1;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with(K=prim, KK=prim)
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -258,8 +240,7 @@ def test_flatten_concat_chain_multicall() -> None:
     flattened form. Both forms must observe the same field values per
     call — a buggy flatten that reordered the operands would
     distinguish here."""
-    pre = frog_parser.parse_game(
-        """
+    pre = frog_parser.parse_game("""
         Game Pre() {
             BitString<n> a;
             BitString<n> b;
@@ -273,10 +254,8 @@ def test_flatten_concat_chain_multicall() -> None:
                 return a || (b || c);
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post() {
             BitString<n> a;
             BitString<n> b;
@@ -290,8 +269,7 @@ def test_flatten_concat_chain_multicall() -> None:
                 return (a || b) || c;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -305,8 +283,7 @@ def test_absorb_redundant_early_return_multicall() -> None:
     one return value depend on shared state — an unsound absorption
     that dropped the early-return path would change observable
     behaviour for inputs satisfying ``P``."""
-    pre = frog_parser.parse_game(
-        """
+    pre = frog_parser.parse_game("""
         Game Pre() {
             BitString<n> stash;
             Void Initialize() {
@@ -323,10 +300,8 @@ def test_absorb_redundant_early_return_multicall() -> None:
                 return stash;
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post() {
             BitString<n> stash;
             Void Initialize() {
@@ -340,8 +315,7 @@ def test_absorb_redundant_early_return_multicall() -> None:
                 return stash;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -364,8 +338,7 @@ def test_lazy_map_scan_multicall() -> None:
     on a shared ``Map<K, V>`` field is observably identical to direct
     membership-test + lookup, across multiple oracle calls that read
     keys populated by earlier writes."""
-    pre = frog_parser.parse_game(
-        """
+    pre = frog_parser.parse_game("""
         Game Pre() {
             Map<BitString<8>, BitString<16>> M;
             Void Store(BitString<8> k, BitString<16> v) {
@@ -380,10 +353,8 @@ def test_lazy_map_scan_multicall() -> None:
                 return 0b0000000000000000;
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post() {
             Map<BitString<8>, BitString<16>> M;
             Void Store(BitString<8> k, BitString<16> v) {
@@ -396,8 +367,7 @@ def test_lazy_map_scan_multicall() -> None:
                 return 0b0000000000000000;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -409,17 +379,14 @@ def test_map_key_reindex_multicall() -> None:
     Eval'd value (and rewriting writes accordingly) preserves cross-call
     observation. Store and Lookup are separate oracles so any mismatch
     between the rewritten write site and the read site would surface."""
-    prim = frog_parser.parse_primitive_file(
-        """
+    prim = frog_parser.parse_primitive_file("""
         Primitive T(Set I, Set Y) {
             Set Input = I;
             Set Image = Y;
             deterministic injective Image Eval(Input x);
         }
-        """
-    )
-    pre = frog_parser.parse_game(
-        """
+        """)
+    pre = frog_parser.parse_game("""
         Game Pre(T TT) {
             Map<TT.Input, BitString<16>> M;
             Void Store(TT.Input a, BitString<16> s) {
@@ -432,10 +399,8 @@ def test_map_key_reindex_multicall() -> None:
                 return None;
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post(T TT) {
             Map<TT.Image, BitString<16>> M;
             Void Store(TT.Input a, BitString<16> s) {
@@ -448,11 +413,39 @@ def test_map_key_reindex_multicall() -> None:
                 return None;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with(T=prim, TT=prim)
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
+
+
+def test_distinct_const_rf_symbolic_length_not_uniform() -> None:
+    """RC7 / F-017: a freshly-sampled RF evaluated at ``0^n`` and ``1^n`` for a
+    SYMBOLIC length ``n`` must NOT canonicalize to two independent uniforms.
+    At ``n == 0`` both literals denote the empty string, so the RF is queried
+    at a single point and both halves are EQUAL -- distinguishable from two
+    independent draws (which differ w.p. ``1 - 2^-1``).  Since the engine
+    cannot rule out ``n == 0``, certifying the equivalence is unsound; the
+    conservative-correct outcome is to refuse."""
+    real = frog_parser.parse_game("""
+        Game Real() {
+            BitString<2> Challenge() {
+                Function<BitString<n>, BitString<1>> RF;
+                RF <- Function<BitString<n>, BitString<1>>;
+                return RF(0^n) || RF(1^n);
+            }
+        }
+        """)
+    random = frog_parser.parse_game("""
+        Game Random() {
+            BitString<2> Challenge() {
+                BitString<1> a <- BitString<1>;
+                BitString<1> b <- BitString<1>;
+                return a || b;
+            }
+        }
+        """)
+    assert not _engine_with().check_equivalent(real, random).valid
 
 
 def test_lazy_map_to_sampled_function_multicall() -> None:
@@ -461,8 +454,7 @@ def test_lazy_map_to_sampled_function_multicall() -> None:
     observably identical to a single sampled ``Function<D, R>`` lookup
     across repeated calls with both fresh and repeated keys — the
     consistency property is exactly the random-function semantics."""
-    pre = frog_parser.parse_game(
-        """
+    pre = frog_parser.parse_game("""
         Game Pre() {
             Map<BitString<8>, BitString<16>> T;
             BitString<16> Hash(BitString<8> x) {
@@ -474,10 +466,8 @@ def test_lazy_map_to_sampled_function_multicall() -> None:
                 return s;
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post() {
             Function<BitString<8>, BitString<16>> T;
             Void Initialize() {
@@ -487,8 +477,7 @@ def test_lazy_map_to_sampled_function_multicall() -> None:
                 return T(x);
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -500,8 +489,7 @@ def test_lazy_map_pair_to_sampled_function_multicall() -> None:
     collapse to a single sampled ``Function<D, R>`` shared by both
     oracles. The cross-oracle consistency (calling QueryA then QueryB
     on the same key) is the multi-call observation under test."""
-    pre = frog_parser.parse_game(
-        """
+    pre = frog_parser.parse_game("""
         Game Pre() {
             Map<BitString<8>, BitString<16>> M1;
             Map<BitString<8>, BitString<16>> M2;
@@ -520,10 +508,8 @@ def test_lazy_map_pair_to_sampled_function_multicall() -> None:
                 return s;
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post() {
             Function<BitString<8>, BitString<16>> F;
             Void Initialize() {
@@ -536,8 +522,7 @@ def test_lazy_map_pair_to_sampled_function_multicall() -> None:
                 return F(k);
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -550,15 +535,12 @@ def test_hoist_deterministic_call_to_initialize_multicall() -> None:
     observation: every call to either oracle returns the same value,
     which holds iff the cached field is computed once at Initialize and
     referenced thereafter."""
-    prim = frog_parser.parse_primitive_file(
-        """
+    prim = frog_parser.parse_primitive_file("""
         Primitive G(Int n) {
             deterministic BitString<n> evaluate(BitString<n> x);
         }
-        """
-    )
-    pre = frog_parser.parse_game(
-        """
+        """)
+    pre = frog_parser.parse_game("""
         Game Pre(G GG) {
             BitString<n> seed;
             Void Initialize() {
@@ -571,10 +553,8 @@ def test_hoist_deterministic_call_to_initialize_multicall() -> None:
                 return GG.evaluate(seed);
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post(G GG) {
             BitString<n> seed;
             BitString<n> cached;
@@ -589,8 +569,7 @@ def test_hoist_deterministic_call_to_initialize_multicall() -> None:
                 return cached;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with(G=prim, GG=prim)
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -602,8 +581,7 @@ def test_hoist_group_exp_to_initialize_multicall() -> None:
     Initialize lets the power-of-power be cached. Multi-call observation:
     every Hash call returns the same group element — the caching field
     must be Initialize-computed, not re-derived per call."""
-    pre = frog_parser.parse_game(
-        """
+    pre = frog_parser.parse_game("""
         Game Pre(Group G) {
             ModInt<G.order> field2;
             GroupElem<G> field1;
@@ -616,10 +594,8 @@ def test_hoist_group_exp_to_initialize_multicall() -> None:
                 return z == field1 ^ field2;
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post(Group G) {
             ModInt<G.order> field2;
             GroupElem<G> field1;
@@ -634,8 +610,7 @@ def test_hoist_group_exp_to_initialize_multicall() -> None:
                 return z == _hge_0;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -647,8 +622,7 @@ def test_refactor_group_elem_field_exp_multicall() -> None:
     ``field2 ^ b`` (power-of-power). A reader oracle exposes both
     fields across calls; the rewrite must agree on every call —
     otherwise a stale or per-call recomputation would diverge."""
-    pre = frog_parser.parse_game(
-        """
+    pre = frog_parser.parse_game("""
         Game Pre(Group G) {
             GroupElem<G> field1;
             GroupElem<G> field2;
@@ -667,10 +641,8 @@ def test_refactor_group_elem_field_exp_multicall() -> None:
                 return field2;
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post(Group G) {
             GroupElem<G> field1;
             GroupElem<G> field2;
@@ -689,8 +661,7 @@ def test_refactor_group_elem_field_exp_multicall() -> None:
                 return field2;
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     result = engine.check_equivalent(pre, post)
     assert result.valid, result.failure_detail
@@ -713,8 +684,7 @@ def test_refactor_group_elem_field_exp_multicall() -> None:
 def test_reject_read_moved_past_uniq_insertion() -> None:
     """`<-uniq[S]` inserts the draw into S, so `|S|` read before vs after the
     draw differs.  Must not be accepted as equivalent."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real() {
             Set<BitString<2>> S;
             BitString<2> t;
@@ -727,10 +697,8 @@ def test_reject_read_moved_past_uniq_insertion() -> None:
             }
             BitString<2> Peek() { return t; }
         }
-        """
-    )
-    random = frog_parser.parse_game(
-        """
+        """)
+    random = frog_parser.parse_game("""
         Game Random() {
             Set<BitString<2>> S;
             BitString<2> t;
@@ -742,16 +710,14 @@ def test_reject_read_moved_past_uniq_insertion() -> None:
             }
             BitString<2> Peek() { return t; }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(real, random).valid
 
 
 def test_reject_read_moved_past_map_write_via_fieldaccess_view() -> None:
     """`|M.keys|` reaches M only through a FieldAccess view; moving it past the
     element write `M[0]=1` changes its value.  Must not be accepted."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real() {
             Map<Int, Int> M;
             [Int, Int] O() {
@@ -761,10 +727,8 @@ def test_reject_read_moved_past_map_write_via_fieldaccess_view() -> None:
             }
             Int Size() { return M[0]; }
         }
-        """
-    )
-    random = frog_parser.parse_game(
-        """
+        """)
+    random = frog_parser.parse_game("""
         Game Random() {
             Map<Int, Int> M;
             [Int, Int] O() {
@@ -773,16 +737,14 @@ def test_reject_read_moved_past_map_write_via_fieldaccess_view() -> None:
             }
             Int Size() { return M[0]; }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(real, random).valid
 
 
 def test_reject_read_moved_past_nested_element_write() -> None:
     """A read of `M[0]` moved past the nested element write `M[0][1]=1`
     observes the mutated value.  Must not be accepted."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real() {
             Map<Int, [Int, Int]> M;
             Void Initialize() { M[0] = [0, 0]; }
@@ -792,10 +754,8 @@ def test_reject_read_moved_past_nested_element_write() -> None:
                 return s;
             }
         }
-        """
-    )
-    random = frog_parser.parse_game(
-        """
+        """)
+    random = frog_parser.parse_game("""
         Game Random() {
             Map<Int, [Int, Int]> M;
             Void Initialize() { M[0] = [0, 0]; }
@@ -804,8 +764,7 @@ def test_reject_read_moved_past_nested_element_write() -> None:
                 return M[0];
             }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(real, random).valid
 
 
@@ -827,26 +786,22 @@ def test_slice_of_concat_z3_residual_distinct_operands() -> None:
     compare equal to `(s || s)[0:2n]`. The slice was previously modelled by
     its width alone (`@@@opaque@...@2 * n`), collapsing distinct operands to
     one atom. No shadowing here -- this is the bare equivalence-layer hole."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real(Int n) {
             BitString<2 * n> Oracle(BitString<n> b) {
                 BitString<n> s <- BitString<n>;
                 return (s || b)[0 : 2 * n];
             }
         }
-        """
-    )
-    random = frog_parser.parse_game(
-        """
+        """)
+    random = frog_parser.parse_game("""
         Game Random(Int n) {
             BitString<2 * n> Oracle(BitString<n> b) {
                 BitString<n> s <- BitString<n>;
                 return (s || s)[0 : 2 * n];
             }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(real, random).valid
 
 
@@ -855,8 +810,7 @@ def test_slice_of_concat_decl_shadow_param() -> None:
     parameter `x`. The bare declaration must survive TopologicalSort /
     RemoveUnnecessary so `x` keeps its n-bit binding, and the slice must not
     be rewritten to `x` (dropping `b`)."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real(Int n) {
             BitString<2 * n> Oracle(BitString<2 * n> x, BitString<n> b) {
                 BitString<n> x;
@@ -864,10 +818,8 @@ def test_slice_of_concat_decl_shadow_param() -> None:
                 return (x || b)[0 : 2 * n];
             }
         }
-        """
-    )
-    random = frog_parser.parse_game(
-        """
+        """)
+    random = frog_parser.parse_game("""
         Game Random(Int n) {
             BitString<2 * n> Oracle(BitString<2 * n> x, BitString<n> b) {
                 BitString<n> x;
@@ -875,8 +827,7 @@ def test_slice_of_concat_decl_shadow_param() -> None:
                 return (x || x)[0 : 2 * n];
             }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(real, random).valid
 
 
@@ -886,8 +837,7 @@ def test_slice_of_concat_nested_redecl_case2() -> None:
     not merge the two `a`s across the scope boundary into a mistyped
     `BitString<k> a <- BitString<k + m>`, which would let the Case 2 slice
     fold to `b`."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real(Int k, Int m) {
             [BitString<m>, BitString<m>] Oracle(Bool cond, BitString<m> b) {
                 BitString<k> a <- BitString<k>;
@@ -898,17 +848,14 @@ def test_slice_of_concat_nested_redecl_case2() -> None:
                 return [b, b];
             }
         }
-        """
-    )
-    random = frog_parser.parse_game(
-        """
+        """)
+    random = frog_parser.parse_game("""
         Game Random(Int k, Int m) {
             [BitString<m>, BitString<m>] Oracle(Bool cond, BitString<m> b) {
                 return [b, b];
             }
         }
-        """
-    )
+        """)
     engine = _engine_with()
     engine.variables["k"] = Symbol("k", positive=True, integer=True)
     engine.variables["m"] = Symbol("m", positive=True, integer=True)
@@ -918,24 +865,20 @@ def test_slice_of_concat_nested_redecl_case2() -> None:
 def test_slice_of_concat_sound_identity_still_fires() -> None:
     """Control: the genuine identity `(a || b)[0 : |a|] = a` must STILL be
     recognized -- the fixes restrict the unsound cases, not the sound one."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real(Int n) {
             BitString<n> Oracle(BitString<n> a, BitString<n> b) {
                 return (a || b)[0 : n];
             }
         }
-        """
-    )
-    post = frog_parser.parse_game(
-        """
+        """)
+    post = frog_parser.parse_game("""
         Game Post(Int n) {
             BitString<n> Oracle(BitString<n> a, BitString<n> b) {
                 return a;
             }
         }
-        """
-    )
+        """)
     assert _engine_with().check_equivalent(real, post).valid
 
 
@@ -947,8 +890,7 @@ def test_guarded_field_element_write_not_dropped() -> None:
     top-level statement kinds and missed the write nested in the if; the branch
     then looked dead and was removed, equating a persistent field mutation
     (Real) with a write to a local parameter (Random)."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real() {
             Map<Int, Int> F;
             Void SetF(Int k, Int v) { F[k] = v; }
@@ -958,10 +900,8 @@ def test_guarded_field_element_write_not_dropped() -> None:
                 return 0;
             }
         }
-        """
-    )
-    random = frog_parser.parse_game(
-        """
+        """)
+    random = frog_parser.parse_game("""
         Game Random() {
             Map<Int, Int> F;
             Void SetF(Int k, Int v) { F[k] = v; }
@@ -971,8 +911,7 @@ def test_guarded_field_element_write_not_dropped() -> None:
                 return 0;
             }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(real, random).valid
 
 
@@ -989,8 +928,7 @@ def test_uniq_sample_is_not_dead_code() -> None:
     observable via |S| on a later call. Removing it (as if dead) would erase
     that effect; the game with the sample is NOT equivalent to the one
     without it."""
-    with_sample = frog_parser.parse_game(
-        """
+    with_sample = frog_parser.parse_game("""
         Game WithSample() {
             Set<BitString<8>> S;
             Int Query() {
@@ -999,10 +937,8 @@ def test_uniq_sample_is_not_dead_code() -> None:
             }
             Int Size() { return |S|; }
         }
-        """
-    )
-    without_sample = frog_parser.parse_game(
-        """
+        """)
+    without_sample = frog_parser.parse_game("""
         Game WithoutSample() {
             Set<BitString<8>> S;
             Int Query() {
@@ -1010,16 +946,14 @@ def test_uniq_sample_is_not_dead_code() -> None:
             }
             Int Size() { return |S|; }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(with_sample, without_sample).valid
 
 
 def test_minus_sample_with_unused_target_is_dead_code() -> None:
     """Control: the pure `x <- T \\ E` form has no side effect, so an unused
     draw IS dead code -- the game with it equals the game without it."""
-    with_sample = frog_parser.parse_game(
-        """
+    with_sample = frog_parser.parse_game("""
         Game WithSample() {
             Set<BitString<8>> S;
             Int Query() {
@@ -1028,10 +962,8 @@ def test_minus_sample_with_unused_target_is_dead_code() -> None:
             }
             Int Size() { return |S|; }
         }
-        """
-    )
-    without_sample = frog_parser.parse_game(
-        """
+        """)
+    without_sample = frog_parser.parse_game("""
         Game WithoutSample() {
             Set<BitString<8>> S;
             Int Query() {
@@ -1039,8 +971,7 @@ def test_minus_sample_with_unused_target_is_dead_code() -> None:
             }
             Int Size() { return |S|; }
         }
-        """
-    )
+        """)
     assert _engine_with().check_equivalent(with_sample, without_sample).valid
 
 
@@ -1049,8 +980,7 @@ def test_uniq_and_minus_forms_not_equivalent() -> None:
     uniq form is NOT equivalent to one drawing via the pure minus form on the
     fall-through path -- they differ in the observable |S| after Query(false,
     false). Previously the engine conflated the forms and accepted the hop."""
-    nested_minus = frog_parser.parse_game(
-        """
+    nested_minus = frog_parser.parse_game("""
         Game Left() {
             Set<BitString<8>> S;
             Int Query(Bool p, Bool q) {
@@ -1064,10 +994,8 @@ def test_uniq_and_minus_forms_not_equivalent() -> None:
             }
             Int Size() { return |S|; }
         }
-        """
-    )
-    merged_uniq = frog_parser.parse_game(
-        """
+        """)
+    merged_uniq = frog_parser.parse_game("""
         Game Right() {
             Set<BitString<8>> S;
             Int Query(Bool p, Bool q) {
@@ -1077,8 +1005,7 @@ def test_uniq_and_minus_forms_not_equivalent() -> None:
             }
             Int Size() { return |S|; }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(nested_minus, merged_uniq).valid
 
 
@@ -1088,8 +1015,7 @@ def test_redundant_conditional_return_uniq_not_collapsed_onto_minus() -> None:
     so deletes the observable `Seen union {x}` insertion. With b always true,
     Real grows Seen each Draw while Ideal never does, so they are not
     equivalent (observable via |Seen|)."""
-    real = frog_parser.parse_game(
-        """
+    real = frog_parser.parse_game("""
         Game Real() {
             Set<BitString<8>> Seen;
             Bool b;
@@ -1104,10 +1030,8 @@ def test_redundant_conditional_return_uniq_not_collapsed_onto_minus() -> None:
             }
             Int Count() { return |Seen|; }
         }
-        """
-    )
-    ideal = frog_parser.parse_game(
-        """
+        """)
+    ideal = frog_parser.parse_game("""
         Game Ideal() {
             Set<BitString<8>> Seen;
             Bool b;
@@ -1118,6 +1042,5 @@ def test_redundant_conditional_return_uniq_not_collapsed_onto_minus() -> None:
             }
             Int Count() { return |Seen|; }
         }
-        """
-    )
+        """)
     assert not _engine_with().check_equivalent(real, ideal).valid

--- a/tests/unit/engine/test_modint_proof_engine.py
+++ b/tests/unit/engine/test_modint_proof_engine.py
@@ -586,14 +586,18 @@ class TestSymbolicComputationExponentiate:
 
 
 class TestZ3FormulaVisitorModInt:
-    def test_modint_variable_maps_to_z3_int(self) -> None:
-        """ModInt<q> variables should be mapped to Z3 Int sort."""
+    def test_modint_variable_maps_to_opaque_const(self) -> None:
+        """F-106: ModInt<q> variables must NOT be mapped to Z3 Int sort -- mod-q
+        arithmetic differs from unbounded Int, so a ModInt is interned as an
+        opaque (uninterpreted) const.  Modelling it as z3.Int let wraparound-
+        true conditions be falsely proven unsat."""
         tm = _type_map_with(x=_modint(_var("q")))
         visitor = Z3FormulaVisitor(tm)
         expr = _var("x")
         result = visitor.visit(expr)
         assert result is not None
-        assert isinstance(result, z3.ArithRef)
+        # Opaque const, NOT an arithmetic (integer) term.
+        assert not isinstance(result, z3.ArithRef)
 
     def test_modint_equality_produces_z3_formula(self) -> None:
         """x == y where both are ModInt should produce a Z3 boolean formula."""
@@ -610,8 +614,11 @@ class TestZ3FormulaVisitorModInt:
         assert result is not None
         assert z3.is_bool(result)
 
-    def test_modint_addition_produces_z3_arith(self) -> None:
-        """x + y where both are ModInt should produce Z3 arithmetic."""
+    def test_modint_addition_is_untranslatable(self) -> None:
+        """F-106: x + y over ModInt must NOT be modelled as Z3 integer
+        arithmetic (that ignores the mod-q reduction).  With ModInt interned
+        as an opaque const, ``+`` over two opaque consts raises in Z3 and the
+        visitor falls back to None ("untranslatable"), the sound choice."""
         tm = _type_map_with(
             x=_modint(_var("q")),
             y=_modint(_var("q")),
@@ -622,8 +629,7 @@ class TestZ3FormulaVisitorModInt:
             _var("y"),
         )
         result = Z3FormulaVisitor(tm).visit(expr)
-        assert result is not None
-        assert isinstance(result, z3.ArithRef)
+        assert result is None
 
     def test_exponentiate_returns_none(self) -> None:
         """Exponentiation is not supported in Z3; should return None."""

--- a/tests/unit/transforms/test_distinct_const_rf_to_uniform.py
+++ b/tests/unit/transforms/test_distinct_const_rf_to_uniform.py
@@ -269,6 +269,45 @@ from proof_frog.transforms.random_functions import _DistinctConstRFTransformer
             }
             """,
         ),
+        # NOT fired (F-017): both literals share a SYMBOLIC length n, whose
+        # keys ("0" vs "allones:n") are textually distinct but denote the
+        # same empty string at n == 0.  Since n's positivity is unruled, the
+        # transform must refuse rather than treat the two RF evaluations as
+        # distinct points.
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<n>, BitString<1>> RF;
+                RF <- Function<BitString<n>, BitString<1>>;
+                return RF(0^n) || RF(1^n);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<n>, BitString<1>> RF;
+                RF <- Function<BitString<n>, BitString<1>>;
+                return RF(0^n) || RF(1^n);
+            }
+            """,
+        ),
+        # NOT fired (F-017): concrete length 0 also collapses all literals to
+        # the empty string, so distinct keys are meaningless.
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<0>, BitString<1>> RF;
+                RF <- Function<BitString<0>, BitString<1>>;
+                return RF(0^0) || RF(1^0);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<0>, BitString<1>> RF;
+                RF <- Function<BitString<0>, BitString<1>>;
+                return RF(0^0) || RF(1^0);
+            }
+            """,
+        ),
         # NOT fired: RF call inside a loop body
         (
             """

--- a/tests/unit/transforms/test_map_key_reindex_soundness.py
+++ b/tests/unit/transforms/test_map_key_reindex_soundness.py
@@ -14,6 +14,7 @@ from proof_frog import frog_ast, frog_parser, visitors
 from proof_frog.transforms._base import PipelineContext
 from proof_frog.transforms.map_reindex import MapKeyReindex
 from proof_frog.transforms._requirements import is_known_nonzero
+from proof_frog.transforms._wrappers import _GroupExpShape
 
 _PRIM = """
 Primitive T() {
@@ -145,3 +146,59 @@ def test_is_known_nonzero_rejects_parameter() -> None:
         }
         """)
     assert not is_known_nonzero("k", game)
+
+
+# --- F-139 / F-140: group-exponent nonzero/coprime preconditions -------------
+
+_G = frog_ast.Variable("G")
+
+
+def _prime_ctx() -> PipelineContext:
+    """A ctx that declares ``G.order is prime`` so ``precondition_misses``
+    only flags the exponent (isolating the F-139/F-140 checks)."""
+    ctx = _ctx()
+    ctx.requirements.append(
+        frog_ast.StructuralRequirement(
+            "prime", frog_ast.FieldAccess(frog_ast.Variable("G"), "order")
+        )
+    )
+    return ctx
+
+
+def _exp_misses(k_expr: frog_ast.Expression) -> list[str]:
+    shape = _GroupExpShape(group_expr=_G, k_expr=k_expr)
+    game = frog_parser.parse_game("Game Pre(Group G) { Int O() { return 0; } }")
+    return shape.precondition_misses(game, _prime_ctx())
+
+
+def test_group_exp_literal_one_allowed() -> None:
+    """A literal exponent of +/-1 is coprime to every prime order, so it is the
+    only literal the reindex may accept."""
+    assert _exp_misses(frog_ast.Integer(1)) == []
+    assert _exp_misses(frog_ast.Integer(-1)) == []
+
+
+def test_group_exp_literal_three_blocks_reindex() -> None:
+    """F-139: a literal exponent k=3 is rejected -- under a *symbolic* prime
+    order q the instantiation q=3 makes x^3 = G.identity for all x, collapsing
+    every key. Only the old ``k == 0`` check passed it."""
+    misses = _exp_misses(frog_ast.Integer(3))
+    assert misses, "literal exponent 3 must be rejected for symbolic prime order"
+
+
+def test_group_exp_literal_zero_blocks_reindex() -> None:
+    """A literal exponent 0 is non-injective (x^0 = identity); still rejected."""
+    assert _exp_misses(frog_ast.Integer(0))
+
+
+def test_group_exp_compound_exponent_blocks_reindex() -> None:
+    """F-140: a compound exponent (e.g. ``k1 * k2``) is neither Integer nor
+    Variable; the dispatch previously had no else branch and silently passed.
+    The product of two plain uniform samples can be 0, collapsing every key."""
+    compound = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY,
+        frog_ast.Variable("k1"),
+        frog_ast.Variable("k2"),
+    )
+    misses = _exp_misses(compound)
+    assert misses, "a compound exponent must be rejected (F-140)"

--- a/tests/unit/transforms/test_unreachable_transformer.py
+++ b/tests/unit/transforms/test_unreachable_transformer.py
@@ -661,6 +661,28 @@ def test_remove_unreachable_unique_sample_bumps_version() -> None:
     ), f"second if wrongly deleted after <-uniq re-sample:\n{transformed}"
 
 
+def test_remove_unreachable_modint_wraparound_not_deleted() -> None:
+    """RC7 / F-106: Case C must NOT delete a live branch whose reachability
+    depends on ModInt wraparound.  Here ``y <- ModInt<2>`` and ``x = y + 1``,
+    so at ``y == 1`` we get ``x == 0`` (mod 2) and the branch fires (w.p. 1/2).
+    Modelling ModInt as unbounded z3.Int made ``x == y + 1`` imply ``x != 0``
+    when ``y == 1`` (2 != 0 over the integers), falsely proving the branch
+    unsat.  Modelling ModInt as an opaque const blocks the arithmetic, so the
+    branch survives."""
+    method = frog_parser.parse_method("""
+        Int O() {
+            ModInt<2> y <- ModInt<2>;
+            ModInt<2> x = y + 1;
+            if (x == 0 && y == 1) { return 0; }
+            return 1;
+        }
+        """)
+    transformed = RemoveUnreachableTransformer(method).transform(method)
+    assert (
+        _count_ifs(transformed) == 1
+    ), f"live ModInt wraparound branch wrongly deleted:\n{transformed}"
+
+
 def test_remove_unreachable_still_dedups_genuine_duplicate() -> None:
     """Positive control: with NO intervening write, two identical
     conditions are genuinely redundant and the second must still be


### PR DESCRIPTION
Model FrogLang values soundly in the Z3/equivalence layer so the engine can only ever REFUSE a true equivalence, never CERTIFY a false one.

- F-106 (Z3FormulaVisitor): stop modelling ModInt<q> as unbounded z3.Int. Mod-q arithmetic differs from integer arithmetic, so encoding `+`/`-`/`*` over a z3.Int let wraparound-true conditions be falsely proven unsat and a live branch deleted. ModInt is now interned as an opaque uninterpreted const (in both visit_variable and _z3_var_for_type) -- a sound over-approximation for UNSAT-proving that still recognises same-atom equality (x == x). Two engine tests that enshrined the old behaviour are updated to the sound semantics.

- F-017 (DistinctConstRFToUniform): distinct _literal_key values imply distinct RF inputs only when the shared bit length is a concrete integer >= 1. At length 0, BitString<0> has a single inhabitant, so 0^n and 1^n collapse onto one point; a symbolic length can be 0, so it is refused with a near-miss.

- F-139/F-140 (MapKeyReindex group-exponent shape): a literal exponent is accepted only when abs(k) == 1 -- on a symbolic prime order q, x^k is injective iff q does not divide k, which no literal |k| >= 2 can guarantee. A compound exponent (neither literal nor variable) now hits an explicit else branch and is refused instead of silently passing.

F-121 (FoldEquivalentReturnBranch, latent) is already closed by the merged F-118 fix: the substituted x_sub/y_sub are re-checked for non-deterministic calls by the in-visitor proof_namespace backstop, and init_field_rhs rejects non-deterministic RHS. No code change needed.