### PR TITLE
Switch package version to v0.6.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "proof_frog"
-version = "0.6.0"
+version = "0.6.1.dev0"
 description = "A tool for checking transitions in cryptographic game-hopping proofs"
 keywords = ["cryptography", "game-hopping", "proofs"]
 readme = "README.md"


### PR DESCRIPTION
Opens the post-v0.6.0 development cycle. One line: `pyproject.toml` `version` `0.6.0` -> `0.6.1.dev0`.

Mirrors #219, which did the same after v0.5.0. The `v0.6.0` tag already points at 57c99b1, whose version string is exactly `0.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)