### PR TITLE
latex export: name decorations, Iverson-bracket bool returns, upright `this`

### DIFF
--- a/proof_frog/export/latex/backends/cryptocode.py
+++ b/proof_frog/export/latex/backends/cryptocode.py
@@ -48,6 +48,8 @@ class CryptocodeBackend:
             PackageSpec("amsthm"),
             PackageSpec("adjustbox"),
             PackageSpec("varwidth"),
+            # \llbracket / \rrbracket for Iverson-bracketed boolean returns.
+            PackageSpec("stmaryrd"),
         ]
 
     def fit_width(self, content: str) -> str:

--- a/proof_frog/export/latex/expr_renderer.py
+++ b/proof_frog/export/latex/expr_renderer.py
@@ -84,6 +84,12 @@ _GREEK_UPPER = [
 ]
 _KEYWORD_VARIABLES = {name: "\\" + name for name in _GREEK_LOWER + _GREEK_UPPER}
 
+# Reserved FrogLang keywords that appear in expression position (e.g. a scheme
+# self-call ``this.DeriveKeyPair(..)``). Set upright as keywords rather than let
+# them fall through to the variable path, where a multi-letter name renders as a
+# run of italic letters (``this`` -> ``t\,h\,i\,s``).
+_RESERVED_UPRIGHT = {"this": r"\mathsf{this}"}
+
 # Field members that denote a group's generator/order. On parse paths that
 # kept them as a plain ``FieldAccess`` (rather than the dedicated
 # ``GroupGenerator`` / ``GroupOrder`` nodes) they are routed to the same
@@ -93,15 +99,25 @@ _GROUP_SYMBOL_MEMBERS = {"generator": "generator", "order": "order"}
 _SUBSCRIPT_RE = re.compile(r"^(.+?)(\d+)$")
 
 # B4: a closed allow-list of name decorations rendered as math superscripts or
-# accents. Matched only at a camelCase boundary (a lowercase letter or digit
-# precedes the capitalized suffix), so literals like ``polestar`` and acronym
-# runs like ``ABStar`` are left untouched. Source identifiers stay legal
-# FrogLang; the operator-disambiguation maps key off the *raw* name, so this is
-# invisible to them.
+# accents. A trailing decoration word (capitalized first letter, e.g. ``Star``)
+# decorates whatever non-empty stem precedes it, whether that stem ends in a
+# lowercase/digit (``ctStar`` -> ``ct^{*}``), a single capital (``ZStar`` ->
+# ``Z^{*}``), or a capital run (``ABStar`` -> ``AB^{*}``). The capitalized-suffix
+# form is required, so all-lowercase literals like ``polestar`` never match.
+# Presentation intent that this greedy rule gets wrong (a real compound word
+# such as ``menuBar``) is not recoverable from the identifier alone; those are
+# rare in game code and are the caller's to override. Source identifiers stay
+# legal FrogLang; the operator-disambiguation maps key off the *raw* name, so
+# this is invisible to them.
 _DECORATION_SUPERSCRIPTS = {"Star": r"^{*}", "Prime": r"^{\prime}"}
 _DECORATION_ACCENTS = {"Hat": r"\hat", "Tilde": r"\tilde", "Bar": r"\overline"}
+# The optional ``tail`` folds a subscript that *follows* the decoration into the
+# subscript group, so a decorated name still subscripts cleanly: a trailing digit
+# run (``ctStar0`` -> ``ct_{0}^{*}``) or an ``_``-delimited suffix
+# (``mStar_in`` -> ``m^{*}_{in}``) both land on the subscript axis, alongside any
+# subscript already on the stem, without stacking into a double subscript.
 _DECORATION_RE = re.compile(
-    r"^(?P<head>.*[a-z0-9])(?P<deco>Star|Prime|Hat|Tilde|Bar)(?P<digits>\d*)$"
+    r"^(?P<head>.+)(?P<deco>Star|Prime|Hat|Tilde|Bar)(?P<tail>\d*(?:_.+)?)$"
 )
 
 
@@ -205,6 +221,8 @@ class ExprRenderer:
         # escaped), matching ``macros._mathsf_body``. A bare trailing-digit run
         # subscripts likewise. The head is never itself subscripted, so the two
         # paths can never compound into a double subscript.
+        if name in _RESERVED_UPRIGHT:
+            return _RESERVED_UPRIGHT[name]
         if name in _KEYWORD_VARIABLES:
             return _KEYWORD_VARIABLES[name]
         decorated = self._render_decorated(name)
@@ -245,16 +263,27 @@ class ExprRenderer:
 
         Superscript decorations (``Star``/``Prime``) sit on a different axis
         from the subscript, so an index composes safely whether it precedes the
-        decoration (``ct1Star`` -> ``ct_{1}^{*}``) or follows it
-        (``ctStar0`` -> ``ct_{0}^{*}``). Accents (``Hat``/``Tilde``/``Bar``)
+        decoration (``ct1Star`` -> ``ct_{1}^{*}``) or follows it, as a trailing
+        digit (``ctStar0`` -> ``ct_{0}^{*}``) or an ``_``-suffix
+        (``mStar_in`` -> ``m^{*}_{in}``). Accents (``Hat``/``Tilde``/``Bar``)
         wrap the base with the subscript kept *outside* the accent
-        (``mHat0`` -> ``\\hat{m}_{0}``), again avoiding a double subscript.
+        (``mHat0`` -> ``\\hat{m}_{0}``), again avoiding a double subscript. Every
+        subscript axis -- the stem's own, a post-decoration digit run, and each
+        ``_``-delimited tail segment -- is comma-joined into the one group.
         """
         m = _DECORATION_RE.match(name)
         if m is None:
             return None
         head, head_sub = cls._split_subscript(m.group("head"))
-        sub = head_sub or (m.group("digits") or None)
+        components: list[str] = []
+        if head_sub:
+            components.append(head_sub)
+        # ``tail`` is ``\d*(?:_.+)?``: the run before the first ``_`` is the
+        # post-decoration digit subscript, each ``_``-delimited segment after it
+        # is a further subscript component.
+        parts = m.group("tail").split("_")
+        components.extend(seg for seg in parts if seg)
+        sub = ",".join(components) if components else None
         subtex = f"_{{{sub}}}" if sub else ""
         deco = m.group("deco")
         if deco in _DECORATION_SUPERSCRIPTS:

--- a/proof_frog/export/latex/stmt_renderer.py
+++ b/proof_frog/export/latex/stmt_renderer.py
@@ -6,6 +6,41 @@ from ... import frog_ast
 from . import ir
 from .expr_renderer import ExprRenderer
 
+# Boolean-valued (predicate) operators. A ``return`` of such an expression in a
+# ``Bool``-returning method is wrapped in an Iverson bracket (``\llbracket ...
+# \rrbracket``) so ``return A == B`` reads as ``[[A = B]]`` -- a 0/1-valued
+# predicate -- rather than a bare relation. ``||`` (OR) is included because the
+# ``Bool`` return-type gate already excludes the BitString-concatenation
+# overload of the same operator.
+_PREDICATE_BINOPS = frozenset(
+    {
+        frog_ast.BinaryOperators.EQUALS,
+        frog_ast.BinaryOperators.NOTEQUALS,
+        frog_ast.BinaryOperators.GT,
+        frog_ast.BinaryOperators.LT,
+        frog_ast.BinaryOperators.GEQ,
+        frog_ast.BinaryOperators.LEQ,
+        frog_ast.BinaryOperators.AND,
+        frog_ast.BinaryOperators.OR,
+        frog_ast.BinaryOperators.IN,
+        frog_ast.BinaryOperators.SUBSETS,
+    }
+)
+
+
+def _is_predicate(expr: frog_ast.Expression) -> bool:
+    """Whether ``expr`` is a boolean relation/combination worth Iverson-bracketing.
+
+    Bare booleans (a variable, ``true``/``false``) are excluded -- only actual
+    relations (``==``, ``<``, ...), logical combinations (``&&``, ``||``), set
+    membership (``in``, ``subsets``), and negation (``!``) are wrapped.
+    """
+    if isinstance(expr, frog_ast.BinaryOperation):
+        return expr.operator in _PREDICATE_BINOPS
+    if isinstance(expr, frog_ast.UnaryOperation):
+        return expr.operator == frog_ast.UnaryOperators.NOT
+    return False
+
 
 class StmtRenderer:
     """Walk a ``Block`` of FrogLang statements and produce a flat list of IR lines.
@@ -84,7 +119,16 @@ class StmtRenderer:
         if isinstance(stmt, frog_ast.ReturnStatement):
             if isinstance(self.return_type, frog_ast.BitStringType):
                 self.expr.note_bitstring_context(stmt.expression)
-            self._emit(out, ir.Return(expr=self.expr.render(stmt.expression)))
+            rendered = self.expr.render(stmt.expression)
+            # A predicate returned from a Bool-typed method is an Iverson
+            # bracket: `return A == B` -> `\llbracket A = B \rrbracket`. Gating
+            # on Bool keeps the concat overload of `||` (BitString return)
+            # untouched.
+            if isinstance(self.return_type, frog_ast.BoolType) and _is_predicate(
+                stmt.expression
+            ):
+                rendered = rf"\llbracket {rendered} \rrbracket"
+            self._emit(out, ir.Return(expr=rendered))
             return
         if isinstance(stmt, frog_ast.IfStatement):
             self._render_if(stmt, out)

--- a/tests/unit/export/latex/test_backend_cryptocode.py
+++ b/tests/unit/export/latex/test_backend_cryptocode.py
@@ -107,6 +107,13 @@ def test_required_packages_includes_adjustbox() -> None:
     assert "adjustbox" in names
 
 
+def test_required_packages_includes_stmaryrd() -> None:
+    # stmaryrd supplies \llbracket / \rrbracket for Iverson-bracketed returns.
+    b = CryptocodeBackend()
+    names = {p.name for p in b.required_packages()}
+    assert "stmaryrd" in names
+
+
 def test_fit_width_wraps_in_max_width_adjustbox() -> None:
     b = CryptocodeBackend()
     out = b.fit_width("CONTENT")

--- a/tests/unit/export/latex/test_expr_decorations.py
+++ b/tests/unit/export/latex/test_expr_decorations.py
@@ -51,15 +51,45 @@ def test_digit_before_decoration_subscripts() -> None:
 
 
 def test_false_positive_lowercase_star_stays_literal() -> None:
-    # Only the camelCase capital form is a decoration; a lowercase trailing
+    # Only the capitalized suffix form is a decoration; a lowercase trailing
     # "star" (e.g. polestar) must not become a superscript.
     assert _var("polestar") == "polestar"
 
 
-def test_uppercase_boundary_not_decorated() -> None:
-    # Decoration requires a camelCase boundary (lowercase/digit before the
-    # suffix), so an all-caps run like "ABStar" is left alone.
-    assert _var("ABStar") == "ABStar"
+def test_single_capital_stem_decorates() -> None:
+    # A lone group/scalar name like Z decorates: ZStar -> Z^{*}.
+    assert _var("ZStar") == r"Z^{*}"
+    assert _var("XPrime") == r"X^{\prime}"
+
+
+def test_capital_run_stem_decorates() -> None:
+    # The greedy rule decorates any non-empty stem, including an all-caps run,
+    # so ABStar -> AB^{*} (previously left literal).
+    assert _var("ABStar") == r"AB^{*}"
+
+
+def test_bare_decoration_word_stays_literal() -> None:
+    # A decoration word with no stem in front is not a decoration.
+    assert _var("Star") == "Star"
+
+
+def test_decoration_composes_with_underscore_subscript() -> None:
+    # A decoration followed by an `_`-suffix (e.g. an Initialize `_in`
+    # parameter) keeps the superscript on its own axis (subscript then
+    # superscript, as for `ctStar0`), not a literal "mStar" with the star
+    # unrendered.
+    assert _var("mStar_in") == r"m_{in}^{*}"
+    assert _var("qStar_in") == r"q_{in}^{*}"
+
+
+def test_accent_composes_with_underscore_subscript() -> None:
+    assert _var("yBar_prev") == r"\overline{y}_{prev}"
+
+
+def test_stem_subscript_and_post_decoration_subscript_combine() -> None:
+    # A subscript on the stem and one after the decoration join into a single
+    # comma-separated group (no stacked double subscript).
+    assert _var("k1Star_pq") == r"k_{1,pq}^{*}"
 
 
 def test_plain_underscore_subscript_still_works() -> None:

--- a/tests/unit/export/latex/test_expr_renderer.py
+++ b/tests/unit/export/latex/test_expr_renderer.py
@@ -190,3 +190,12 @@ def test_concrete_game_renders_dotted_without_unsupported() -> None:
     out = ExprRenderer(MacroRegistry()).render(game)
     assert "% unsupported" not in out
     assert "Left" in out
+
+
+def test_this_keyword_renders_upright() -> None:
+    # The `this` self-reference (e.g. `this.DeriveKeyPair(..)`) is a keyword,
+    # not a variable, so it is set upright rather than as an italic letter-run.
+    r = ExprRenderer(MacroRegistry())
+    assert r.render(frog_ast.Variable("this")) == r"\mathsf{this}"
+    call = frog_ast.FieldAccess(frog_ast.Variable("this"), "DeriveKeyPair")
+    assert r.render(call).startswith(r"\mathsf{this}.")

--- a/tests/unit/export/latex/test_stmt_renderer.py
+++ b/tests/unit/export/latex/test_stmt_renderer.py
@@ -50,6 +50,55 @@ def test_return_emits_return() -> None:
     assert line.expr == "x"
 
 
+def _eq(left: str, right: str) -> frog_ast.BinaryOperation:
+    return frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS,
+        frog_ast.Variable(left),
+        frog_ast.Variable(right),
+    )
+
+
+def test_bool_return_equality_is_iverson_bracketed() -> None:
+    # `return A == B` in a Bool method reads as a 0/1 predicate.
+    r = _renderer()
+    r.return_type = frog_ast.BoolType()
+    [line] = r.render_block(_block([frog_ast.ReturnStatement(_eq("A", "B"))]))
+    assert isinstance(line, ir.Return)
+    assert line.expr == r"\llbracket A = B \rrbracket"
+
+
+def test_bool_return_negation_is_iverson_bracketed() -> None:
+    r = _renderer()
+    r.return_type = frog_ast.BoolType()
+    neg = frog_ast.UnaryOperation(frog_ast.UnaryOperators.NOT, frog_ast.Variable("b"))
+    [line] = r.render_block(_block([frog_ast.ReturnStatement(neg)]))
+    assert line.expr == r"\llbracket \neg b \rrbracket"
+
+
+def test_bool_return_bare_boolean_is_not_bracketed() -> None:
+    # `return false;` is not a relation, so it stays a bare literal.
+    r = _renderer()
+    r.return_type = frog_ast.BoolType()
+    [line] = r.render_block(_block([frog_ast.ReturnStatement(frog_ast.Boolean(False))]))
+    assert line.expr == r"\mathsf{false}"
+
+
+def test_bool_return_bare_variable_is_not_bracketed() -> None:
+    r = _renderer()
+    r.return_type = frog_ast.BoolType()
+    [line] = r.render_block(_block([frog_ast.ReturnStatement(frog_ast.Variable("b"))]))
+    assert line.expr == "b"
+
+
+def test_non_bool_return_equality_is_not_bracketed() -> None:
+    # Without a Bool return type we do not know the expression is a predicate,
+    # so no Iverson bracket is applied.
+    r = _renderer()
+    r.return_type = None
+    [line] = r.render_block(_block([frog_ast.ReturnStatement(_eq("A", "B"))]))
+    assert line.expr == "A = B"
+
+
 def test_if_emits_if_else_endif() -> None:
     cond = frog_ast.Variable("b")
     then_blk = _block([frog_ast.ReturnStatement(frog_ast.Integer(1))])


### PR DESCRIPTION
Four improvements to the LaTeX export renderer:

- Decorations: a trailing Star/Prime/Hat/Tilde/Bar now decorates any non-empty stem, so single-letter and all-caps bases decorate too (ZStar -> Z^{*}, ABStar -> AB^{*}), not just camelCase-boundary stems. A decoration also composes with a following underscore-subscript (mStar_in -> m_{in}^{*}) instead of leaving the suffix unrendered.

- Boolean returns: a predicate returned from a Bool-typed oracle (return A == B, A && B, A in S, !A, ...) is wrapped in an Iverson bracket, \llbracket A = B \rrbracket. Adds the stmaryrd package to the cryptocode backend. Bare booleans/variables are left unwrapped.

- The `this` self-reference (this.DeriveKeyPair(..)) renders upright as a keyword rather than as an italic letter-run.