### PR TITLE
Fix canonicalization passes that reused facts invalidated by reassignment or call order

### DIFF
--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -280,6 +280,43 @@ class UniformModIntSimplificationTransformer(BlockTransformer):
             if add_node is None:
                 continue
 
+            # The "used exactly once" count above is textual.  If the single
+            # textual use sits inside a loop body while the sample is outside
+            # that loop, the same uniform value is consumed once PER ITERATION
+            # -- e.g. `t <- ModInt<q>; for (...) { acc = acc + t; }` over a
+            # two-element range leaves acc = 2t (even-only support), not the
+            # uniform t the absorption would produce.  Decline (audit F-132c).
+            def _loop_contains_use(
+                node: frog_ast.ASTNode, target: frog_ast.ASTNode = add_node
+            ) -> bool:
+                return isinstance(
+                    node, (frog_ast.NumericFor, frog_ast.GenericFor)
+                ) and (
+                    SearchVisitor(lambda n, t=target: n is t).visit(node) is not None
+                )
+
+            if SearchVisitor(_loop_contains_use).visit(remaining_block) is not None:
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Uniform ModInt Simplification",
+                            reason=(
+                                f"Uniform-ModInt did not fire for '{var_name}': "
+                                f"its additive use is inside a loop while the "
+                                f"sample is outside, so the value is reused across "
+                                f"iterations (not single-use)"
+                            ),
+                            location=statement.origin,
+                            suggestion=(
+                                f"Move the sample of '{var_name}' inside the loop "
+                                f"if a fresh draw per iteration is intended"
+                            ),
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
+                continue
+
             # Replace the BinaryOperation with just the uniform variable
             assert isinstance(add_node, frog_ast.BinaryOperation)
             if (

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -1088,6 +1088,29 @@ class RemoveUnreachableTransformer(BlockTransformer):
                         continue
                     seen_return_conditions.append(condition)
 
+            # An assignment inside a KEPT if-branch (e.g. `if (b==0){ x=0; }`)
+            # may change a variable's value on some path.  Unlike a top-level
+            # assignment (handled above), the branch write would otherwise never
+            # bump the variable's Z3 version or invalidate syntactic tracking, so
+            # a later `if (x==0) return` is wrongly judged dead against a stale
+            # `x==0` fact (audit F-105, Case B).  Bump the versions of variables
+            # written in the branches and drop any seen return-condition that
+            # references one of them.
+            pre_branch_versions = dict(variable_version_map)
+            for branch in statement.blocks:
+                update_version(branch)
+            branch_writes = {
+                name
+                for name, ver in variable_version_map.items()
+                if ver != pre_branch_versions.get(name)
+            }
+            if branch_writes:
+                seen_return_conditions[:] = [
+                    cond
+                    for cond in seen_return_conditions
+                    if not (referenced_variable_names(cond) & branch_writes)
+                ]
+
             # Tag inner blocks with accumulated path constraints
             for cond_idx, cond in enumerate(statement.conditions):
                 if cond_idx < len(statement.blocks):
@@ -1610,6 +1633,38 @@ class AbsorbRedundantEarlyReturnTransformer(BlockTransformer):
             if trailing_idx is None:
                 continue
 
+            # Soundness (F-110): the rewrite re-evaluates ``!P`` at each
+            # intervening guard.  The docstring's argument that this is
+            # equivalent assumes ``P``'s value is unchanged between the early
+            # return and the trailing return.  But an intervening if-BODY may
+            # write a free variable of ``P`` (e.g. ``if (a) { flag = 1; }`` with
+            # ``P == flag == 1``): in the original the LATER bodies still run
+            # unconditionally, while the rewrite gates them on a now-false
+            # ``!P``.  Decline if any intervening statement reassigns a free
+            # variable of ``P``.
+            p_free_vars = referenced_variable_names(early_p)
+            intervening = frog_ast.Block(
+                list(block.statements[index + 1 : trailing_idx])
+            )
+            if reassigns_or_rebinds(p_free_vars, intervening):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Absorb Redundant Early Return",
+                            reason=(
+                                "Early-return absorption declined: an intervening "
+                                "if-body reassigns a free variable of the early "
+                                "guard P, so re-evaluating !P at the later guards "
+                                "no longer matches the original control flow"
+                            ),
+                            location=None,
+                            suggestion=None,
+                            variable=str(early_p),
+                            method=None,
+                        )
+                    )
+                continue
+
             # Build !P with light surface simplification (== ↔ !=); deeper
             # simplification happens via SimplifyNot / NormalizeCommutativeChains.
             neg_p = _negate_condition(early_p)
@@ -2022,6 +2077,31 @@ class FoldEquivalentReturnBranchTransformer(BlockTransformer):
                             "Init-only field RHS not expanded: the field is "
                             "assigned a non-deterministic call, so substituting "
                             "the call text would equate independent draws"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=stmt.var.name,
+                        method=None,
+                    )
+                )
+                continue
+            # Soundness (F-120): the recorded `F -> rhs` is only valid where
+            # `rhs` evaluates to the SAME value it had in Initialize.  If a field
+            # referenced by `rhs` (e.g. the key `k` in `G = F.eval(k)`) is
+            # reassigned in an oracle (`k = kp`), then at the fold site `rhs`
+            # denotes `F.eval(kp)`, not the stored `F.eval(k_init)` -- so the
+            # substitution would equate `G` with a different value.  Require every
+            # FIELD referenced by the RHS to be single-write (only its Initialize
+            # assignment).
+            rhs_field_refs = referenced_variable_names(stmt.value) & field_names
+            if any(counts.get(name, 0) > 1 for name in rhs_field_refs):
+                self.ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Fold Equivalent Return Branch",
+                        reason=(
+                            "Init-only field RHS not expanded: a field referenced "
+                            "by the RHS is reassigned outside Initialize, so the "
+                            "stored value no longer matches the RHS at the fold site"
                         ),
                         location=None,
                         suggestion=None,
@@ -2538,10 +2618,39 @@ class DeadGuardedAssignmentEliminationTransformer(BlockTransformer):
                     continue
             elif self._read_count(block, v_name) != 1:
                 continue
+            # Soundness (F-098): the kill replaces `v = E` (sitting under path
+            # condition P) with `v = false`, justified by "P entails the inner
+            # guard G, and under G the output is R regardless of v".  That
+            # entailment compares G by string equality against earlier path
+            # facts, treating them as timeless.  It only holds if every variable
+            # in G has the SAME value at the assignment site and at the `if (v)`
+            # use site.  If a variable in G is reassigned anywhere in the prefix
+            # (e.g. `y = y + 1;` between `if (y==1){ v=c; }` and `if (v){ if
+            # (y==1) ... }`), the path fact is stale and the entailment fails --
+            # decline.
+            prefix = list(block.statements[:index])
+            guard_vars = referenced_variable_names(guard)
+            if reassigns_or_rebinds(guard_vars, frog_ast.Block(prefix)):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Dead Guarded Assignment Elimination",
+                            reason=(
+                                "Dead-store kill declined: a variable in the "
+                                "dominating guard is reassigned before the use, "
+                                "so the earlier path fact is stale and no longer "
+                                "entails the guard at the use site"
+                            ),
+                            location=None,
+                            suggestion=None,
+                            variable=v_name,
+                            method=None,
+                        )
+                    )
+                continue
             guard_lits = [
                 _condition_literal(g, True) for g in _flatten_top_level_and(guard)
             ]
-            prefix = list(block.statements[:index])
             new_prefix = [self._kill(s, v_name, guard_lits, []) for s in prefix]
             if new_prefix != prefix:
                 return self.transform_block(

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -1228,6 +1228,8 @@ class IfConditionAliasSubstitutionTransformer(BlockTransformer):
         """
         assign_counts: dict[str, int] = {}
         definitions: dict[str, frog_ast.Expression] = {}
+        # Method that holds each field's (single, top-level) defining assignment.
+        def_methods: dict[str, str] = {}
 
         for method in game.methods:
             # Collect top-level definitions (for the expression value)
@@ -1238,6 +1240,7 @@ class IfConditionAliasSubstitutionTransformer(BlockTransformer):
                     and stmt.var.name in self.field_names
                 ):
                     definitions[stmt.var.name] = stmt.value
+                    def_methods[stmt.var.name] = method.signature.name
 
             # Count ALL assignments recursively (including nested blocks)
             for field_name in self.field_names:
@@ -1252,6 +1255,16 @@ class IfConditionAliasSubstitutionTransformer(BlockTransformer):
         for name, expr in definitions.items():
             if assign_counts.get(name, 0) != 1:
                 continue
+            # Flow-sensitivity (F-076): a single ASSIGNMENT SITE is not a single
+            # runtime write.  A field assigned once in an oracle (`SetA(){ A=B; }`)
+            # is rewritten on every call, and the adversary controls call order,
+            # so `A == B` (its definition) holds only at the instant SetA ran --
+            # a later `SetB` leaves A a stale snapshot.  The alias `A -> def(A)`
+            # is stable only when A is written exactly once in Initialize (which
+            # runs once, deterministically, before any oracle) AND every field in
+            # def(A) is likewise written only in Initialize.
+            if def_methods.get(name) != "Initialize":
+                continue
             used_vars = VariableCollectionVisitor().visit(expr)
             if not all(v.name in self.field_names for v in used_vars):
                 continue
@@ -1259,6 +1272,10 @@ class IfConditionAliasSubstitutionTransformer(BlockTransformer):
             # referenced field is reassigned after this definition, the
             # stored value diverges from the current field value.
             if not all(assign_counts.get(v.name, 0) == 1 for v in used_vars):
+                continue
+            # ...and that single assignment must be in Initialize too, so the
+            # referenced field cannot be re-set by an interleaved oracle call.
+            if not all(def_methods.get(v.name) == "Initialize" for v in used_vars):
                 continue
             if has_nondeterministic_call(
                 expr, self._proof_namespace, self._proof_let_types

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2064,6 +2064,32 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
         if assign_count != 1 or assign_expr is None:
             return None
 
+        # 1b. A self-referential assignment (``c = c + 1``) is accumulator
+        # state, not a single-use alias: the field reads its own previous value,
+        # so it cannot be eliminated by substituting the definition into uses
+        # (doing so both loses the cross-call accumulation and -- because the
+        # value mentions the field -- makes inlining non-terminating).
+        def _refs_self(node: frog_ast.ASTNode) -> bool:
+            return isinstance(node, frog_ast.Variable) and node.name == field_name
+
+        if SearchVisitor(_refs_self).visit(assign_expr) is not None:
+            if self.ctx is not None:
+                self.ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Inline Single-Use Field",
+                        reason=(
+                            f"Cannot inline field '{field_name}': its defining "
+                            f"expression references the field itself (accumulator "
+                            f"state, not a single-use alias)"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=field_name,
+                        method=None,
+                    )
+                )
+            return None
+
         # 2. Count total uses of field_name across the entire game
         def uses_field(node: frog_ast.ASTNode) -> bool:
             return isinstance(node, frog_ast.Variable) and node.name == field_name

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -25,6 +25,7 @@ from ..visitors import (
     VariableCollectionVisitor,
     referenced_variable_names,
     reassigns_or_rebinds,
+    lvalue_base_name,
 )
 from ._base import (
     TransformPass,
@@ -1908,15 +1909,21 @@ class HoistFieldPureAlias(TransformPass):
 
 
 def _count_assigns_recursive(node: frog_ast.ASTNode, name: str) -> int:
-    """Count all assignments/samples to *name* recursively in the AST."""
+    """Count all assignments/samples to *name* recursively in the AST.
+
+    Peels element/slice/field accesses via :func:`lvalue_base_name` so an
+    in-place mutation (``B[0] = 5``, ``B.f = v``) counts as an assignment to
+    ``B`` -- otherwise a single-use-field stability check would treat a
+    later-mutated free-variable field as stable and inline a stale snapshot
+    across methods (audit F-079).
+    """
     count = 0
 
     def _counter(n: frog_ast.ASTNode) -> bool:
         nonlocal count
         if (
             isinstance(n, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample))
-            and isinstance(n.var, frog_ast.Variable)
-            and n.var.name == name
+            and lvalue_base_name(n.var) == name
         ):
             count += 1
         return False

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -27,6 +27,7 @@ from ..visitors import (
     ReplaceTransformer,
     Transformer,
     lvalue_base_name,
+    reassigns_or_rebinds,
 )
 from ._base import (
     TransformPass,
@@ -2190,6 +2191,38 @@ class ChallengeExclusionRFToUniformTransformer:
             # Check that Init arg references at least one challenge field
             init_field_refs = _collect_field_vars(resolved_init_arg, field_names)
 
+            # Vector (F-013): the challenge value must be IMMUTABLE.  If any
+            # oracle reassigns a challenge field (e.g. a `Mutate(v){ cf = v; }`
+            # oracle), the per-oracle exclusion guard `param == cf` later
+            # protects a DIFFERENT, adversary-chosen value, so the adversary can
+            # query H at the original challenge point.  H(cf) is then observable
+            # and not an independent uniform draw -- decline.
+            challenge_reassigned = any(
+                reassigns_or_rebinds(init_field_refs, om.block)
+                for om in oracle_methods
+            )
+            if challenge_reassigned:
+                if ctx is not None:
+                    ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Challenge Exclusion RF To Uniform",
+                            reason=(
+                                f"A challenge field used in the Initialize call "
+                                f"to '{rf_name}' is reassigned by an oracle, so the "
+                                "exclusion guard no longer protects the original "
+                                "challenge value; H(cf) becomes observable"
+                            ),
+                            location=None,
+                            suggestion=(
+                                "Do not reassign the challenge field outside "
+                                "Initialize"
+                            ),
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
+                continue
+
             # Check each oracle method
             all_oracle_ok = True
             for oracle_method in oracle_methods:
@@ -2208,6 +2241,12 @@ class ChallengeExclusionRFToUniformTransformer:
                 challenge_fields = guard.challenge_fields
                 guard_lhs_vars = guard.guard_lhs_vars
                 guard_idx = guard.guard_idx
+
+                # The variables actually appearing in the guard condition (e.g.
+                # `param` in `if (param == cf)`).  Their inequality-to-cf is the
+                # guard's invariant; a later reassignment of one of them breaks
+                # it (vector F-014), distinct from deriving a NEW var below.
+                original_guard_vars = set(guard_lhs_vars)
 
                 # Extend guard vars with variables derived from guard LHS
                 # (e.g., v4 = c[0] where c is the guard parameter)
@@ -2239,6 +2278,35 @@ class ChallengeExclusionRFToUniformTransformer:
                 post_guard_block = frog_ast.Block(
                     list(oracle_method.block.statements[guard_idx + 1 :])
                 )
+
+                # Vector (F-014): a guard variable reassigned after the guard no
+                # longer satisfies the guard's `!= cf` invariant.  E.g.
+                # `if (param == cf) return None; param = cf; return H(param);`
+                # re-queries the excluded point, but the alias resolver freezes
+                # guard vars as `!= cf` leaves and never sees the reassignment.
+                if reassigns_or_rebinds(original_guard_vars, post_guard_block):
+                    if ctx is not None:
+                        ctx.near_misses.append(
+                            NearMiss(
+                                transform_name="Challenge Exclusion RF To Uniform",
+                                reason=(
+                                    "A guard variable is reassigned after the "
+                                    "challenge-exclusion guard, so its inequality "
+                                    "to the challenge no longer holds and an RF "
+                                    "call may re-query the challenge input"
+                                ),
+                                location=None,
+                                suggestion=(
+                                    "Do not reassign the guarded variable between "
+                                    "the guard and the random-function call"
+                                ),
+                                variable=rf_name,
+                                method=oracle_method.signature.name,
+                            )
+                        )
+                    all_oracle_ok = False
+                    break
+
                 guard_stmt = oracle_method.block.statements[guard_idx]
                 assert isinstance(guard_stmt, frog_ast.IfStatement)
 

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -230,6 +230,23 @@ def _analyze_block(
     uniq_guards: dict[str, str] = {}
 
     for statement in block.statements:
+        # F-022: any write to a guarded variable other than a fresh
+        # `<-uniq[S]` draw destroys the freshness that draw established -- after
+        # `r <-uniq[S]; r = c;` the variable holds an arbitrary, possibly
+        # previously-queried value, so `RF(r)` is no longer a distinct input.
+        # Invalidate the guard before this statement's RF-call check below.
+        if isinstance(
+            statement,
+            (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
+        ):
+            written_base = lvalue_base_name(statement.var)
+            is_fresh_uniq = (
+                isinstance(statement, frog_ast.UniqueSample)
+                and statement.surface_form == "uniq"
+            )
+            if written_base in uniq_guards and not is_fresh_uniq:
+                del uniq_guards[written_base]
+
         # Track <-uniq bindings. Only the stateful `<-uniq[S]` form
         # accumulates draws into S (S = S union {x}); the pure `x <- T \ E`
         # form performs no insertion, so it does NOT guarantee cross-call
@@ -1243,9 +1260,7 @@ def _index_of_var_in_arg(arg: frog_ast.Expression, var_name: str) -> int | None 
 def _contains_return(node: frog_ast.ASTNode) -> bool:
     """True if *node* contains a ``return`` statement anywhere."""
     return (
-        SearchVisitor(
-            lambda n: isinstance(n, frog_ast.ReturnStatement)
-        ).visit(node)
+        SearchVisitor(lambda n: isinstance(n, frog_ast.ReturnStatement)).visit(node)
         is not None
     )
 
@@ -1285,6 +1300,7 @@ def _proj_tracked_in_set(
       through untracked, so only a top-level add reached before any
       early-return-bearing statement counts.
     """
+
     # Form 1: <-uniq[set_name] draw (anywhere -- path-consistent with its use).
     def is_uniq_draw(node: frog_ast.ASTNode) -> bool:
         return (
@@ -2235,8 +2251,7 @@ class ChallengeExclusionRFToUniformTransformer:
             # query H at the original challenge point.  H(cf) is then observable
             # and not an independent uniform draw -- decline.
             challenge_reassigned = any(
-                reassigns_or_rebinds(init_field_refs, om.block)
-                for om in oracle_methods
+                reassigns_or_rebinds(init_field_refs, om.block) for om in oracle_methods
             )
             if challenge_reassigned:
                 if ctx is not None:

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -1240,46 +1240,76 @@ def _index_of_var_in_arg(arg: frog_ast.Expression, var_name: str) -> int | None 
     return False
 
 
+def _contains_return(node: frog_ast.ASTNode) -> bool:
+    """True if *node* contains a ``return`` statement anywhere."""
+    return (
+        SearchVisitor(
+            lambda n: isinstance(n, frog_ast.ReturnStatement)
+        ).visit(node)
+        is not None
+    )
+
+
+def _is_union_add(
+    stmt: frog_ast.Statement, set_name: str, proj: frog_ast.Expression
+) -> bool:
+    """True if *stmt* is exactly ``set_name = set_name union {... proj ...}``."""
+    return (
+        isinstance(stmt, frog_ast.Assignment)
+        and isinstance(stmt.var, frog_ast.Variable)
+        and stmt.var.name == set_name
+        and isinstance(stmt.value, frog_ast.BinaryOperation)
+        and stmt.value.operator
+        in (frog_ast.BinaryOperators.UNION, frog_ast.BinaryOperators.ADD)
+        and isinstance(stmt.value.left_expression, frog_ast.Variable)
+        and stmt.value.left_expression.name == set_name
+        and isinstance(stmt.value.right_expression, frog_ast.Set)
+        and any(elem == proj for elem in stmt.value.right_expression.elements)
+    )
+
+
 def _proj_tracked_in_set(
     method: frog_ast.Method, set_name: str, proj: frog_ast.Expression
 ) -> bool:
-    """True if *proj* is guaranteed to be in *set_name* within *method*.
+    """True if *proj* is guaranteed to be in *set_name* on EVERY path through
+    *method* (path-sensitive -- audit F-001).
 
-    Either *proj* is a variable sampled ``<-uniq[set_name]``, or *method*
-    contains ``set_name = set_name union {... proj ...}`` (or ``+``).
+    Two tracking forms qualify:
+
+    - *proj* is a variable sampled ``<-uniq[set_name]``: the draw IS the
+      insertion and the RF call uses the same drawn value, so the two are
+      path-consistent wherever the draw occurs.
+    - an UNCONDITIONAL top-level ``set_name = set_name union {... proj ...}``
+      that runs on every invocation.  A conditional add (nested under an
+      ``if``) or one placed after an early return lets an RF query slip
+      through untracked, so only a top-level add reached before any
+      early-return-bearing statement counts.
     """
-    found = [False]
-
-    def visit(node: frog_ast.ASTNode) -> bool:
-        if (
+    # Form 1: <-uniq[set_name] draw (anywhere -- path-consistent with its use).
+    def is_uniq_draw(node: frog_ast.ASTNode) -> bool:
+        return (
             isinstance(node, frog_ast.UniqueSample)
-            # Only `<-uniq[S]` inserts the draw into S; `x <- T \ S` does not,
-            # so a minus-form draw is NOT guaranteed to be in set_name.
+            # Only `<-uniq[S]` inserts the draw into S; `x <- T \ S` does not.
             and node.surface_form == "uniq"
             and isinstance(node.var, frog_ast.Variable)
             and isinstance(proj, frog_ast.Variable)
             and node.var.name == proj.name
             and isinstance(node.unique_set, frog_ast.Variable)
             and node.unique_set.name == set_name
-        ):
-            found[0] = True
-        if (
-            isinstance(node, frog_ast.Assignment)
-            and isinstance(node.var, frog_ast.Variable)
-            and node.var.name == set_name
-            and isinstance(node.value, frog_ast.BinaryOperation)
-            and node.value.operator
-            in (frog_ast.BinaryOperators.UNION, frog_ast.BinaryOperators.ADD)
-            and isinstance(node.value.left_expression, frog_ast.Variable)
-            and node.value.left_expression.name == set_name
-            and isinstance(node.value.right_expression, frog_ast.Set)
-            and any(elem == proj for elem in node.value.right_expression.elements)
-        ):
-            found[0] = True
-        return False
+        )
 
-    SearchVisitor(visit).visit(method.block)
-    return found[0]
+    if SearchVisitor(is_uniq_draw).visit(method.block) is not None:
+        return True
+
+    # Form 2: an unconditional top-level union-add, reached before any
+    # statement that can return early on some path.
+    for stmt in method.block.statements:
+        if _is_union_add(stmt, set_name, proj):
+            return True
+        if _contains_return(stmt):
+            # An early return here would skip a later add on some path.
+            break
+    return False
 
 
 def _set_only_monotone(game: frog_ast.Game, set_name: str) -> bool:
@@ -1343,7 +1373,14 @@ def _exclusion_adequate(
     """Whether ``v <-uniq[set_name]`` at projection *proj_index* of an
     ``rf_name(arg)`` call guarantees the queried point is fresh for ``rf_name``.
     See the regime (A)/(B) discussion above."""
-    # Regime (A): the exclusion set is the called RF's own domain.
+    # Regime (A): the exclusion set is the called RF's own domain.  Whether
+    # `RF.domain` tracks plain `RF(x)` evaluations (standard ROM table) or only
+    # `<-uniq[RF.domain]` draws (USER-ATTENTION sec 1.b) is a CONTESTED semantics
+    # ruling and the crux of F-002/F-003: tightening regime A to require every
+    # RF query to be a tracked fresh draw rejects standard ROM proofs (the
+    # adversary `Hash(x){ return H(x); }` oracle) that the example corpus relies
+    # on.  Per Principle 6/7 this is left as-is pending the user's ruling; F-002
+    # is ESCALATED.
     if set_name == f"{rf_name}.domain" and proj_index is None:
         return True
     # Regime (B): persistent, never-reset field that tracks the k-th

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -1326,6 +1326,27 @@ class SplitUniformSampleTransformer(BlockTransformer):
 # ---------------------------------------------------------------------------
 
 
+def _method_is_internally_called(game: frog_ast.Game, method_name: str) -> bool:
+    """True if any method body contains a call to *method_name* -- a bare
+    ``method_name(...)`` or a qualified ``X.method_name(...)`` /
+    ``this.method_name(...)`` sibling call."""
+
+    def is_call(node: frog_ast.ASTNode) -> bool:
+        if not isinstance(node, frog_ast.FuncCall):
+            return False
+        func = node.func
+        if isinstance(func, frog_ast.Variable):
+            return func.name == method_name
+        if isinstance(func, frog_ast.FieldAccess):
+            return func.name == method_name
+        return False
+
+    for method in game.methods:
+        if SearchVisitor(is_call).visit(method.block) is not None:
+            return True
+    return False
+
+
 def _single_call_field_to_local(
     game: frog_ast.Game, ctx: PipelineContext | None = None
 ) -> frog_ast.Game:
@@ -1400,6 +1421,32 @@ def _single_call_field_to_local(
         target_method_name = using_methods[0]
         target_method = game.get_method(target_method_name)
         if _is_written_in_recursive(target_method.block, field.name):
+            continue
+
+        # F-056: the localization is sound only if the read site runs at most
+        # once.  If the using method is invoked by a SIBLING method (a call
+        # `X.Helper()` / `this.Helper()` / `Helper()` inside another oracle),
+        # one adversary call to that sibling triggers an extra execution of the
+        # read site -- so the persistent field (read repeatedly) is no longer
+        # interchangeable with a per-call fresh local.  This holds under any
+        # `calls <= N` reading, so decline conservatively.
+        if _method_is_internally_called(game, target_method_name):
+            if ctx is not None:
+                ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Single Call Field To Local",
+                        reason=(
+                            f"Field '{field.name}' not localized: its read site "
+                            f"'{target_method_name}' is called by another method, "
+                            f"so it can execute more than once and a per-call "
+                            f"local sample would diverge from the persistent field"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=field.name,
+                        method=None,
+                    )
+                )
             continue
 
         # RC5 domain-invariance: moving the sample out of Initialize and into

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -23,6 +23,8 @@ from ..visitors import (
     ReplaceTransformer,
     VariableCollectionVisitor,
     FrogToSympyVisitor,
+    referenced_variable_names,
+    reassigns_or_rebinds,
 )
 from ._base import TransformPass, PipelineContext, NearMiss
 
@@ -1172,6 +1174,38 @@ class SplitUniformSampleTransformer(BlockTransformer):
             ):
                 continue
 
+            # Flow-sensitivity (F-032): the bounds are resolved by NAME to a
+            # single sympy symbol, so two textually-identical slices
+            # ``z[i : i+4]`` resolve to the same bounds and get deduplicated --
+            # but if the index ``i`` is reassigned between them (``i = i + 4``),
+            # they denote DIFFERENT, non-overlapping slices at run time, and
+            # collapsing them to one fresh piece changes the distribution
+            # (``z[0:4] xor z[4:8]`` is uniform, ``z[i] xor z[i]`` is 0).
+            # Decline when any variable in a slice's bounds is reassigned in the
+            # region the slices span.
+            bound_vars: set[str] = set()
+            for s in slices:
+                bound_vars |= referenced_variable_names(s.start)
+                bound_vars |= referenced_variable_names(s.end)
+            if bound_vars and reassigns_or_rebinds(bound_vars, remaining_block):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Split Uniform Samples",
+                            reason=(
+                                f"Sample '{var_name}' not split: a slice-bound "
+                                f"variable is reassigned between slice uses, so "
+                                f"textually-identical slices denote different "
+                                f"ranges at run time"
+                            ),
+                            location=statement.origin,
+                            suggestion=None,
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
+                continue
+
             # Resolve slice bounds to sympy
             slice_bounds: list[tuple[Symbol | int, Symbol | int]] = []
             all_resolved = True
@@ -1715,6 +1749,26 @@ def _all_refs_in_counter_guarded_branches(
     *mutable_names* is the set of variable names that can change between oracle
     calls (game fields and method parameters).
     """
+    # A local assigned (transitively) from a field or parameter is itself
+    # adversary-controlled / non-constant across calls, even though it is
+    # neither a field nor a param.  A guard `ctr == t` with `t = x` (x a
+    # parameter) can then fire on EVERY call, so the field would be read every
+    # call rather than once (audit F-049).  Treat such tainted locals as
+    # mutable for the guard-constancy check below.
+    tainted: set[str] = set(mutable_names)
+    changed = True
+    while changed:
+        changed = False
+        for stmt in block.statements:
+            if (
+                isinstance(stmt, frog_ast.Assignment)
+                and isinstance(stmt.var, frog_ast.Variable)
+                and stmt.var.name not in tainted
+                and referenced_variable_names(stmt.value) & tainted
+            ):
+                tainted.add(stmt.var.name)
+                changed = True
+
     past_increment = False
     guarded_branch_count = 0
     for stmt in block.statements:
@@ -1758,10 +1812,11 @@ def _all_refs_in_counter_guarded_branches(
                 if guard_expr is None:
                     return False
                 # The guard expression (the non-counter side of the ==) must
-                # be constant across oracle calls.  Reject if it references
-                # any game field or method parameter, since those can differ
+                # be constant across oracle calls.  Reject if it references any
+                # game field, method parameter, or a local tainted by one (a
+                # `t = x` indirection -- audit F-049), since those can differ
                 # between calls and would let the branch fire multiple times.
-                for mname in mutable_names:
+                for mname in tainted:
                     if _references_name(guard_expr, mname):
                         return False
                 guarded_branch_count += 1

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -322,9 +322,7 @@ class InstantiationTransformer(Transformer):
         saved = self._mutable_fields
         written: set[str] = set()
         for field in getattr(node, "fields", []):
-            if field.value is not None and reassigns_or_rebinds(
-                {field.name}, node
-            ):
+            if field.value is not None and reassigns_or_rebinds({field.name}, node):
                 written.add(field.name)
         self._mutable_fields = written
         try:

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -167,7 +167,13 @@ class Transformer(ABC):
             if returned:
                 return returned
 
-        # Copy-on-write: only create a new node if a child changed
+        return self._transform_children(node)
+
+    def _transform_children(self, node: T) -> T:
+        # Copy-on-write recursion into a node's children, bypassing this
+        # transformer's own per-node hooks for *node* itself. Subclasses that
+        # override a container hook (e.g. ``transform_game``) to set up state
+        # call this to perform the default structural descent.
         changed = False
         new_attrs: dict[str, Any] = {}
         for attr_name in vars(node):
@@ -305,6 +311,32 @@ class SubstitutionTransformer(Transformer):
 class InstantiationTransformer(Transformer):
     def __init__(self, namespace: frog_ast.Namespace) -> None:
         self.namespace = dict(namespace)
+        # Field names that are reassigned somewhere in the module currently being
+        # transformed. Their initializer must NOT be substituted into method
+        # bodies: a field `Int c = 0` that is later mutated (`c = c + 1`) is
+        # genuine state, not a constant alias, so replacing reads of `c` with `0`
+        # would silently drop the mutation (see audit F-045).
+        self._mutable_fields: set[str] = set()
+
+    def _instantiate_module(self, node: T) -> T:
+        saved = self._mutable_fields
+        written: set[str] = set()
+        for field in getattr(node, "fields", []):
+            if field.value is not None and reassigns_or_rebinds(
+                {field.name}, node
+            ):
+                written.add(field.name)
+        self._mutable_fields = written
+        try:
+            return self._transform_children(node)
+        finally:
+            self._mutable_fields = saved
+
+    def transform_game(self, game: frog_ast.Game) -> frog_ast.ASTNode:
+        return self._instantiate_module(game)
+
+    def transform_scheme(self, scheme: frog_ast.Scheme) -> frog_ast.ASTNode:
+        return self._instantiate_module(scheme)
 
     def transform_field(self, field: frog_ast.Field) -> frog_ast.ASTNode:
         new_field = frog_ast.Field(
@@ -323,7 +355,13 @@ class InstantiationTransformer(Transformer):
             ns_value = frog_ast.ProductType(
                 [v for v in ns_value.values if isinstance(v, frog_ast.Type)]
             )
-        self.namespace[field.name] = ns_value
+        # A reassigned field is genuine state, not a constant alias: do not
+        # register its initializer for substitution into reads (audit F-045).
+        # A pre-existing namespace binding (a proof-let constant) is left intact.
+        if field.name in self._mutable_fields:
+            self.namespace.pop(field.name, None)
+        else:
+            self.namespace[field.name] = ns_value
         return new_field
 
     def transform_variable(self, variable: frog_ast.Variable) -> frog_ast.ASTNode:

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -1044,3 +1044,30 @@ def test_redundant_conditional_return_uniq_not_collapsed_onto_minus() -> None:
         }
         """)
     assert not _engine_with().check_equivalent(real, ideal).valid
+
+
+def test_reassigned_field_initializer_not_substituted() -> None:
+    """A reassigned field is genuine state, not a constant alias.  The engine
+    must not substitute its initializer into a post-reassignment read:
+    ``Int c = 0; c = c + 1; return c`` returns 1, not 0, so it is not
+    equivalent to ``return 0``.  Audit F-045 (InstantiationTransformer +
+    InlineSingleUseField self-reference)."""
+    real = frog_parser.parse_game("""
+        Game Real() {
+            Int c = 0;
+            Int Initialize() {
+                c = c + 1;
+                return c;
+            }
+            BitString<1> Query() { return 0b0; }
+        }
+        """)
+    random = frog_parser.parse_game("""
+        Game Random() {
+            Int Initialize() {
+                return 0;
+            }
+            BitString<1> Query() { return 0b0; }
+        }
+        """)
+    assert not _engine_with().check_equivalent(real, random).valid

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -1071,3 +1071,35 @@ def test_reassigned_field_initializer_not_substituted() -> None:
         }
         """)
     assert not _engine_with().check_equivalent(real, random).valid
+
+
+def test_modint_loop_reused_uniform_not_absorbed() -> None:
+    """A uniform ModInt sampled once outside a two-iteration loop and added into
+    an accumulator each pass leaves `acc = 2t` (even-only support), which is not
+    distributionally equal to a single `acc = t` (uniform).  The engine must not
+    absorb the loop-reused uniform (audit F-132c)."""
+    twice = frog_parser.parse_game("""
+        Game Twice() {
+            ModInt<16> acc;
+            Void Probe() {
+                acc = 0;
+                ModInt<16> t <- ModInt<16>;
+                for (ModInt<16> i in {1, 2}) {
+                    acc = acc + t;
+                }
+            }
+            ModInt<16> GetAcc() { return acc; }
+        }
+        """)
+    once = frog_parser.parse_game("""
+        Game Once() {
+            ModInt<16> acc;
+            Void Probe() {
+                acc = 0;
+                ModInt<16> t <- ModInt<16>;
+                acc = t;
+            }
+            ModInt<16> GetAcc() { return acc; }
+        }
+        """)
+    assert not _engine_with().check_equivalent(twice, once).valid

--- a/tests/integration/test_rc3_random_functions.py
+++ b/tests/integration/test_rc3_random_functions.py
@@ -155,3 +155,102 @@ def test_challenge_exclusion_direct_rf_control_fires() -> None:
     random = frog_parser.parse_game(_alias_game(_RANDOM_FIELD, aliased=False))
     result = engine.check_equivalent(real, random)
     assert result.valid, result.failure_detail
+
+
+# --------------------------------------------------------------------------
+# RC6 vectors F-013 / F-014: the challenge-exclusion invariant must survive
+# reassignment.  The challenge field must be immutable, and the guard variable
+# must not be reassigned to the challenge after the guard.  In both attacks the
+# adversary can observe H(cf), so Real (field = H(cf)) is NOT equivalent to
+# Random (field <- R) -- the engine must reject.
+# --------------------------------------------------------------------------
+
+
+def test_challenge_field_mutation_not_equivalent() -> None:
+    """F-013: a Mutate oracle reassigns the challenge field; H(cf) is
+    observable, so the games are distinguishable."""
+    engine = _engine()
+    real = frog_parser.parse_game("""
+        Game Real(Int n) {
+            Function<BitString<n>, BitString<n>> H;
+            BitString<n> cf;
+            BitString<n> field;
+            BitString<n> Initialize() {
+                H <- Function<BitString<n>, BitString<n>>;
+                cf <- BitString<n>;
+                field = H(cf);
+                return cf;
+            }
+            BitString<n> Reveal() { return field; }
+            Void Mutate(BitString<n> v) { cf = v; }
+            BitString<n>? Query(BitString<n> param) {
+                if (param == cf) { return None; }
+                return H(param);
+            }
+        }
+        """)
+    random = frog_parser.parse_game("""
+        Game Random(Int n) {
+            Function<BitString<n>, BitString<n>> H;
+            BitString<n> cf;
+            BitString<n> field;
+            BitString<n> Initialize() {
+                H <- Function<BitString<n>, BitString<n>>;
+                cf <- BitString<n>;
+                field <- BitString<n>;
+                return cf;
+            }
+            BitString<n> Reveal() { return field; }
+            Void Mutate(BitString<n> v) { cf = v; }
+            BitString<n>? Query(BitString<n> param) {
+                if (param == cf) { return None; }
+                return H(param);
+            }
+        }
+        """)
+    assert not engine.check_equivalent(real, random).valid
+
+
+def test_guard_var_reassigned_to_challenge_not_equivalent() -> None:
+    """F-014: the guard variable is reassigned to cf after the guard and then
+    fed to H, re-querying the excluded point."""
+    engine = _engine()
+    real = frog_parser.parse_game("""
+        Game Real(Int n) {
+            Function<BitString<n>, BitString<n>> H;
+            BitString<n> cf;
+            BitString<n> field;
+            BitString<n> Initialize() {
+                H <- Function<BitString<n>, BitString<n>>;
+                cf <- BitString<n>;
+                field = H(cf);
+                return cf;
+            }
+            BitString<n> Reveal() { return field; }
+            BitString<n>? Query(BitString<n> param) {
+                if (param == cf) { return None; }
+                param = cf;
+                return H(param);
+            }
+        }
+        """)
+    random = frog_parser.parse_game("""
+        Game Random(Int n) {
+            Function<BitString<n>, BitString<n>> H;
+            BitString<n> cf;
+            BitString<n> field;
+            BitString<n> Initialize() {
+                H <- Function<BitString<n>, BitString<n>>;
+                cf <- BitString<n>;
+                field <- BitString<n>;
+                return cf;
+            }
+            BitString<n> Reveal() { return field; }
+            BitString<n>? Query(BitString<n> param) {
+                if (param == cf) { return None; }
+                param = cf;
+                return H(param);
+            }
+        }
+        """)
+    assert not engine.check_equivalent(real, random).valid

--- a/tests/unit/transforms/test_absorb_redundant_early_return.py
+++ b/tests/unit/transforms/test_absorb_redundant_early_return.py
@@ -342,3 +342,29 @@ def test_aer_fires_on_deterministic_control() -> None:
     ctx = _aer_ctx(D=_aer_det_prim(), F=_aer_det_prim())
     result = AbsorbRedundantEarlyReturn().apply(game, ctx)
     assert result != game  # the early-return guard was absorbed
+
+
+def test_intervening_body_writes_guard_free_var_not_absorbed() -> None:
+    """F-110: an intervening if-body reassigns a free variable of the early
+    guard P (`if (a) { flag = 1; }` with `P == flag == 1`).  In the original
+    the later body `if (b) { out = flag; }` runs unconditionally, but the
+    rewrite would gate it on a now-false negated P -- O1(true, true) returns 1
+    in the original vs 0 in the rewrite.  Must DECLINE."""
+    method = """
+        Int O1(Bool a, Bool b) {
+            if (flag == 1) {
+                return out;
+            }
+            if (a) {
+                flag = 1;
+            }
+            if (b) {
+                out = flag;
+            }
+            return out;
+        }
+        """
+    parsed = frog_parser.parse_method(method)
+    expected = frog_parser.parse_method(method)
+    result = AbsorbRedundantEarlyReturnTransformer().transform(parsed)
+    assert result == expected, f"absorb wrongly fired across a guard-var write:\n{result}"

--- a/tests/unit/transforms/test_challenge_exclusion_rf.py
+++ b/tests/unit/transforms/test_challenge_exclusion_rf.py
@@ -423,3 +423,59 @@ def test_embedded_second_init_call_not_simplified() -> None:
     }
     """
     assert not _fired(source)
+
+
+def test_challenge_field_mutation_not_simplified() -> None:
+    """Vector F-013: a `Mutate(v){ cf = v; }` oracle reassigns the challenge
+    field, so the exclusion guard later protects a different value and H(cf)
+    becomes observable; the pass must decline."""
+    source = """
+    Game G(Int n) {
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<n> Initialize() {
+            H <- Function<BitString<n>, BitString<n>>;
+            cf <- BitString<n>;
+            field = H(cf);
+            return cf;
+        }
+        Void Mutate(BitString<n> v) {
+            cf = v;
+        }
+        BitString<n>? Query(BitString<n> param) {
+            if (param == cf) {
+                return None;
+            }
+            return H(param);
+        }
+    }
+    """
+    assert not _fired(source)
+
+
+def test_guard_var_reassigned_to_challenge_not_simplified() -> None:
+    """Vector F-014: reassigning the guard variable to the challenge after the
+    guard (`param = cf; return H(param);`) re-queries the excluded point; the
+    pass must decline."""
+    source = """
+    Game G(Int n) {
+        Function<BitString<n>, BitString<n>> H;
+        BitString<n> cf;
+        BitString<n> field;
+        BitString<n> Initialize() {
+            H <- Function<BitString<n>, BitString<n>>;
+            cf <- BitString<n>;
+            field = H(cf);
+            return cf;
+        }
+        BitString<n>? Query(BitString<n> param) {
+            if (param == cf) {
+                return None;
+            }
+            param = cf;
+            return H(param);
+        }
+    }
+    """
+    assert not _fired(source)

--- a/tests/unit/transforms/test_counter_guarded_field_to_local.py
+++ b/tests/unit/transforms/test_counter_guarded_field_to_local.py
@@ -645,3 +645,54 @@ def test_param_shadowed_field_not_localized() -> None:
         }
         """)
     assert _counter_guarded_field_to_local(game) == game
+
+
+def test_counter_guard_local_aliasing_param_not_localized() -> None:
+    """F-049: the counter guard `ctr == t` reads a LOCAL `t = x` that aliases
+    the adversary-controlled parameter x, so the guarded branch can fire on
+    EVERY call (O(1), O(2), ...).  Moving the persistent Initialize sample F
+    into a per-call local would then return a fresh value each call instead of
+    the same one -- the pass must DECLINE (the constancy screen must see
+    through the `t = x` indirection)."""
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Int ctr;
+            BitString<n> F;
+            Void Initialize() {
+                ctr = 0;
+                F <- BitString<n>;
+            }
+            BitString<n> O(Int x) {
+                ctr = ctr + 1;
+                Int t = x;
+                if (ctr == t) {
+                    return F;
+                }
+                return 0^n;
+            }
+        }
+        """)
+    assert _counter_guarded_field_to_local(game) == game
+
+
+def test_counter_guard_constant_local_still_localizes() -> None:
+    """Positive control: a local bound to a genuine constant (`Int t = 1`) keeps
+    the guard constant across calls, so the localization still fires."""
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            Int ctr;
+            BitString<n> F;
+            Void Initialize() {
+                ctr = 0;
+                F <- BitString<n>;
+            }
+            BitString<n> O(Int x) {
+                ctr = ctr + 1;
+                if (ctr == 1) {
+                    return F;
+                }
+                return 0^n;
+            }
+        }
+        """)
+    assert _counter_guarded_field_to_local(game) != game

--- a/tests/unit/transforms/test_dead_guarded_assignment_elimination.py
+++ b/tests/unit/transforms/test_dead_guarded_assignment_elimination.py
@@ -173,3 +173,56 @@ def test_deterministic_guard_still_kills() -> None:
     ctx = _ctx_with(D=_det_prim(), F=_det_prim())
     result = DeadGuardedAssignmentElimination().apply(game, ctx)
     assert result != game  # the dead store was killed
+
+
+def test_guard_var_reassigned_before_use_not_killed() -> None:
+    """F-098: the dominating guard's variable (`y`) is reassigned (`y = y + 1`)
+    between the guarded assignment and the `if (v)` use, so the path fact
+    `y == 1` is stale at the inner `if (y == 1)` -- the kill must DECLINE.
+    Here O(1, true) = 1 (Left) is distinguishable from the killed `v = false`
+    form which always returns 0."""
+    game, result = _apply("""
+        Game G() {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                Int y = x;
+                if (y == 1) {
+                    v = c;
+                }
+                y = y + 1;
+                if (v) {
+                    if (y == 1) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """)
+    assert result == game, "stale-guard-fact kill must be declined"
+
+
+def test_guard_var_reassigned_emits_near_miss() -> None:
+    ctx = _make_ctx()
+    game = frog_parser.parse_game("""
+        Game G() {
+            Int O(Int x, Bool c) {
+                Bool v = false;
+                Int y = x;
+                if (y == 1) { v = c; }
+                y = y + 1;
+                if (v) {
+                    if (y == 1) { return 0; }
+                    return 1;
+                }
+                return 0;
+            }
+        }
+        """)
+    DeadGuardedAssignmentElimination().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Dead Guarded Assignment Elimination"
+        and "stale" in nm.reason
+        for nm in ctx.near_misses
+    )

--- a/tests/unit/transforms/test_fold_equivalent_return_branch.py
+++ b/tests/unit/transforms/test_fold_equivalent_return_branch.py
@@ -141,3 +141,40 @@ def test_deterministic_init_field_rhs_enables_fold() -> None:
     ctx = _ctx_with(D=prim, F=prim)
     result = FoldEquivalentReturnBranch().apply(game, ctx)
     assert result != game  # the trivially-equal branch folded
+
+
+def test_init_rhs_field_reassigned_in_oracle_not_folded() -> None:
+    """F-120: the Init-only RHS ``G = F.eval(k)`` references the field ``k``,
+    which an oracle reassigns (``k = kp``).  At the fold site ``F.eval(k)``
+    denotes ``F.eval(kp)``, not the stored ``G = F.eval(k_init)``, so the
+    substitution that would fold ``if (flag) return G; return F.eval(k)`` into
+    ``return F.eval(k)`` is unsound -- the pass must DECLINE."""
+    prim = frog_parser.parse_primitive_file(
+        "Primitive D(Int n) { deterministic BitString<n> eval(BitString<n> x); "
+        "BitString<n> KeyGen(); }"
+    )
+    game = frog_parser.parse_game("""
+        Game Collapse(D F, Int n) {
+            BitString<n> k;
+            BitString<n> G;
+            Void Initialize() {
+                k = F.KeyGen();
+                G = F.eval(k);
+            }
+            BitString<n> Oracle(Bool flag, BitString<n> kp) {
+                k = kp;
+                if (flag) {
+                    return G;
+                }
+                return F.eval(k);
+            }
+        }
+        """)
+    ctx = _ctx_with(D=prim, F=prim)
+    result = FoldEquivalentReturnBranch().apply(game, ctx)
+    assert result == game, "fold wrongly fired across a reassigned RHS field"
+    assert any(
+        nm.transform_name == "Fold Equivalent Return Branch"
+        and "reassigned outside Initialize" in nm.reason
+        for nm in ctx.near_misses
+    )

--- a/tests/unit/transforms/test_fresh_input_rf_to_uniform.py
+++ b/tests/unit/transforms/test_fresh_input_rf_to_uniform.py
@@ -80,7 +80,11 @@ def test_fires_when_exclusion_is_rf_domain() -> None:
 
 
 def test_fires_rf_domain_even_with_adversary_oracle() -> None:
-    # H is also exposed via Hash, but S == H.domain covers those queries too.
+    # H is also exposed via Hash. Whether H.domain tracks those plain queries
+    # (standard ROM) or only `<-uniq[H.domain]` draws (USER-ATTENTION sec 1.b)
+    # is the contested F-002/F-003 ruling; regime A currently trusts the former,
+    # which the ROM example corpus relies on. F-002 is ESCALATED, so this stays
+    # a positive (fires) test pending the ruling.
     _assert_game(
         """
         Game G() {
@@ -300,3 +304,87 @@ def test_does_not_fire_inside_loop() -> None:
             }
         }
         """)
+
+
+def test_f001_conditional_tracking_add_not_fresh() -> None:
+    """F-001 (attack_a): the tracking-add `seen = seen union {x}` is nested under
+    `if (flag)`, so a Probe(x, false) queries RF(x) WITHOUT recording x; a later
+    `v <-uniq[seen]` could draw v == x, making RF(v) a stale re-query.  Decline."""
+    _assert_unchanged(
+        """
+        Game G(Int n, Int m) {
+            Function<BitString<n>, BitString<m>> RF;
+            Set<BitString<n>> seen;
+            Void Initialize() {
+                RF <- Function<BitString<n>, BitString<m>>;
+            }
+            BitString<m> Probe(BitString<n> x, Bool flag) {
+                BitString<m> z = RF(x);
+                if (flag) {
+                    seen = seen union {x};
+                }
+                return z;
+            }
+            BitString<m> Fresh() {
+                BitString<n> v <-uniq[seen] BitString<n>;
+                return RF(v);
+            }
+        }
+        """
+    )
+
+
+def test_f001_tracking_add_after_early_return_not_fresh() -> None:
+    """F-001 (attack_b): the tracking-add is placed AFTER an early return
+    `if (flag) return z;`, so on the flag=true path RF(x) ran but x was never
+    recorded.  Decline."""
+    _assert_unchanged(
+        """
+        Game G(Int n, Int m) {
+            Function<BitString<n>, BitString<m>> RF;
+            Set<BitString<n>> seen;
+            Void Initialize() {
+                RF <- Function<BitString<n>, BitString<m>>;
+            }
+            BitString<m> Probe(BitString<n> x, Bool flag) {
+                BitString<m> z = RF(x);
+                if (flag) {
+                    return z;
+                }
+                seen = seen union {x};
+                return z;
+            }
+            BitString<m> Fresh() {
+                BitString<n> v <-uniq[seen] BitString<n>;
+                return RF(v);
+            }
+        }
+        """
+    )
+
+
+def test_f001_unconditional_tracking_add_still_fires() -> None:
+    """Positive control: an unconditional top-level `seen = seen union {x}`
+    records every RF query, so the fresh-input rewrite still fires."""
+    transformed, _ = _apply(
+        """
+        Game G(Int n, Int m) {
+            Function<BitString<n>, BitString<m>> RF;
+            Set<BitString<n>> seen;
+            Void Initialize() {
+                RF <- Function<BitString<n>, BitString<m>>;
+            }
+            BitString<m> Probe(BitString<n> x) {
+                seen = seen union {x};
+                BitString<m> z = RF(x);
+                return z;
+            }
+            BitString<m> Fresh() {
+                BitString<n> v <-uniq[seen] BitString<n>;
+                return RF(v);
+            }
+        }
+        """
+    )
+    src = str(transformed)
+    assert "<- BitString<m>" in src and "RF(v)" not in src

--- a/tests/unit/transforms/test_if_condition_alias.py
+++ b/tests/unit/transforms/test_if_condition_alias.py
@@ -557,3 +557,61 @@ def test_no_substitution_after_replacement_reassignment() -> None:
     game = frog_parser.parse_game(source)
     result = IfConditionAliasSubstitutionTransformer().transform(game)
     assert result == game, "replacement reassignment must stop substitution (A4)"
+
+
+def test_no_phase1_inline_when_field_defined_in_oracle() -> None:
+    """F-076: a field assigned once in an ORACLE (`SetA(){ A = B; }`) is a
+    single ASSIGNMENT SITE but not a single runtime write -- the adversary can
+    call SetA, then SetB to change B, then read A, leaving A a stale snapshot.
+    The alias `A -> B` is stable only when A and B are written exactly once in
+    Initialize.  Here neither is, so Phase 1 must NOT inline A in Test()."""
+    source = """
+    Game Real() {
+        Int A;
+        Int B;
+        Void SetB(Int x) { B = x; }
+        Void SetA() { A = B; }
+        Int Test(Int y) {
+            if (y == B) {
+                return A;
+            }
+            return 0;
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = IfConditionAliasSubstitutionTransformer().transform(game)
+    test_method = result.get_method("Test")
+    if_stmt = test_method.block.statements[0]
+    assert isinstance(if_stmt, frog_ast.IfStatement)
+    ret_stmt = if_stmt.blocks[0].statements[0]
+    assert isinstance(ret_stmt, frog_ast.ReturnStatement)
+    assert (
+        isinstance(ret_stmt.expression, frog_ast.Variable)
+        and ret_stmt.expression.name == "A"
+    ), "oracle-assigned field A must not be inlined to B (stale-snapshot)"
+
+
+def test_phase1_inline_still_fires_for_initialize_only_fields() -> None:
+    """Positive control: when both the field and its definition's free fields
+    are written exactly once in Initialize, the alias is stable and Phase 1
+    still inlines (the legitimate cross-method pattern)."""
+    source = """
+    Game G() {
+        Int A;
+        Int B;
+        Void Initialize() {
+            B = 5;
+            A = B;
+        }
+        Int Test(Int y) {
+            if (y == B) {
+                return A;
+            }
+            return 0;
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = IfConditionAliasSubstitutionTransformer().transform(game)
+    assert result != game, "Initialize-only field alias should still inline"

--- a/tests/unit/transforms/test_inline_single_use_field.py
+++ b/tests/unit/transforms/test_inline_single_use_field.py
@@ -564,3 +564,33 @@ def test_self_referential_field_emits_near_miss() -> None:
         and "references the field itself" in nm.reason
         for nm in ctx.near_misses
     )
+
+
+def test_cross_method_inline_declines_on_element_mutated_free_var() -> None:
+    """Cross-method inlining of ``A = B`` into a later use is only sound when
+    ``B`` is stable between the snapshot and the use.  An in-place element write
+    ``B[0] = 5`` mutates B, so the stability check (``B`` assigned at most once)
+    must now count that write via lvalue_base_name and decline the inline --
+    otherwise a stale snapshot of B is captured (audit F-079, the
+    InlineSingleUseField route of attack5)."""
+    source = """
+    Game Test() {
+        Map<Int, Int> A;
+        Map<Int, Int> B;
+        Void Setup(Map<Int, Int> b0) {
+            B = b0;
+            A = B;
+        }
+        Void Mut() {
+            B[0] = 5;
+        }
+        Int Probe(Map<Int, Int> y) {
+            if (y == B) {
+                return A[0];
+            }
+            return 7;
+        }
+    }
+    """
+    # A must NOT be inlined to B: the game is unchanged.
+    _transform_and_compare(source, source)

--- a/tests/unit/transforms/test_inline_single_use_field.py
+++ b/tests/unit/transforms/test_inline_single_use_field.py
@@ -518,3 +518,49 @@ def test_no_inline_when_field_assigned_in_nested_block() -> None:
     }
     """
     _transform_and_compare(source, expected)
+
+
+def test_self_referential_field_not_inlined() -> None:
+    """A self-referential accumulator assignment (``c = c + 1``) must not be
+    inlined: the field reads its own previous value, so substituting the
+    definition into uses both drops the cross-call accumulation and -- because
+    the value mentions the field -- would not terminate (audit F-045)."""
+    source = """
+    Game Test() {
+        Int c = 0;
+        Int Initialize() {
+            c = c + 1;
+            return c;
+        }
+    }
+    """
+    # The field is genuine state; the pass must leave the game unchanged.
+    _transform_and_compare(source, source)
+
+
+def test_self_referential_field_emits_near_miss() -> None:
+    from proof_frog.transforms._base import PipelineContext
+    from proof_frog import visitors
+
+    source = """
+    Game Test() {
+        Int c = 0;
+        Int Initialize() {
+            c = c + 1;
+            return c;
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    ctx = PipelineContext(
+        variables={},
+        proof_let_types=visitors.NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+    InlineSingleUseFieldTransformer(ctx=ctx).transform(game)
+    assert any(
+        nm.transform_name == "Inline Single-Use Field"
+        and "references the field itself" in nm.reason
+        for nm in ctx.near_misses
+    )

--- a/tests/unit/transforms/test_map_key_reindex_soundness.py
+++ b/tests/unit/transforms/test_map_key_reindex_soundness.py
@@ -202,3 +202,20 @@ def test_group_exp_compound_exponent_blocks_reindex() -> None:
     )
     misses = _exp_misses(compound)
     assert misses, "a compound exponent must be rejected (F-140)"
+
+
+def test_is_known_nonzero_rekey_resamples_blocks_reindex() -> None:
+    """F-137: a `Rekey()` oracle resampling the group exponent `k` between store
+    and read breaks the stored-key/read-key correspondence even for nonzero
+    values.  The exponent-constancy requirement is subsumed by F-136's
+    "established in Initialize with NO other write anywhere" clause -- the Rekey
+    write voids the guarantee, so the reindex declines."""
+    game = _nonzero_game("""
+        Void Initialize() {
+            k <-uniq[{0}] ModInt<G.order>;
+        }
+        Void Rekey() {
+            k <-uniq[{0}] ModInt<G.order>;
+        }
+        """)
+    assert not is_known_nonzero("k", game)

--- a/tests/unit/transforms/test_remove_unnecessary_statements.py
+++ b/tests/unit/transforms/test_remove_unnecessary_statements.py
@@ -133,3 +133,24 @@ def test_unnecessary_statements(method: str, expected: str, fields: list[str]) -
     new_method.block = transformed_block
     print("TRANSFORMED", new_method)
     assert expected_ast == new_method
+
+
+def test_dead_uniq_sample_survives_but_minus_form_removed() -> None:
+    """A dead-target ``<-uniq[S]`` draw has an observable side effect (it
+    inserts the drawn value into S, visible via |S|), so it must NOT be deleted
+    as dead code; the pure set-minus form ``<- T \\ S`` performs no insertion
+    and a dead-target draw of it IS removable (audit F-095, subsumed by the
+    RC2 F-004 dead-code fix)."""
+    method = frog_parser.parse_method(
+        """
+        Int f() {
+            BitString<8> a <-uniq[S] BitString<8>;
+            BitString<8> b <- BitString<8> \\ S;
+            return 1;
+        }
+        """
+    )
+    transformed = dependencies.remove_unnecessary_statements(["S"], method.block)
+    text = str(transformed)
+    assert "<-uniq[S]" in text, f"dead uniq draw was wrongly removed:\n{text}"
+    assert "\\ S" not in text, f"pure set-minus dead draw should be removed:\n{text}"

--- a/tests/unit/transforms/test_single_call_field_to_local_f056.py
+++ b/tests/unit/transforms/test_single_call_field_to_local_f056.py
@@ -1,0 +1,54 @@
+"""F-056 regression: SingleCallFieldToLocal must account for sibling-method
+calls when deciding whether a field's read site runs at most once."""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.sampling import _single_call_field_to_local
+
+
+def test_sibling_call_to_read_site_blocks_localization() -> None:
+    """F-056: the field ``x`` is read in ``Helper``, which is invoked by the
+    sibling ``Probe`` via ``Left.Helper()``.  One adversary call to Probe runs
+    Helper an extra time, so the persistent field (read repeatedly) is not
+    interchangeable with a per-call fresh local -- the pass must DECLINE."""
+    game = frog_parser.parse_game("""
+        Game Left(Int n) {
+            BitString<n> x;
+            Void Initialize() {
+                x <- BitString<n>;
+            }
+            BitString<n> Helper() {
+                return x;
+            }
+            BitString<n> Probe() {
+                return Left.Helper();
+            }
+        }
+        """)
+    assert _single_call_field_to_local(game) == game
+
+
+def test_no_sibling_call_still_localizes() -> None:
+    """Positive control: with no internal call to the read site, the move still
+    fires."""
+    game = frog_parser.parse_game("""
+        Game Left(Int n) {
+            BitString<n> x;
+            Void Initialize() {
+                x <- BitString<n>;
+            }
+            BitString<n> Helper() {
+                return x;
+            }
+        }
+        """)
+    expected = frog_parser.parse_game("""
+        Game Left(Int n) {
+            Void Initialize() {
+            }
+            BitString<n> Helper() {
+                BitString<n> x <- BitString<n>;
+                return x;
+            }
+        }
+        """)
+    assert _single_call_field_to_local(game) == expected

--- a/tests/unit/transforms/test_split_uniform_samples.py
+++ b/tests/unit/transforms/test_split_uniform_samples.py
@@ -370,3 +370,39 @@ def test_f035_clean_case_single_declaration_still_fires() -> None:
         frog_parser.parse_method(method)
     )
     assert transformed == frog_parser.parse_method(expected)
+
+
+def test_f032_declines_when_slice_index_reassigned() -> None:
+    """F-032: both slices are textually `z[i : i + 4]`, but `i = i + 4` between
+    them makes them the non-overlapping ranges `z[0:4]` and `z[4:8]`.  Resolving
+    `i` by name to one symbol would dedup them to a single fresh piece, turning
+    the uniform `z[0:4] xor z[4:8]` into 0.  The pass must DECLINE."""
+    method = """
+        BitString<4> f() {
+            Int i = 0;
+            BitString<8> z <- BitString<8>;
+            BitString<4> a = z[i : i + 4];
+            i = i + 4;
+            BitString<4> b = z[i : i + 4];
+            return a + b;
+        }
+        """
+    parsed = frog_parser.parse_method(method)
+    transformed = SplitUniformSampleTransformer({}).transform(parsed)
+    assert transformed == parsed, "split fired across a reassigned slice index"
+
+
+def test_f032_constant_bounds_still_split() -> None:
+    """Positive control: with constant (non-reassigned) bounds the split still
+    fires."""
+    method = """
+        BitString<4> f() {
+            BitString<8> z <- BitString<8>;
+            BitString<4> a = z[0 : 4];
+            BitString<4> b = z[4 : 8];
+            return a + b;
+        }
+        """
+    parsed = frog_parser.parse_method(method)
+    transformed = SplitUniformSampleTransformer({}).transform(parsed)
+    assert transformed != parsed, "constant-bound split should still fire"

--- a/tests/unit/transforms/test_uniform_modint_simplification.py
+++ b/tests/unit/transforms/test_uniform_modint_simplification.py
@@ -1,0 +1,105 @@
+"""Tests for UniformModIntSimplification, including the loop-reuse soundness
+guard (audit F-132c): a uniform ModInt sampled OUTSIDE a loop and consumed
+INSIDE it is reused once per iteration, so the "used exactly once" absorption
+`acc = acc + t` -> `acc = t` would change the distribution (`2t` even-only vs
+uniform `t`) and must be declined."""
+
+from proof_frog import frog_parser, visitors
+from proof_frog.transforms.algebraic import UniformModIntSimplification
+from proof_frog.transforms._base import PipelineContext
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=visitors.NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _apply(source: str) -> str:
+    game = frog_parser.parse_game(source)
+    return str(UniformModIntSimplification().apply(game, _ctx()))
+
+
+def test_sample_outside_loop_use_inside_not_absorbed() -> None:
+    """Negative: sample outside a >=2-iteration loop, additive use inside ->
+    decline (the value is reused across iterations)."""
+    result = _apply(
+        """
+        Game G() {
+            ModInt<16> acc;
+            ModInt<16> Probe() {
+                acc = 0;
+                ModInt<16> t <- ModInt<16>;
+                for (ModInt<16> i in {1, 2}) {
+                    acc = acc + t;
+                }
+                return acc;
+            }
+        }
+        """
+    )
+    assert "acc = acc + t" in result, f"loop-reused uniform was absorbed:\n{result}"
+
+
+def test_plain_non_loop_absorption_still_fires() -> None:
+    """Positive control: ordinary single-use absorption is unchanged."""
+    result = _apply(
+        """
+        Game G() {
+            ModInt<16> Probe(ModInt<16> m) {
+                ModInt<16> u <- ModInt<16>;
+                return u + m;
+            }
+        }
+        """
+    )
+    assert "return u" in result and "u + m" not in result
+
+
+def test_sample_inside_loop_fresh_each_iteration_still_fires() -> None:
+    """Positive control: when the sample is INSIDE the loop body, each
+    iteration draws a fresh value used once, so the absorption is sound."""
+    result = _apply(
+        """
+        Game G() {
+            ModInt<16> acc;
+            ModInt<16> Probe() {
+                acc = 0;
+                for (ModInt<16> i in {1, 2}) {
+                    ModInt<16> t <- ModInt<16>;
+                    acc = acc + t;
+                }
+                return acc;
+            }
+        }
+        """
+    )
+    assert "acc = t" in result
+
+
+def test_loop_reuse_emits_near_miss() -> None:
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            ModInt<16> acc;
+            ModInt<16> Probe() {
+                acc = 0;
+                ModInt<16> t <- ModInt<16>;
+                for (ModInt<16> i in {1, 2}) {
+                    acc = acc + t;
+                }
+                return acc;
+            }
+        }
+        """
+    )
+    ctx = _ctx()
+    UniformModIntSimplification().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Uniform ModInt Simplification"
+        and "reused across" in nm.reason
+        for nm in ctx.near_misses
+    )

--- a/tests/unit/transforms/test_unique_rf_simplification.py
+++ b/tests/unit/transforms/test_unique_rf_simplification.py
@@ -317,3 +317,48 @@ def test_dotted_nondomain_exclusion_set_modified_not_simplified() -> None:
     assert not _exclusion_set_modified(game, "RF.domain")
     # A non-`.domain` dotted set with an explicit field assignment IS flagged.
     assert _exclusion_set_modified(game, "S.field")
+
+
+def test_guard_var_reassigned_before_rf_call_not_simplified() -> None:
+    """F-022: a guarded variable `r <-uniq[S]` reassigned to an
+    adversary-controlled value (`r = c`) before `RF(r)` no longer holds the
+    fresh draw, so the freshness guard must be invalidated and the RF call
+    left unsimplified."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            Set<BitString<8>> S;
+            Function<BitString<8>, BitString<16>> RF;
+            Void Initialize() {
+                RF <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Query(BitString<8> c) {
+                BitString<8> r <-uniq[S] BitString<8>;
+                r = c;
+                BitString<16> z = RF(r);
+                return z;
+            }
+        }
+        """)
+    result = UniqueRFSimplification().apply(game, _make_ctx())
+    assert result == game, "RF(r) after `r = c` must not be simplified (stale guard)"
+
+
+def test_fresh_guard_without_reassignment_still_simplified() -> None:
+    """Positive control: with no intervening reassignment the guarded fresh
+    draw still enables simplification."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            Set<BitString<8>> S;
+            Function<BitString<8>, BitString<16>> RF;
+            Void Initialize() {
+                RF <- Function<BitString<8>, BitString<16>>;
+            }
+            BitString<16> Query() {
+                BitString<8> r <-uniq[S] BitString<8>;
+                BitString<16> z = RF(r);
+                return z;
+            }
+        }
+        """)
+    result = UniqueRFSimplification().apply(game, _make_ctx())
+    assert result != game, "clean fresh-draw RF call should still simplify"

--- a/tests/unit/transforms/test_unreachable_transformer.py
+++ b/tests/unit/transforms/test_unreachable_transformer.py
@@ -775,3 +775,23 @@ def test_ru_dedups_deterministic_duplicate_condition() -> None:
     ctx = _ru_ctx(D=_ru_det_prim(), F=_ru_det_prim())
     result = RemoveUnreachable().apply(game, ctx)
     assert result != game  # the dead duplicate if was removed
+
+
+def test_remove_unreachable_branch_write_clears_seen_condition() -> None:
+    """F-105 (Case B): an assignment INSIDE a kept if-branch (`if (b==0){ x=0; }`)
+    reassigns x between two `if (x==0) return` guards, so the second guard is
+    reachable (O(1,0) returns 2) and must NOT be deleted against the stale
+    `x==0` fact from the first guard."""
+    method = frog_parser.parse_method("""
+        Int O(Int a, Int b) {
+            Int x = a;
+            if (x == 0) { return 1; }
+            if (b == 0) { x = 0; }
+            if (x == 0) { return 2; }
+            return 3;
+        }
+        """)
+    transformed = RemoveUnreachableTransformer(method).transform(method)
+    assert (
+        _count_ifs(transformed) == 3
+    ), f"live `if (x==0) return 2` was wrongly deleted:\n{transformed}"

--- a/tests/unit/visitors/test_instantiation_transformer.py
+++ b/tests/unit/visitors/test_instantiation_transformer.py
@@ -106,3 +106,57 @@ def test_funccall_field_unknown_scheme_returns_original() -> None:
     result = visitors.InstantiationTransformer(namespace).transform(node)
     assert isinstance(result, frog_ast.FieldAccess)
     assert result.name == "EncapsKey"
+
+
+def test_mutable_field_initializer_not_substituted_into_body() -> None:
+    """A field that is reassigned in a method body is genuine state, not a
+    constant alias.  ``InstantiationTransformer`` must NOT substitute its
+    initializer into reads -- doing so silently drops the mutation
+    (``c = c + 1; return c`` would become ``return 0``).  Audit F-045.
+    """
+    from proof_frog import frog_parser
+
+    game = frog_parser.parse_game(
+        """
+        Game Real() {
+            Int c = 0;
+            Int Initialize() {
+                c = c + 1;
+                return c;
+            }
+        }
+        """
+    )
+    result = visitors.InstantiationTransformer({}).transform(game)
+    # The mutating read/write must survive verbatim -- no `c -> 0` rewrite.
+    assert result == game
+
+
+def test_constant_field_initializer_still_substituted() -> None:
+    """Positive control: a field that is never reassigned IS a constant alias,
+    so its initializer is still substituted into reads (the legitimate
+    behaviour F-045's fix preserves)."""
+    from proof_frog import frog_parser
+
+    game = frog_parser.parse_game(
+        """
+        Game Const() {
+            Int n = 5;
+            Int Initialize() {
+                return n;
+            }
+        }
+        """
+    )
+    result = visitors.InstantiationTransformer({}).transform(game)
+    expected = frog_parser.parse_game(
+        """
+        Game Const() {
+            Int n = 5;
+            Int Initialize() {
+                return 5;
+            }
+        }
+        """
+    )
+    assert result == expected


### PR DESCRIPTION
Several canonicalization passes proved two games equivalent by trusting a fact
that only holds at one point in the program (a field's definition, a guard
condition, a "this value is fresh" flag) without checking that a later write,
or a different oracle call order, could invalidate it. In each of these the
engine accepted a game hop whose two sides are actually distinguishable. This
adds the missing checks. Finding IDs from the audit are in parentheses.

### Field and value inlining

- `InstantiationTransformer` inlined a field's initializer into every read,
  including fields that get reassigned, so `Int c = 0; c = c + 1; return c`
  collapsed to `return 0`. It now only inlines fields that are never
  reassigned. Preserving the mutation also exposed an infinite loop in
  `InlineSingleUseField` on a self-referential `c = c + 1`, fixed here. (F-045)
- `IfConditionAliasSubstitution` treated `A = B` in one oracle as a permanent
  alias, but an adversary can set `A`, change `B`, then read `A`. It now only
  aliases fields written once, in `Initialize`. (F-076)
- `FoldEquivalentReturnBranch` substituted `G -> F.eval(k)` from `Initialize`
  into an oracle that reassigns `k`. It now requires every field in the
  substituted expression to be written only once. (F-120)
- `InlineSingleUseField` moved a field whose value depended on another field
  that was element-mutated between the snapshot and the use. (F-079, partial)
- `SingleCallFieldToLocal` moved a sampled field into an oracle whose read site
  is reached by a sibling call, so it can run more than once. It now declines
  when the read site is called internally. (F-056)

### Sampling

- `SplitUniformSamples` resolved slice bounds by name, so
  `z[i:i+4] ... i = i + 4 ... z[i:i+4]` looked like one slice and got merged,
  turning the uniform `z[0:4] xor z[4:8]` into `0`. It now declines when a
  slice-bound variable is reassigned between the slices. (F-032)
- `UniformModIntSimplification` absorbed `acc = acc + t` into `acc = t` inside a
  loop that reuses a single `t`, so `2t` became a uniform `t`. It now declines
  unless `t` is drawn fresh each iteration. (F-132)
- `CounterGuardedFieldToLocal`'s constant-guard check looked at fields and
  parameters but not a local `t = x` aliasing a parameter, so `ctr == t` could
  fire every call. Locals derived from mutable state are now tracked. (F-049)

### Control flow

- `RemoveUnreachable` deleted a live `if (x == 0) return` because an assignment
  inside a preceding `if`-branch never invalidated the earlier identical guard.
  (F-105)
- `DeadGuardedAssignmentElimination` carried a guard's truth across an
  intervening `y = y + 1`. (F-098)
- `AbsorbRedundantEarlyReturn` folded `!P` onto later guards while an
  intervening body reassigned a variable of `P`. (F-110)

### Random functions

- `ChallengeExclusionRFToUniform` rewrote `H(cf)` to a fresh sample even when an
  oracle could reassign `cf`, or reassign the guard variable back to `cf`, which
  re-exposes `H(cf)`. (F-013, F-014)
- `FreshInputRFToUniform` accepted a freshness-tracking update
  `seen = seen union {x}` that sits under a branch or after an early return, so
  some queries went unrecorded. (F-001)
- `UniqueRFSimplification` kept treating `RF(r)` as a fresh input after `r` was
  reassigned to an arbitrary value. (F-022)

Two more findings (F-095, F-137) were already prevented by existing guards;
regression tests are added to lock that in.