### PR TITLE
Fix latex-export pylint findings (break import cycles + per-file)

### DIFF
--- a/proof_frog/export/latex/document.py
+++ b/proof_frog/export/latex/document.py
@@ -1,0 +1,76 @@
+"""Document assembly for LaTeX export.
+
+A leaf module: ``assemble`` wraps a rendered body as a standalone document or
+an ``\\input``-able fragment. It lives here (rather than in ``exporter``) so
+both ``exporter`` and ``proof_renderer`` can import it without forming an
+import cycle.
+"""
+
+from __future__ import annotations
+
+from .backends.base import Backend
+from .macros import MacroRegistry
+
+
+def _package_lines(backend: Backend) -> list[str]:
+    lines = []
+    for spec in backend.required_packages():
+        if spec.options:
+            lines.append(rf"\usepackage[{','.join(spec.options)}]{{{spec.name}}}")
+        else:
+            lines.append(rf"\usepackage{{{spec.name}}}")
+    return lines
+
+
+def _fragment(backend: Backend, macros: MacroRegistry, body: str) -> str:
+    """Assemble an ``\\input``-able fragment (no document wrapper).
+
+    Packages and ``preamble_extras`` (e.g. ``\\newtheorem``) cannot appear in
+    the document body, so they are listed in a commented header for the user
+    to copy into their own preamble. The generated ``\\providecommand`` macros
+    *can* live in the body and are emitted inline so a bare ``\\input`` works
+    without hand-copying them; ``\\providecommand`` yields to any definition the
+    user already has, so inlining is safe.
+    """
+    preamble: list[str] = list(_package_lines(backend))
+    extras = backend.preamble_extras()
+    if extras:
+        preamble.extend(extras.splitlines())
+    header = [
+        "% --- ProofFrog LaTeX export (fragment; \\input this file) ---",
+        "% Add the following lines to your document preamble:",
+        *(f"% {line}" for line in preamble),
+        "% The \\providecommand macros below may stay inline (they yield to",
+        "% any definitions already in your preamble).",
+        "% -----------------------------------------------------------",
+    ]
+    parts = [
+        "\n".join(header),
+        macros.preamble().rstrip(),
+        body,
+        "",
+    ]
+    return "\n".join(p for p in parts if p != "")
+
+
+def assemble(
+    backend: Backend, macros: MacroRegistry, body: str, standalone: bool = True
+) -> str:
+    """Wrap a rendered ``body`` as a full document or an ``\\input`` fragment."""
+    if not standalone:
+        return _fragment(backend, macros, body)
+    extras = backend.preamble_extras()
+    parts = [
+        r"\documentclass{article}",
+        # Page geometry is document-level, so it lives only in the self-contained
+        # build; an \input fragment inherits the host document's margins.
+        r"\usepackage[letterpaper,margin=1in]{geometry}",
+        *_package_lines(backend),
+        *([extras] if extras else []),
+        macros.preamble().rstrip(),
+        r"\begin{document}",
+        body,
+        r"\end{document}",
+        "",
+    ]
+    return "\n".join(p for p in parts if p != "")

--- a/proof_frog/export/latex/exporter.py
+++ b/proof_frog/export/latex/exporter.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from ... import frog_parser
 from .backends.cryptocode import CryptocodeBackend
 from .backends.base import Backend
+from .document import assemble
 from .macros import MacroRegistry
 from .module_renderer import ModuleRenderer
 
@@ -19,71 +20,7 @@ def _make_backend(name: str, diff_style: str = "box") -> Backend:
     return _BACKENDS[name](diff_style=diff_style)  # type: ignore[abstract,call-arg]
 
 
-def _package_lines(backend: Backend) -> list[str]:
-    lines = []
-    for spec in backend.required_packages():
-        if spec.options:
-            lines.append(rf"\usepackage[{','.join(spec.options)}]{{{spec.name}}}")
-        else:
-            lines.append(rf"\usepackage{{{spec.name}}}")
-    return lines
-
-
-def _fragment(backend: Backend, macros: MacroRegistry, body: str) -> str:
-    """Assemble an ``\\input``-able fragment (no document wrapper).
-
-    Packages and ``preamble_extras`` (e.g. ``\\newtheorem``) cannot appear in
-    the document body, so they are listed in a commented header for the user
-    to copy into their own preamble. The generated ``\\providecommand`` macros
-    *can* live in the body and are emitted inline so a bare ``\\input`` works
-    without hand-copying them; ``\\providecommand`` yields to any definition the
-    user already has, so inlining is safe.
-    """
-    preamble: list[str] = list(_package_lines(backend))
-    extras = backend.preamble_extras()
-    if extras:
-        preamble.extend(extras.splitlines())
-    header = [
-        "% --- ProofFrog LaTeX export (fragment; \\input this file) ---",
-        "% Add the following lines to your document preamble:",
-        *(f"% {line}" for line in preamble),
-        "% The \\providecommand macros below may stay inline (they yield to",
-        "% any definitions already in your preamble).",
-        "% -----------------------------------------------------------",
-    ]
-    parts = [
-        "\n".join(header),
-        macros.preamble().rstrip(),
-        body,
-        "",
-    ]
-    return "\n".join(p for p in parts if p != "")
-
-
-def assemble(
-    backend: Backend, macros: MacroRegistry, body: str, standalone: bool = True
-) -> str:
-    """Wrap a rendered ``body`` as a full document or an ``\\input`` fragment."""
-    if not standalone:
-        return _fragment(backend, macros, body)
-    extras = backend.preamble_extras()
-    parts = [
-        r"\documentclass{article}",
-        # Page geometry is document-level, so it lives only in the self-contained
-        # build; an \input fragment inherits the host document's margins.
-        r"\usepackage[letterpaper,margin=1in]{geometry}",
-        *_package_lines(backend),
-        *([extras] if extras else []),
-        macros.preamble().rstrip(),
-        r"\begin{document}",
-        body,
-        r"\end{document}",
-        "",
-    ]
-    return "\n".join(p for p in parts if p != "")
-
-
-def export_file(
+def export_file(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     path: str,
     backend_name: str = "cryptocode",
     composition: str = "symbolic",

--- a/proof_frog/export/latex/expr_renderer.py
+++ b/proof_frog/export/latex/expr_renderer.py
@@ -190,11 +190,9 @@ class ExprRenderer:
             side = self.macros.register_algorithm(expr.which)
             return f"{head}.{side}"
         # A Type used in expression position (e.g. `a <- ModInt<q>;`):
-        # delegate to TypeRenderer to avoid the fallback comment.
+        # delegate to TypeRenderer (defined below in this module) to avoid the
+        # fallback comment.
         if isinstance(expr, frog_ast.Type):
-            # pylint: disable=import-outside-toplevel
-            from .type_renderer import TypeRenderer
-
             return TypeRenderer(self).render(expr)
         # Unknown node: emit a math-safe placeholder. A bare `%` comment would
         # comment out the rest of the line — fatal inside a `$...$` span.
@@ -401,3 +399,68 @@ class ExprRenderer:
         else:
             tail = self._render_variable(expr.name)
         return f"{head}.{tail}"
+
+
+class TypeRenderer:
+    """Render ``frog_ast.Type`` nodes to LaTeX math strings.
+
+    Co-located with :class:`ExprRenderer` (which it composes, and which in turn
+    renders a ``Type`` in expression position via this class) so the mutual
+    dependency stays within one module instead of forming an import cycle.
+    """
+
+    def __init__(self, expr: ExprRenderer) -> None:
+        self.expr = expr
+
+    def _render_type_name(self, expr: frog_ast.Expression) -> str:
+        """Render a name appearing in a type, macroifying algorithm-like names.
+
+        A group/scheme variable inside a type argument (e.g. the ``G`` in
+        ``GroupElem<G>``) should read as its ``\\G`` macro, matching how the
+        same identifier renders elsewhere, so a game reference shows
+        ``\\RandomTargetGuessing(\\G)`` not ``(G)``.
+        """
+        if isinstance(expr, frog_ast.Variable) and _looks_like_algorithm_name(
+            expr.name
+        ):
+            return self.expr.macros.register_algorithm(expr.name)
+        return self.expr.render(expr)
+
+    # pylint: disable=too-many-return-statements,too-many-branches
+    def render(self, t: frog_ast.Type) -> str:
+        if isinstance(t, frog_ast.IntType):
+            return r"\mathbb{Z}"
+        if isinstance(t, frog_ast.BoolType):
+            return r"\{0,1\}"
+        if isinstance(t, frog_ast.Void):
+            return r"\bot"
+        if isinstance(t, frog_ast.BitStringType):
+            if t.parameterization is None:
+                return r"\{0,1\}^{*}"
+            return rf"\{{0,1\}}^{{{self.expr.render(t.parameterization)}}}"
+        if isinstance(t, frog_ast.SetType):
+            if t.parameterization is None:
+                return r"\mathsf{Set}"
+            return rf"\mathsf{{Set}}({self.render(t.parameterization)})"
+        if isinstance(t, frog_ast.ArrayType):
+            return rf"{self.render(t.element_type)}^{{{self.expr.render(t.count)}}}"
+        if isinstance(t, frog_ast.MapType):
+            return rf"{self.render(t.key_type)} \to {self.render(t.value_type)}"
+        if isinstance(t, frog_ast.ModIntType):
+            return rf"\mathbb{{Z}}_{{{self.expr.render(t.modulus)}}}"
+        if isinstance(t, frog_ast.GroupType):
+            return r"\mathsf{Group}"
+        if isinstance(t, frog_ast.GroupElemType):
+            return self._render_type_name(t.group)
+        if isinstance(t, frog_ast.ProductType):
+            inner = r" \times ".join(self.render(s) for s in t.types)
+            return inner
+        if isinstance(t, frog_ast.FunctionType):
+            return rf"{self.render(t.domain_type)} \to {self.render(t.range_type)}"
+        if isinstance(t, frog_ast.OptionalType):
+            return rf"{self.render(t.the_type)}^{{?}}"
+        if isinstance(t, frog_ast.Variable):
+            return self._render_type_name(t)
+        if isinstance(t, frog_ast.FieldAccess):
+            return self.expr.render(t)
+        return f"% unsupported type: {type(t).__name__}"

--- a/proof_frog/export/latex/proof_renderer.py
+++ b/proof_frog/export/latex/proof_renderer.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from ... import frog_ast
 from . import ir
 from .backends.base import Backend
+from .document import assemble
 from .expr_renderer import _looks_like_algorithm_name
 from .macros import MacroRegistry
 from .module_renderer import ModuleRenderer
@@ -31,7 +32,7 @@ class _SymbolicHeading:
     sections_ref: bool  # start/end step: heading-only, references shared sections
 
 
-def render_proof(
+def render_proof(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     ctx: "ProofContext",
     backend: Backend,
     macros: MacroRegistry,
@@ -51,9 +52,6 @@ def render_proof(
     The body is rendered first so macro registration populates the preamble,
     then the document (or fragment) is assembled.
     """
-    # pylint: disable=import-outside-toplevel
-    from .exporter import assemble
-
     # Make proof-level let types visible to operand disambiguation (`+`/`||`)
     # inside reduction / intermediate-game bodies.
     renderer.base_name_types = ctx.let_types()
@@ -327,9 +325,9 @@ def _step_figure_ir(
     try:
         if composition == "inlined":
             game = ctx.resolve_inlined(step)
-            block = renderer._method_blocks_vstack(
+            block = renderer._method_blocks_vstack(  # pylint: disable=protected-access
                 game
-            )  # pylint: disable=protected-access
+            )
             return ir.Figure(body=block, caption=caption, label=label), None
         # symbolic mode
         sr = ctx.resolve_symbolic(step)
@@ -346,9 +344,9 @@ def _step_figure_ir(
             sections_ref=sr.novel is None,
         )
         if sr.novel is not None:
-            vstack = renderer._method_blocks_vstack(
+            vstack = renderer._method_blocks_vstack(  # pylint: disable=protected-access
                 sr.novel
-            )  # pylint: disable=protected-access
+            )
             # heading is assembled later by _apply_symbolic_diff from `head`.
             return ir.Figure(body=vstack, caption=caption, label=label), head
         # start/end step: heading only, referencing the shared sections.

--- a/proof_frog/export/latex/type_renderer.py
+++ b/proof_frog/export/latex/type_renderer.py
@@ -1,66 +1,14 @@
-"""Render FrogLang ``Type`` AST nodes to LaTeX math."""
+"""Render FrogLang ``Type`` AST nodes to LaTeX math.
+
+``TypeRenderer`` now lives in :mod:`.expr_renderer`, co-located with
+``ExprRenderer`` because the two mutually depend on each other (TypeRenderer
+composes an ExprRenderer; ExprRenderer renders a ``Type`` in expression
+position via TypeRenderer). Keeping them in one module avoids an import cycle.
+This module re-exports ``TypeRenderer`` for backward compatibility.
+"""
 
 from __future__ import annotations
 
-from ... import frog_ast
-from .expr_renderer import ExprRenderer, _looks_like_algorithm_name
+from .expr_renderer import TypeRenderer
 
-
-class TypeRenderer:
-    """Render ``frog_ast.Type`` nodes to LaTeX math strings."""
-
-    def __init__(self, expr: ExprRenderer) -> None:
-        self.expr = expr
-
-    def _render_type_name(self, expr: frog_ast.Expression) -> str:
-        """Render a name appearing in a type, macroifying algorithm-like names.
-
-        A group/scheme variable inside a type argument (e.g. the ``G`` in
-        ``GroupElem<G>``) should read as its ``\\G`` macro, matching how the
-        same identifier renders elsewhere, so a game reference shows
-        ``\\RandomTargetGuessing(\\G)`` not ``(G)``.
-        """
-        if isinstance(expr, frog_ast.Variable) and _looks_like_algorithm_name(
-            expr.name
-        ):
-            return self.expr.macros.register_algorithm(expr.name)
-        return self.expr.render(expr)
-
-    # pylint: disable=too-many-return-statements,too-many-branches
-    def render(self, t: frog_ast.Type) -> str:
-        if isinstance(t, frog_ast.IntType):
-            return r"\mathbb{Z}"
-        if isinstance(t, frog_ast.BoolType):
-            return r"\{0,1\}"
-        if isinstance(t, frog_ast.Void):
-            return r"\bot"
-        if isinstance(t, frog_ast.BitStringType):
-            if t.parameterization is None:
-                return r"\{0,1\}^{*}"
-            return rf"\{{0,1\}}^{{{self.expr.render(t.parameterization)}}}"
-        if isinstance(t, frog_ast.SetType):
-            if t.parameterization is None:
-                return r"\mathsf{Set}"
-            return rf"\mathsf{{Set}}({self.render(t.parameterization)})"
-        if isinstance(t, frog_ast.ArrayType):
-            return rf"{self.render(t.element_type)}^{{{self.expr.render(t.count)}}}"
-        if isinstance(t, frog_ast.MapType):
-            return rf"{self.render(t.key_type)} \to {self.render(t.value_type)}"
-        if isinstance(t, frog_ast.ModIntType):
-            return rf"\mathbb{{Z}}_{{{self.expr.render(t.modulus)}}}"
-        if isinstance(t, frog_ast.GroupType):
-            return r"\mathsf{Group}"
-        if isinstance(t, frog_ast.GroupElemType):
-            return self._render_type_name(t.group)
-        if isinstance(t, frog_ast.ProductType):
-            inner = r" \times ".join(self.render(s) for s in t.types)
-            return inner
-        if isinstance(t, frog_ast.FunctionType):
-            return rf"{self.render(t.domain_type)} \to {self.render(t.range_type)}"
-        if isinstance(t, frog_ast.OptionalType):
-            return rf"{self.render(t.the_type)}^{{?}}"
-        if isinstance(t, frog_ast.Variable):
-            return self._render_type_name(t)
-        if isinstance(t, frog_ast.FieldAccess):
-            return self.expr.render(t)
-        return f"% unsupported type: {type(t).__name__}"
+__all__ = ["TypeRenderer"]


### PR DESCRIPTION
## Summary

The LaTeX exporter (#222) carries pylint debt that `pylint proof_frog` on `main` passes only by luck: pylint's package-mode traversal never closes the latex-internal import cycles, so the cyclic-import (`R0401`) and the per-file findings it cascades stay quiet. Add any sibling package to the module graph (e.g. the EasyCrypt exporter on the `easycrypt` branch) and pylint *discovers* the cycle, surfacing `R0401` plus `too-many-arguments`/`too-many-positional-arguments` and `protected-access` on the same modules — turning `make lint` red.

This fixes the root causes rather than suppressing the symptom.

## Changes

- **Break the `exporter ↔ proof_renderer` cycle** by extracting the leaf document-assembly helpers (`assemble`, `_fragment`, `_package_lines`) into a new `document.py`; both `exporter` and `proof_renderer` now import it one-directionally. `assemble` was not imported by any test, so this is API-safe.
- **Break the `expr_renderer ↔ type_renderer` cycle** by co-locating `TypeRenderer` (which composes `ExprRenderer`, which in turn renders a `Type` in expression position via `TypeRenderer`) in `expr_renderer.py`. `type_renderer.py` re-exports it for backward compatibility (`module_renderer` and `test_type_renderer` still import from there).
- **Relocate the two `# pylint: disable=protected-access` comments** onto the access line — they were on the closing-paren line, so pylint ignored them.
- **Add `too-many-arguments,too-many-positional-arguments` disables** to the two public render entry points (`export_file`, `render_proof`).

No behavior change — purely structural (function/class relocation) plus disable placement.

## Verification

- `make lint`: **PASS** — black ✓, mypy ✓, pylint **10.00/10**, tsc ✓.
- `pylint proof_frog` is now also clean (**10.00/10**) when the EasyCrypt export package is in the module graph (verified by applying this change on the `easycrypt` branch).
- **211 latex tests pass** (`tests/unit/export/latex/`, `tests/integration/test_latex_export*.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)