### PR TITLE
Handle bitstring literals in Z3FormulaVisitor (#235)

### DIFF
--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -926,6 +926,23 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
         else:
             self.stack.append(None)
 
+    def leave_bit_string_literal(self, node: frog_ast.BitStringLiteral) -> None:
+        # A bitstring literal (`0^n` / `1^n`) is a deterministic constant not
+        # modelled natively in Z3. Its `length` child was visited and left on
+        # the stack; pop it. With opaque fallback on, intern the WHOLE literal
+        # as a memoized opaque atom so two structurally identical literals
+        # share an atom (`0^n` == `0^n`), while distinct ones (`0^n` vs `1^n`,
+        # `0^n` vs `0^m`) get distinct atoms. Without a handler the `length`
+        # subexpression masqueraded as the literal's value, so `t == [0^n, 0^n]`
+        # produced `t@0 == n` -- an opaque-vs-Int sort-mismatch crash when
+        # compared against an opaque tuple component (issue #235).
+        if self.stack:
+            self.stack.pop()
+        if self.opaque_func_call_fallback:
+            self.stack.append(self._intern_opaque(node))
+        else:
+            self.stack.append(None)
+
     def leave_unary_operation(self, operation: frog_ast.UnaryOperation) -> None:
         if not self.stack or operation.operator == frog_ast.UnaryOperators.SIZE:
             self.stack.append(None)

--- a/tests/unit/visitors/test_z3_formula_visitor_opaque.py
+++ b/tests/unit/visitors/test_z3_formula_visitor_opaque.py
@@ -165,6 +165,81 @@ def test_fallback_with_namespace_allows_deterministic_call() -> None:
     assert formula is not None
 
 
+# ---------------------------------------------------------------------------
+# Bitstring literals (`0^n` / `1^n`): deterministic constants modelled as
+# opaque atoms (issue #235). Without a handler the visitor left the literal's
+# `length` subexpression on the stack, so `t == [0^n, 0^n]` produced
+# `t@0 == n` -- an opaque-vs-Int sort-mismatch crash.
+# ---------------------------------------------------------------------------
+
+
+def _type_map_tuple_lambda() -> visitors.NameTypeMap:
+    lam = frog_ast.Variable("lambda")
+    bs = frog_ast.BitStringType(lam)
+    tm = visitors.NameTypeMap()
+    tm.set("t", frog_ast.ProductType([bs, bs]))
+    tm.set("lambda", frog_ast.IntType())
+    tm.set("n", frog_ast.IntType())
+    return tm
+
+
+def test_tuple_literal_vs_componentwise_equivalent() -> None:
+    # Regression for #235: `t == [0^lambda, 0^lambda]` and its component-wise
+    # form must translate to equivalent formulas instead of crashing with a
+    # Z3 "sort mismatch".
+    tm = _type_map_tuple_lambda()
+    fa = visitors.Z3FormulaVisitor(tm, opaque_func_call_fallback=True).visit(
+        _parse_expr("t == [0^lambda, 0^lambda]")
+    )
+    fb = visitors.Z3FormulaVisitor(tm, opaque_func_call_fallback=True).visit(
+        _parse_expr("t[0] == 0^lambda && t[1] == 0^lambda")
+    )
+    assert fa is not None and fb is not None
+    solver = z3.Solver()
+    solver.add(fa != fb)
+    assert solver.check() == z3.unsat
+
+
+def test_bit_string_literal_distinct_bit_distinct_atoms() -> None:
+    # `0^lambda` and `1^lambda` are different constants; they must not be
+    # equated (guards against over-merging in the opaque encoding).
+    tm = _type_map_tuple_lambda()
+    fa = visitors.Z3FormulaVisitor(tm, opaque_func_call_fallback=True).visit(
+        _parse_expr("t[0] == 0^lambda")
+    )
+    fb = visitors.Z3FormulaVisitor(tm, opaque_func_call_fallback=True).visit(
+        _parse_expr("t[0] == 1^lambda")
+    )
+    assert fa is not None and fb is not None
+    solver = z3.Solver()
+    solver.add(fa != fb)
+    assert solver.check() == z3.sat
+
+
+def test_bit_string_literal_distinct_length_distinct_atoms() -> None:
+    # `0^lambda` and `0^n` differ in length; they must map to distinct atoms.
+    tm = _type_map_tuple_lambda()
+    fa = visitors.Z3FormulaVisitor(tm, opaque_func_call_fallback=True).visit(
+        _parse_expr("t[0] == 0^lambda")
+    )
+    fb = visitors.Z3FormulaVisitor(tm, opaque_func_call_fallback=True).visit(
+        _parse_expr("t[0] == 0^n")
+    )
+    assert fa is not None and fb is not None
+    solver = z3.Solver()
+    solver.add(fa != fb)
+    assert solver.check() == z3.sat
+
+
+def test_bit_string_literal_off_by_default_returns_none() -> None:
+    # Without opt-in, a bitstring literal is untranslatable (None) and the
+    # stack stays balanced -- it must not leak its `length` child as a
+    # garbage sub-term (the pre-fix behavior).
+    visitor = visitors.Z3FormulaVisitor(_empty_type_map(), variable_version_map={})
+    assert visitor.visit(_parse_expr("0^lambda")) is None
+    assert visitor.stack == []
+
+
 def test_two_visitor_instances_share_opaque_atom_by_repr() -> None:
     # Equivalence checking constructs ONE visitor per game and translates
     # one expression each. For the formulas to compare cleanly, two


### PR DESCRIPTION
Fixes #235.

Z3FormulaVisitor had no handler for BitStringLiteral nodes, so the generic traversal left the literal's `length` child on the stack in place of the literal itself: `0^lambda` translated to the Z3 integer `lambda`. When a tuple value was compared against a tuple literal, this produced `t@0 == lambda` -- an opaque-vs-Int comparison that crashed Z3 with a sort mismatch, and before the tuple-equality path existed left `t == [0^lambda, 0^lambda]` unreconcilable with its component-wise form `t[0] == 0^lambda && t[1] == 0^lambda`.

Add a leave_bit_string_literal handler that pops the visited length child and interns the whole literal as a memoized opaque atom under the opaque fallback (returning None otherwise). Structurally identical literals share an atom while distinct bits or lengths get distinct atoms, so the two tuple-comparison forms now reduce to equivalent formulas.