### PR TITLE
transforms: don't collapse a tuple var declared in multiple places (Collapse Single-Index Tuple)

### DIFF
--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -18,6 +18,7 @@ from ..visitors import (
     ReplaceTransformer,
     AllConstantFieldAccesses,
     GetTypeMapVisitor,
+    lvalue_base_name,
 )
 from ._base import TransformPass, PipelineContext, has_nondeterministic_call
 
@@ -315,6 +316,43 @@ class CollapseSingleIndexTupleTransformer(BlockTransformer):
     when a scheme-inlined game drops unused components.
     """
 
+    def __init__(self) -> None:
+        self._multi_assigned: set[str] = set()
+
+    def transform_method(self, method: frog_ast.Method) -> frog_ast.Method:
+        # A variable assigned in more than one place within the method
+        # (e.g. a phi-like variable declared in both arms of an if after
+        # If-Split Branch Assignment) must NOT be collapsed: rewriting one
+        # declaration to ``Ti v = expr[i]`` while leaving a sibling
+        # ``[T0,T1] v = expr2`` produces an inconsistently-typed variable,
+        # and a later inlining then substitutes the whole tuple in place of
+        # ``v`` (dropping the index). Precompute the set of names with two
+        # or more assignments in this method and skip them. Counting is
+        # per-method so a name reused as an independent local in another
+        # method is not affected.
+        counts: dict[str, int] = {}
+
+        def _count(node: frog_ast.ASTNode) -> bool:
+            if isinstance(
+                node,
+                (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
+            ):
+                base = lvalue_base_name(node.var)
+                if base is not None:
+                    counts[base] = counts.get(base, 0) + 1
+            return False
+
+        SearchVisitor(_count).visit(method.block)
+        saved = self._multi_assigned
+        self._multi_assigned = {n for n, c in counts.items() if c > 1}
+        try:
+            new_block = self.transform(method.block)
+        finally:
+            self._multi_assigned = saved
+        if new_block is method.block:
+            return method
+        return frog_ast.Method(method.signature, new_block)
+
     @staticmethod
     def _analyse_uses(var_name: str, block: frog_ast.Block) -> tuple[bool, set[int]]:
         """Return (has_bare_use, indices_used) for *var_name* in *block*.
@@ -373,6 +411,8 @@ class CollapseSingleIndexTupleTransformer(BlockTransformer):
                 continue
 
             var_name = statement.var.name
+            if var_name in self._multi_assigned:
+                continue
             remaining = frog_ast.Block(list(block.statements[stmt_idx + 1 :]))
 
             has_bare, indices_used = self._analyse_uses(var_name, remaining)

--- a/tests/unit/transforms/test_collapse_single_index_tuple.py
+++ b/tests/unit/transforms/test_collapse_single_index_tuple.py
@@ -106,3 +106,56 @@ def test_collapse_single_index_tuple_no_change(method: str) -> None:
     method_ast = frog_parser.parse_method(method)
     transformed = CollapseSingleIndexTupleTransformer().transform(method_ast)
     assert transformed == method_ast
+
+
+def test_collapse_skips_variable_assigned_in_multiple_places() -> None:
+    """Must NOT collapse a name that is declared in more than one place in
+    the method (e.g. the same variable written in both arms of an if, as
+    produced by If-Split Branch Assignment). Collapsing one declaration to
+    ``Ti v = expr[i]`` while leaving a sibling ``[T0,T1] v = expr2`` yields
+    an inconsistently-typed variable; a later inlining then substitutes the
+    whole tuple where ``v`` is used, dropping the index. (Regression for the
+    seeded-form ROM binding proofs, whose SeededKEMWrapper.Decaps re-derives
+    the keypair from the seed, producing exactly this shape.)
+
+    Without the fix both ``v`` declarations collapse to a scalar; with it
+    they remain product-typed.
+    """
+    method_ast = frog_parser.parse_method("""
+        Int O(Bool b) {
+            if (b) {
+                [Int, Int] v = challenger.g();
+                Int a = v[0];
+            } else {
+                [Int, Int] v = challenger.h();
+                Int a = v[0];
+            }
+            return 0;
+        }
+        """)
+    transformed = CollapseSingleIndexTupleTransformer().transform(method_ast)
+    product_decls = 0
+    stack: list[object] = [transformed]
+    seen: set[int] = set()
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        if (
+            isinstance(node, frog_ast.Assignment)
+            and isinstance(node.var, frog_ast.Variable)
+            and node.var.name == "v"
+            and isinstance(node.the_type, frog_ast.ProductType)
+        ):
+            product_decls += 1
+        if isinstance(node, frog_ast.ASTNode):
+            for attr in vars(node).values():
+                if isinstance(attr, frog_ast.ASTNode):
+                    stack.append(attr)
+                elif isinstance(attr, (list, tuple)):
+                    stack.extend(a for a in attr if isinstance(a, frog_ast.ASTNode))
+    assert product_decls == 2, (
+        "a variable declared in both arms of an if must not be collapsed "
+        f"(both declarations should stay product-typed):\n{transformed}"
+    )


### PR DESCRIPTION
CollapseSingleIndexTupleTransformer rewrites `[T0,T1] v = expr; ... v[i] ...` to `Ti v = expr[i]` when only one index of v is ever read. When the same variable name is declared in more than one place in a method -- e.g. both arms of an if produced by If-Split Branch Assignment, where each arm assigns `[T0,T1] v = ...` -- collapsing one declaration to a scalar while leaving its sibling product-typed yields an inconsistently-typed variable. A later inlining pass then substitutes the whole tuple where `v` is used, dropping the `[i]` index and corrupting the term.

Guard the collapse with a per-method multi-assignment count: skip any name assigned in more than one place. This fixes the seeded-form ROM binding proofs, whose SeededKEMWrapper.Decaps re-derives the keypair from the seed and produces exactly this shape.

Adds a discriminating unit test (product-typed with the guard, scalar without).