### PR TITLE
Normalize ProductType tuple literals in expression positions; fix their Z3 encoding

### DIFF
--- a/proof_frog/transforms/pipelines.py
+++ b/proof_frog/transforms/pipelines.py
@@ -105,6 +105,7 @@ from .tuples import (
     ExpandTuple,
     SimplifyTuple,
     CollapseSingleIndexTuple,
+    NormalizeProductLiteral,
 )
 from .standardization import (
     VariableStandardize,
@@ -117,6 +118,7 @@ from .standardization import (
 
 CORE_PIPELINE: list[TransformPass] = [
     AlphaRename(),
+    NormalizeProductLiteral(),
     SingleCallFieldToLocal(),
     CounterGuardedFieldToLocal(),
     SymbolicComputation(),

--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -20,7 +20,12 @@ from ..visitors import (
     GetTypeMapVisitor,
     lvalue_base_name,
 )
-from ._base import TransformPass, PipelineContext, has_nondeterministic_call
+from ._base import (
+    TransformPass,
+    PipelineContext,
+    has_nondeterministic_call,
+    NearMiss,
+)
 
 # ---------------------------------------------------------------------------
 # Transformer classes (moved from visitors.py)
@@ -466,3 +471,168 @@ class CollapseSingleIndexTuple(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         return CollapseSingleIndexTupleTransformer().transform(game)
+
+
+class _ProductLiteralValueRewriter(Transformer):
+    """Rewrites ``ProductType`` tuple literals into ``Tuple`` nodes inside a
+    single VALUE expression.
+
+    Instantiation and inlining substitute namespace values for variables, and
+    convert a ``Tuple`` whose members all satisfy ``isinstance(_, Type)`` into
+    a ``ProductType`` so that Set-alias substitutions land in type positions
+    as genuine types. Because ``Variable`` (and ``FieldAccess``) are both
+    ``Expression`` and ``Type``, this also mangles ordinary tuple literals of
+    bare variables (e.g. an inlined oracle argument ``[ss, ct]``) into
+    ``ProductType`` nodes in expression positions, which downstream passes
+    (``FoldTupleIndex``, ``TupleEqualityDecompose``) and ``Z3FormulaVisitor``
+    do not recognize as tuple literals.
+
+    This rewriter is applied only to expression slots that cannot hold a
+    type (if-conditions, assignment/return values, loop bounds/iterables,
+    map indices), so any ``ProductType`` it meets is a literal. Two guarded
+    positions are left untouched because a bare ``ProductType`` there
+    legitimately denotes a *space* rather than a literal: the operand of the
+    cardinality operator ``|...|``, and the right-hand side of
+    ``in``/``subsets``.
+    """
+
+    def __init__(self, ctx: PipelineContext | None = None) -> None:
+        self.ctx = ctx
+
+    def transform_product_type(self, node: frog_ast.ProductType) -> frog_ast.ASTNode:
+        values = frog_ast.tuple_literal_values(node)
+        if values is not None and all(
+            isinstance(v, frog_ast.Expression) for v in values
+        ):
+            return frog_ast.Tuple([self.transform(v) for v in values])
+        if self.ctx is not None:
+            self.ctx.near_misses.append(
+                NearMiss(
+                    transform_name="Normalize Product-Literal Tuples",
+                    reason=(
+                        "ProductType found in an expression position but not "
+                        "converted to a tuple literal: not all members are "
+                        "expressions"
+                    ),
+                    location=None,
+                    suggestion=None,
+                    variable=str(node),
+                    method=None,
+                )
+            )
+        return self._transform_children(node)
+
+    def transform_unary_operation(
+        self, node: frog_ast.UnaryOperation
+    ) -> frog_ast.ASTNode:
+        # `|X|` may take a space (type) operand: cardinality of a product
+        # space must stay a ProductType (a Tuple there would mean length).
+        if node.operator == frog_ast.UnaryOperators.SIZE:
+            return node
+        return self._transform_children(node)
+
+    def transform_binary_operation(
+        self, node: frog_ast.BinaryOperation
+    ) -> frog_ast.ASTNode:
+        # The RHS of `in` / `subsets` may be a space (type); leave it alone.
+        if node.operator in (
+            frog_ast.BinaryOperators.IN,
+            frog_ast.BinaryOperators.SUBSETS,
+        ):
+            new_left = self.transform(node.left_expression)
+            if new_left is node.left_expression:
+                return node
+            return frog_ast.BinaryOperation(
+                node.operator, new_left, node.right_expression
+            )
+        return self._transform_children(node)
+
+
+class NormalizeProductLiteralTransformer(BlockTransformer):
+    """Applies ``_ProductLiteralValueRewriter`` to every method-body
+    expression slot that can only hold a value, never a type. Declared types
+    (``the_type``, sample spaces, loop variable types) are never touched."""
+
+    def __init__(self, ctx: PipelineContext | None = None) -> None:
+        self.ctx = ctx
+
+    def _value(self, expr: frog_ast.Expression) -> frog_ast.Expression:
+        result: frog_ast.Expression = _ProductLiteralValueRewriter(self.ctx).transform(
+            expr
+        )
+        return result
+
+    def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
+        new_statements: list[frog_ast.Statement] = []
+        changed = False
+        for statement in block.statements:
+            new_statement = self._rewrite_statement(statement)
+            changed = changed or new_statement is not statement
+            new_statements.append(new_statement)
+        return frog_ast.Block(new_statements) if changed else block
+
+    def _rewrite_statement(self, statement: frog_ast.Statement) -> frog_ast.Statement:
+        if isinstance(statement, frog_ast.Assignment):
+            # `Set S = ...;` binds a type alias; leave its RHS alone.
+            if isinstance(statement.the_type, frog_ast.SetType):
+                return statement
+            new_var = self._value(statement.var)
+            new_value = self._value(statement.value)
+            if new_var is statement.var and new_value is statement.value:
+                return statement
+            return frog_ast.Assignment(statement.the_type, new_var, new_value)
+        if isinstance(statement, frog_ast.Sample):
+            new_var = self._value(statement.var)
+            if new_var is statement.var:
+                return statement
+            return frog_ast.Sample(statement.the_type, new_var, statement.sampled_from)
+        if isinstance(statement, frog_ast.UniqueSample):
+            new_var = self._value(statement.var)
+            new_unique_set = self._value(statement.unique_set)
+            if new_var is statement.var and new_unique_set is statement.unique_set:
+                return statement
+            return frog_ast.UniqueSample(
+                statement.the_type,
+                new_var,
+                new_unique_set,
+                statement.sampled_from,
+                statement.surface_form,
+            )
+        if isinstance(statement, frog_ast.ReturnStatement):
+            new_expression = self._value(statement.expression)
+            if new_expression is statement.expression:
+                return statement
+            return frog_ast.ReturnStatement(new_expression)
+        if isinstance(statement, frog_ast.IfStatement):
+            new_conditions = [self._value(cond) for cond in statement.conditions]
+            if all(
+                new is old for new, old in zip(new_conditions, statement.conditions)
+            ):
+                return statement
+            return frog_ast.IfStatement(new_conditions, list(statement.blocks))
+        if isinstance(statement, frog_ast.NumericFor):
+            new_start = self._value(statement.start)
+            new_end = self._value(statement.end)
+            if new_start is statement.start and new_end is statement.end:
+                return statement
+            return frog_ast.NumericFor(
+                statement.name, new_start, new_end, statement.block
+            )
+        if isinstance(statement, frog_ast.GenericFor):
+            new_over = self._value(statement.over)
+            if new_over is statement.over:
+                return statement
+            return frog_ast.GenericFor(
+                statement.var_type,
+                statement.var_name,
+                new_over,
+                statement.block,
+            )
+        return statement
+
+
+class NormalizeProductLiteral(TransformPass):
+    name = "Normalize Product-Literal Tuples"
+
+    def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
+        return NormalizeProductLiteralTransformer(ctx).transform(game)

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -909,6 +909,29 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
         else:
             self.stack.append(tuple(items))
 
+    def leave_product_type(self, node: frog_ast.ProductType) -> None:
+        # A ProductType can reach the formula visitor in EXPRESSION position:
+        # instantiation converts an all-Variable tuple literal (e.g. an
+        # inlined oracle argument `[ss, ct]`) into a ProductType because
+        # Variable is both Expression and Type. Without this handler the
+        # node's visited children leaked onto the stack (the same defect the
+        # Slice handler fixes above), so an enclosing equality popped the two
+        # nearest components and produced a WRONG formula -- e.g.
+        # `[a, b] == [c, d]` became `c == d`. Treat it exactly like a Tuple
+        # literal: pop one item per member and push the component tuple.
+        # NormalizeProductLiteral rewrites these nodes to Tuples during
+        # canonicalization; this handler is defense-in-depth for visitor
+        # uses on not-yet-normalized ASTs.
+        n = len(node.types)
+        items = []
+        for _ in range(n):
+            items.append(self.stack.pop() if self.stack else None)
+        items.reverse()
+        if any(item is None for item in items):
+            self.stack.append(None)
+        else:
+            self.stack.append(tuple(items))
+
     def leave_array_access(self, _node: frog_ast.ArrayAccess) -> None:
         index = self.stack.pop() if self.stack else None
         array = self.stack.pop() if self.stack else None
@@ -955,7 +978,16 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
             self.stack.append(None)
 
     def leave_unary_operation(self, operation: frog_ast.UnaryOperation) -> None:
-        if not self.stack or operation.operator == frog_ast.UnaryOperators.SIZE:
+        if operation.operator == frog_ast.UnaryOperators.SIZE:
+            # `|x|` is not modelled, but the operand's visited item must
+            # still be popped: leaving it on the stack misaligns every
+            # enclosing operation's pops (the same stack-discipline defect
+            # the Slice handler above describes).
+            if self.stack:
+                self.stack.pop()
+            self.stack.append(None)
+            return
+        if not self.stack:
             self.stack.append(None)
             return
 

--- a/tests/unit/transforms/test_normalize_product_literal.py
+++ b/tests/unit/transforms/test_normalize_product_literal.py
@@ -1,0 +1,291 @@
+"""Tests for the NormalizeProductLiteral pass.
+
+Instantiation/inlining substitution converts a Tuple literal whose members
+are all bare variables (each ``Variable`` is both ``Expression`` and
+``Type``) into a ``ProductType`` node, so tuple literals in expression
+positions can arrive at canonicalization as ``ProductType`` nodes.
+``NormalizeProductLiteral`` rewrites them back into ``Tuple`` nodes in
+value positions so downstream passes (``FoldTupleIndex``,
+``TupleEqualityDecompose``, ``RemoveUnreachable``'s Z3 encoding) recognise
+them; type positions (declared types, sample spaces, ``|...|`` operands,
+the RHS of ``in``/``subsets``) are left untouched.
+"""
+
+from proof_frog import frog_ast, frog_parser
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.transforms.control_flow import RemoveUnreachableTransformer
+from proof_frog.transforms.tuples import (
+    NormalizeProductLiteral,
+    NormalizeProductLiteralTransformer,
+)
+from proof_frog.visitors import NameTypeMap
+
+
+def _product(*names: str) -> frog_ast.ProductType:
+    """A ProductType-as-expression node, as the inliner manufactures them."""
+    return frog_ast.ProductType([frog_ast.Variable(n) for n in names])
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _count(game: frog_ast.ASTNode, cls: type) -> int:
+    from proof_frog.visitors import SearchVisitor
+
+    total = 0
+    remaining = game
+
+    def is_cls(node: frog_ast.ASTNode) -> bool:
+        return isinstance(node, cls) and id(node) not in seen
+
+    seen: set[int] = set()
+    while True:
+        found = SearchVisitor(is_cls).visit(remaining)
+        if found is None:
+            return total
+        seen.add(id(found))
+        total += 1
+
+
+def test_condition_product_literal_becomes_tuple() -> None:
+    game = frog_parser.parse_game("""
+    Game G(Set S, Set T) {
+        S a;
+        T b;
+        S c;
+        T d;
+        Bool O() {
+            if ([a, b] == [c, d]) {
+                return true;
+            }
+            return false;
+        }
+    }
+    """)
+    # Mangle the parsed Tuples into ProductTypes, as the inliner would.
+    cond = game.methods[0].block.statements[0].conditions[0]
+    cond.left_expression = _product("a", "b")
+    cond.right_expression = _product("c", "d")
+
+    out = NormalizeProductLiteral().apply(game, _ctx())
+    new_cond = out.methods[0].block.statements[0].conditions[0]
+    assert isinstance(new_cond.left_expression, frog_ast.Tuple)
+    assert isinstance(new_cond.right_expression, frog_ast.Tuple)
+    assert str(new_cond) == "[a, b] == [c, d]"
+
+
+def test_assignment_value_and_array_access_normalized() -> None:
+    game = frog_parser.parse_game("""
+    Game G(Set S, Set T) {
+        S a;
+        T b;
+        Bool O() {
+            T x = b;
+            return true;
+        }
+    }
+    """)
+    stmt = game.methods[0].block.statements[0]
+    # x = [a, b][1]; with the tuple literal mangled to a ProductType
+    stmt.value = frog_ast.ArrayAccess(_product("a", "b"), frog_ast.Integer(1))
+
+    out = NormalizeProductLiteral().apply(game, _ctx())
+    new_value = out.methods[0].block.statements[0].value
+    assert isinstance(new_value, frog_ast.ArrayAccess)
+    assert isinstance(new_value.the_array, frog_ast.Tuple)
+
+
+def test_size_operand_and_in_rhs_left_alone() -> None:
+    game = frog_parser.parse_game("""
+    Game G(Set S, Set T) {
+        S a;
+        T b;
+        Bool O() {
+            return true;
+        }
+    }
+    """)
+    ret = game.methods[0].block.statements[0]
+    # return (|[S, T]| == |[S, T]|) — cardinality of a product SPACE: the
+    # ProductType under |...| must stay a ProductType.
+    size = frog_ast.UnaryOperation(frog_ast.UnaryOperators.SIZE, _product("S", "T"))
+    ret.expression = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, size, frog_ast.Integer(4)
+    )
+    out = NormalizeProductLiteral().apply(game, _ctx())
+    new_ret = out.methods[0].block.statements[0]
+    assert isinstance(
+        new_ret.expression.left_expression.expression, frog_ast.ProductType
+    )
+
+    # a in [S, T] — membership in a product SPACE: RHS stays a ProductType.
+    ret2 = frog_ast.ReturnStatement(
+        frog_ast.BinaryOperation(
+            frog_ast.BinaryOperators.IN,
+            frog_ast.Variable("a"),
+            _product("S", "T"),
+        )
+    )
+    game.methods[0].block.statements[0] = ret2
+    out2 = NormalizeProductLiteral().apply(game, _ctx())
+    new_ret2 = out2.methods[0].block.statements[0]
+    assert isinstance(new_ret2.expression.right_expression, frog_ast.ProductType)
+
+
+def test_sample_space_left_alone() -> None:
+    game = frog_parser.parse_game("""
+    Game G(Set S, Set T) {
+        Bool O() {
+            S x <- S;
+            return true;
+        }
+    }
+    """)
+    stmt = game.methods[0].block.statements[0]
+    stmt.sampled_from = _product("S", "T")
+    out = NormalizeProductLiteral().apply(game, _ctx())
+    assert isinstance(
+        out.methods[0].block.statements[0].sampled_from, frog_ast.ProductType
+    )
+
+
+def test_near_miss_on_unconvertible_product() -> None:
+    game = frog_parser.parse_game("""
+    Game G(Set S) {
+        S a;
+        Bool O() {
+            if (a == a) {
+                return true;
+            }
+            return false;
+        }
+    }
+    """)
+    cond = game.methods[0].block.statements[0].conditions[0]
+    # A ProductType with a genuine (non-Expression) type member cannot be a
+    # tuple literal; the pass must decline and record a near-miss.
+    cond.right_expression = frog_ast.ProductType(
+        [frog_ast.Variable("a"), frog_ast.IntType()]
+    )
+    ctx = _ctx()
+    NormalizeProductLiteral().apply(game, ctx)
+    assert any(
+        nm.transform_name == "Normalize Product-Literal Tuples"
+        for nm in ctx.near_misses
+    )
+
+
+def test_unreachable_qstar_branch_eliminated_after_normalization() -> None:
+    """End-to-end regression for the CG INDCCA_T derived-key hop: the
+    inlined helper's excluded-query branch is semantically dead given the
+    challenge exclusion and the C2PRI abort guard, but arrives with its
+    tuple literals mangled into ProductType nodes. After normalization,
+    RemoveUnreachable must eliminate it."""
+    game = frog_parser.parse_game("""
+    Game G(Set CtSpace, Set ElemSpace, Int n) {
+        BitString<n> field1;
+        CtSpace field3;
+        ElemSpace field5;
+        Function<CtSpace, BitString<n>> F;
+
+        BitString<8>? Decaps([CtSpace, ElemSpace] ct) {
+            if (ct == [field3, field5]) {
+                return None;
+            }
+            CtSpace v7 = ct[0];
+            ElemSpace v8 = ct[1];
+            BitString<n> v9 = F(v7);
+            if (field5 == v8 && (field3 != v7 && field1 == v9)) {
+                BitString<8> r <- BitString<8>;
+                return r;
+            }
+            if ([field1, field5] == [v9, v8]) {
+                return None;
+            }
+            BitString<8> out <- BitString<8>;
+            return out;
+        }
+    }
+    """)
+    # Mangle all three tuple literals into ProductType nodes, as arrives
+    # from inlining.
+    decaps = game.methods[0]
+    stmts = decaps.block.statements
+    stmts[0].conditions[0].right_expression = _product("field3", "field5")
+    if_stmts = [s for s in stmts if isinstance(s, frog_ast.IfStatement)]
+    qstar_if = if_stmts[-1]
+    qstar_if.conditions[0].left_expression = _product("field1", "field5")
+    qstar_if.conditions[0].right_expression = _product("v9", "v8")
+
+    ctx = _ctx()
+    normalized = NormalizeProductLiteral().apply(game, ctx)
+    out = RemoveUnreachableTransformer(normalized, ctx).transform(normalized)
+    assert str(out).count("if (") == 2, f"dead qStar branch not removed:\n{out}"
+
+
+def test_unreachable_qstar_branch_eliminated_even_without_normalization() -> None:
+    """Defense-in-depth: Z3FormulaVisitor's leave_product_type handler
+    encodes ProductType tuple literals componentwise, so RemoveUnreachable
+    eliminates the dead branch even on a NOT-yet-normalized AST. (Before
+    that handler existed, the mangled literals' children leaked onto the
+    visitor stack and produced a wrong formula, and this branch
+    survived — the CG INDCCA_T hop failures.)"""
+    game = frog_parser.parse_game("""
+    Game G(Set CtSpace, Set ElemSpace, Int n) {
+        BitString<n> field1;
+        CtSpace field3;
+        ElemSpace field5;
+        Function<CtSpace, BitString<n>> F;
+
+        BitString<8>? Decaps([CtSpace, ElemSpace] ct) {
+            if (ct == [field3, field5]) {
+                return None;
+            }
+            CtSpace v7 = ct[0];
+            ElemSpace v8 = ct[1];
+            BitString<n> v9 = F(v7);
+            if (field5 == v8 && (field3 != v7 && field1 == v9)) {
+                BitString<8> r <- BitString<8>;
+                return r;
+            }
+            if ([field1, field5] == [v9, v8]) {
+                return None;
+            }
+            BitString<8> out <- BitString<8>;
+            return out;
+        }
+    }
+    """)
+    decaps = game.methods[0]
+    stmts = decaps.block.statements
+    stmts[0].conditions[0].right_expression = _product("field3", "field5")
+    if_stmts = [s for s in stmts if isinstance(s, frog_ast.IfStatement)]
+    qstar_if = if_stmts[-1]
+    qstar_if.conditions[0].left_expression = _product("field1", "field5")
+    qstar_if.conditions[0].right_expression = _product("v9", "v8")
+
+    ctx = _ctx()
+    out = RemoveUnreachableTransformer(game, ctx).transform(game)
+    assert str(out).count("if (") == 2, f"dead qStar branch not removed:\n{out}"
+
+
+def test_transformer_no_change_returns_same_block() -> None:
+    game = frog_parser.parse_game("""
+    Game G(Set S) {
+        S a;
+        Bool O() {
+            if (a == a) {
+                return true;
+            }
+            return false;
+        }
+    }
+    """)
+    out = NormalizeProductLiteralTransformer(_ctx()).transform(game)
+    assert out == game

--- a/tests/unit/visitors/test_z3_formula_visitor_product_type.py
+++ b/tests/unit/visitors/test_z3_formula_visitor_product_type.py
@@ -1,0 +1,106 @@
+"""Tests for Z3FormulaVisitor's handling of ProductType-as-expression nodes.
+
+Instantiation converts an all-variable tuple literal into a ProductType
+node (Variable is both Expression and Type). Before the
+``leave_product_type`` handler existed, such a node's visited children
+leaked onto the visitor stack, so ``[a, b] == [c, d]`` (with ProductType
+literals) encoded as the WRONG formula ``c == d`` — an actively unsound
+input for RemoveUnreachable's dead-branch solver. The handler must encode
+it exactly like a Tuple literal.
+
+Also covers the ``|...|`` stack-discipline fix: the SIZE operand's visited
+item must be popped, not leaked beneath the appended None.
+"""
+
+import z3
+
+from proof_frog import frog_ast, frog_parser, visitors
+
+
+def _parse_expr(src: str) -> frog_ast.Expression:
+    return frog_parser.parse_expression(src)
+
+
+def _empty_type_map() -> visitors.NameTypeMap:
+    return visitors.NameTypeMap()
+
+
+def _product(*names: str) -> frog_ast.ProductType:
+    return frog_ast.ProductType([frog_ast.Variable(n) for n in names])
+
+
+def _equiv(f1: z3.AstRef, f2: z3.AstRef) -> bool:
+    solver = z3.Solver()
+    solver.add(z3.Not(f1 == f2))
+    return solver.check() == z3.unsat
+
+
+def test_product_type_equality_encodes_componentwise() -> None:
+    # [a, b] == [c, d] with ProductType literals must encode identically to
+    # the same equality with genuine Tuple literals.
+    mangled = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, _product("a", "b"), _product("c", "d")
+    )
+    tuple_form = _parse_expr("[a, b] == [c, d]")
+    f_mangled = visitors.Z3FormulaVisitor(_empty_type_map()).visit(mangled)
+    f_tuple = visitors.Z3FormulaVisitor(_empty_type_map()).visit(tuple_form)
+    assert f_mangled is not None
+    assert f_tuple is not None
+    assert _equiv(f_mangled, f_tuple)
+
+
+def test_product_type_equality_is_not_the_old_garbage_formula() -> None:
+    # Regression: the leaked-children encoding produced `c == d`. The fixed
+    # encoding must NOT be equivalent to that.
+    mangled = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, _product("a", "b"), _product("c", "d")
+    )
+    f_mangled = visitors.Z3FormulaVisitor(_empty_type_map()).visit(mangled)
+    garbage = visitors.Z3FormulaVisitor(_empty_type_map()).visit(_parse_expr("c == d"))
+    assert f_mangled is not None
+    assert garbage is not None
+    assert not _equiv(f_mangled, garbage)
+
+
+def test_product_type_indexing_encodes_component() -> None:
+    # [a, b][1] == b must be tautologically true.
+    expr = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS,
+        frog_ast.ArrayAccess(_product("a", "b"), frog_ast.Integer(1)),
+        frog_ast.Variable("b"),
+    )
+    formula = visitors.Z3FormulaVisitor(_empty_type_map()).visit(expr)
+    assert formula is not None
+    solver = z3.Solver()
+    solver.add(z3.Not(formula))
+    assert solver.check() == z3.unsat
+
+
+def test_size_operand_is_popped_not_leaked() -> None:
+    # `|a| == |b|` is untranslatable (None), and must not leave leaked
+    # operand items behind that a later visit could mis-pop.
+    visitor = visitors.Z3FormulaVisitor(_empty_type_map())
+    assert visitor.visit(_parse_expr("|a| == |b|")) is None
+    # A subsequent, unrelated visit on the same visitor must be unaffected.
+    formula = visitor.visit(_parse_expr("x == x"))
+    assert formula is not None
+    solver = z3.Solver()
+    solver.add(z3.Not(formula))
+    assert solver.check() == z3.unsat
+
+
+def test_tuple_containing_size_is_none_not_garbage() -> None:
+    # [|a|, b] == [c, d]: the size member is untranslatable, so the whole
+    # comparison must be None — never a partial/garbage equality.
+    left = frog_ast.Tuple(
+        [
+            frog_ast.UnaryOperation(
+                frog_ast.UnaryOperators.SIZE, frog_ast.Variable("a")
+            ),
+            frog_ast.Variable("b"),
+        ]
+    )
+    expr = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, left, _product("c", "d")
+    )
+    assert visitors.Z3FormulaVisitor(_empty_type_map()).visit(expr) is None


### PR DESCRIPTION
The inliner's parameter substitution turns a tuple literal whose members are all bare variables into a `ProductType` node. This is deliberate for `Set` aliases (`Variable` is both `Expression` and `Type`, and a substituted alias like `[K.SharedSecret, NG.Element]` must land in type positions as a genuine type), but it also fires on ordinary value tuples: an inlined oracle argument such as `challenger.Indirect([ss, ct])` reaches canonicalization with `[ss, ct]` as a `ProductType` in expression position.

Most passes only recognize `Tuple` as a tuple literal (`frog_ast.tuple_literal_values` papers over the quirk in a few places, but `FoldTupleIndex` and `TupleEqualityDecompose` do not use it), and `Z3FormulaVisitor` had no `ProductType` handler at all. In the visitor, the node's visited children leaked onto the stack — the same defect previously fixed for `Slice` and `BitStringLiteral` — so an equality like `[a, b] == [c, d]` encoded as the *wrong formula* `c == d` rather than `None`. Since `RemoveUnreachable` feeds these formulas to its dead-branch solver as path facts, a wrong formula there is unsound in principle; in practice it made the solver unable to discharge genuinely dead branches, which is how the bug surfaced (the reworked CG proofs in ProofFrog/examples#53 stalled on four equivalence hops whose excluded-query branch could not be proven unreachable).

Three changes:

- A `NormalizeProductLiteral` pass, early in `CORE_PIPELINE`, rewrites expression-position `ProductType` literals back into `Tuple` nodes so every downstream pass sees the canonical representation. It only touches slots that cannot hold a type — if-conditions, assignment and return values, loop bounds and iterables, sample targets — and leaves alone the positions where a bare `ProductType` legitimately denotes a space: `|...|` operands, the right-hand side of `in`/`subsets`, declared types, and sample spaces. It records a near-miss when it declines because a member is not an expression.
- Defense in depth for ASTs the pass hasn't seen: `Z3FormulaVisitor` gains a `leave_product_type` handler that encodes such nodes exactly like `Tuple` literals, so no caller can get a garbage formula from one.
- A related stack-discipline fix in the same visitor: `|x|` never popped its operand before pushing `None`, leaving a stray item that misaligned enclosing pops.

The final commit bumps the examples pin to ProofFrog/examples#53 (`3f7f819`), whose CG IND-CCA-T proofs are the first to exercise tuple-literal oracle arguments, so CI tests the engine and those proofs together.

Testing: 13 new unit tests in `tests/unit/transforms/test_normalize_product_literal.py` and `tests/unit/visitors/test_z3_formula_visitor_product_type.py`, including a regression of the exact stalled hop shape and coverage that the normalization pass and the visitor handler are each independently sufficient for it; the full unit suite and `make lint` pass, and all 226 example proofs pass at the bumped pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
