### PR TITLE
Transform-soundness fix campaign (audit 2026-06): ~100 gated finding fixes

### DIFF
--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -421,21 +421,39 @@ def _collect_field_access_refs(game: frog_ast.Game) -> list[frog_ast.Variable]:
 
 
 def remove_unnecessary_fields(game: frog_ast.Game) -> frog_ast.Game:
-    necessary_vars = []
-    for method in game.methods:
-        # We pass an empty list of fields
-        # so that we can determine which fields are necessary based solely on return values
-        necessary_vars += unnecessary_statement_info([], method.block)[1]
-
-    # Also include fields referenced via FieldAccess (e.g. field1.domain in
-    # <-uniq expressions), which VariableCollectionVisitor skips.
-    necessary_vars += _collect_field_access_refs(game)
+    # F-319: field necessity must be computed GAME-WIDE, to a fixpoint. Seeding
+    # each method's `unnecessary_statement_info` with an EMPTY field list only
+    # discovers fields needed for that method's OWN returns. A field read solely
+    # in the index/key position of a write to ANOTHER field (`M[F] = v`) is
+    # necessary iff that write is kept, which depends on `M` being necessary --
+    # a cross-method dependency the single empty-seeded pass missed. It then
+    # dropped `F` (and its setter) while `M[F] = v` survived, emitting a game
+    # with a dangling reference to the undeclared `F`. Iterate: seed each pass
+    # with the fields known necessary so far (so writes to a necessary field are
+    # kept and their index/RHS fields harvested) until the necessary set is
+    # stable. The set grows monotonically and is bounded by the fields, so this
+    # terminates; a genuinely unnecessary field is still never harvested.
+    all_field_names = {field.name for field in game.fields}
+    field_access_field_names = {
+        var.name
+        for var in _collect_field_access_refs(game)
+        if var.name in all_field_names
+    }
+    necessary_field_names: set[str] = set(field_access_field_names)
+    while True:
+        harvested: set[str] = set(necessary_field_names)
+        seed = sorted(necessary_field_names)
+        for method in game.methods:
+            for var in unnecessary_statement_info(seed, method.block)[1]:
+                if var.name in all_field_names:
+                    harvested.add(var.name)
+        if harvested == necessary_field_names:
+            break
+        necessary_field_names = harvested
 
     new_game = copy.deepcopy(game)
     new_game.fields = [
-        field
-        for field in game.fields
-        if frog_ast.Variable(field.name) in necessary_vars
+        field for field in game.fields if field.name in necessary_field_names
     ]
     actually_necessary_field_names = [field.name for field in new_game.fields]
     # Names bound outside any method body: every field (a method local may

--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -280,6 +280,22 @@ def unnecessary_statement_info(
 
     necessary_vars = [frog_ast.Variable(field) for field in fields]
 
+    def _run_loop_body_to_fixpoint(body: frog_ast.Block) -> None:
+        # F-320: a loop body needs a liveness FIXPOINT, not a single reverse
+        # pass. A loop-carried write can be marked dead when its reviving read
+        # is earlier in the body TEXT but executes in a LATER iteration via the
+        # back-edge (`for (...) { y = y + x; x = x + 1; }` -- the single pass
+        # sees `x = x + 1` before `y = y + x` makes `x` necessary, so it deletes
+        # the increment and corrupts the loop-carried value). Re-run the body
+        # pass until necessary_vars stops growing; the set is monotone and
+        # bounded by the variable names, so this terminates.
+        nonlocal necessary_vars
+        while True:
+            before = {v.name for v in necessary_vars}
+            remove_helper(body)
+            if {v.name for v in necessary_vars} == before:
+                break
+
     def remove_helper(block: frog_ast.Block) -> None:
         for statement in block.statements:
             required_map.set(statement, False)
@@ -305,13 +321,13 @@ def unnecessary_statement_info(
                 required_map.set(statement, True)
             elif isinstance(statement, frog_ast.NumericFor):
                 necessary_vars += _vars_of(statement.start) + _vars_of(statement.end)
-                remove_helper(statement.block)
+                _run_loop_body_to_fixpoint(statement.block)
             elif isinstance(
                 statement,
                 frog_ast.GenericFor,
             ):
                 necessary_vars += _vars_of(statement.over)
-                remove_helper(statement.block)
+                _run_loop_body_to_fixpoint(statement.block)
             elif isinstance(statement, frog_ast.IfStatement):
                 for condition in statement.conditions:
                     necessary_vars += _vars_of(condition)

--- a/proof_frog/frog_ast.py
+++ b/proof_frog/frog_ast.py
@@ -50,14 +50,21 @@ class ASTNode:
         # (stateful, auto-adds the draw to S) and `x <- T \ E` (pure one-shot
         # exclusion, no insertion) surface forms are distinct constructs with
         # different observable semantics, so they must not compare equal.
-        return all(
-            (
-                True
-                if attr in {"line_num", "column_num", "origin"}
-                else getattr(self, attr) == getattr(other, attr)
-            )
-            for attr in self.__dict__
-        )
+        #
+        # F-336: compare the attribute KEY SETS first, then values. Iterating
+        # only `self.__dict__` made equality partial and asymmetric on a
+        # malformed node (one missing an attribute its class normally has):
+        # a degenerate left operand subset-compared equal to a complete right
+        # operand, while the reflected direction raised AttributeError. Two
+        # well-formed instances of the same class have identical key sets, so
+        # this changes nothing for them; a malformed node now compares
+        # unequal (fail-closed) instead of accepting or raising.
+        excluded = {"line_num", "column_num", "origin"}
+        self_keys = self.__dict__.keys() - excluded
+        other_keys = other.__dict__.keys() - excluded
+        if self_keys != other_keys:
+            return False
+        return all(getattr(self, attr) == getattr(other, attr) for attr in self_keys)
 
 
 Namespace: TypeAlias = dict[str, Optional[ASTNode]]
@@ -846,8 +853,16 @@ class Game(ASTNode):
         self.methods = body[3]
 
     def __eq__(self, __value: object) -> bool:
-        if not isinstance(__value, Game):
+        # F-335: exact-type match, not `isinstance`. `Reduction` subclasses
+        # `Game`, so a loose `isinstance` check let a `Reduction` compare
+        # equal to a plain `Game` with the same body (and, via the inherited
+        # comparison, two `Reduction`s composing different security games
+        # compared equal -- see `Reduction.__eq__`). The exact-type guard
+        # keeps `Game == Reduction` and `Reduction == Game` both False and is
+        # symmetric.
+        if type(self) is not type(__value):
             return False
+        assert isinstance(__value, Game)
         return (
             self.parameters == __value.parameters
             and self.fields == __value.fields
@@ -906,6 +921,20 @@ class Reduction(Game):
         super().__init__(body)
         self.to_use = to_use
         self.play_against = play_against
+
+    def __eq__(self, __value: object) -> bool:
+        # F-335: a Reduction is defined by its composition (which game it
+        # plays and against what), not only by its body. Two Reductions with
+        # identical bodies but different `to_use`/`play_against` are distinct;
+        # the inherited `Game.__eq__` ignored those attributes. The exact-type
+        # guard in `Game.__eq__` already rejects a plain `Game`.
+        if not isinstance(__value, Reduction):
+            return False
+        return (
+            super().__eq__(__value)
+            and self.to_use == __value.to_use
+            and self.play_against == __value.play_against
+        )
 
     def _get_signature(self) -> str:
         return pretty_print(

--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -648,7 +648,7 @@ class ProofEngine:
                     self.max_calls = val.num
 
         self.get_method_lookup()
-        self._extract_subsets_pairs()
+        self._extract_subsets_pairs(proof_file)
 
     def prove(self, proof_file: frog_ast.ProofFile, proof_path: str = "") -> None:
         self.set_up_proof_context(proof_file)
@@ -1758,8 +1758,37 @@ class ProofEngine:
                 for method in rewritten.methods:
                     self.method_lookup[(name, method.signature.name)] = method
 
-    def _extract_subsets_pairs(self) -> None:
-        """Extract type constraint pairs from all schemes in the proof.
+    def _theorem_dependency_cone(self, proof_file: frog_ast.ProofFile) -> set[str]:
+        """Names of the let-bindings the proof body actually depends on.
+
+        Seeded from every name referenced in the theorem, the games
+        sequence (steps) and the helper games/reductions, then closed
+        transitively through let-value composition (so a component scheme
+        reached only as an argument of another instantiation is included).
+        A let-binding referenced nowhere but the ``let:`` block itself --
+        e.g. a decoy scheme instantiated solely to smuggle a ``requires``
+        equality into the global pool -- is excluded.
+        """
+        used: set[str] = set()
+        seeds: list[frog_ast.ASTNode] = [proof_file.theorem, *proof_file.steps]
+        seeds.extend(proof_file.helpers)
+        for seed in seeds:
+            used |= visitors.referenced_variable_names(seed)
+        lets_by_name = {let.name: let for let in proof_file.lets}
+        worklist = list(used)
+        while worklist:
+            name = worklist.pop()
+            let = lets_by_name.get(name)
+            if let is None or let.value is None:
+                continue
+            for ref in visitors.referenced_variable_names(let.value):
+                if ref not in used:
+                    used.add(ref)
+                    worklist.append(ref)
+        return used
+
+    def _extract_subsets_pairs(self, proof_file: frog_ast.ProofFile) -> None:
+        """Extract type constraint pairs from the schemes the proof uses.
 
         Both ``==`` and ``subsets`` constraints are collected.  They are
         safe for normalizing type annotations (widening is harmless).
@@ -1768,8 +1797,24 @@ class ProofEngine:
         A ⊊ B where replacing ``x <- A`` with ``x <- B`` would change
         the distribution.  The pair is tagged via ``equality_pairs`` so
         the normalizer can distinguish them.
+
+        F-333: a ``requires`` constraint is honored ONLY when its scheme is
+        in the theorem's dependency cone (see ``_theorem_dependency_cone``).
+        A scheme's ``requires A == B`` is a hypothesis of *that scheme's*
+        well-definedness -- legitimate because the scheme under test (and
+        the reductions/intermediate games composing it) quantify over
+        instantiations satisfying it. Harvesting from *every* let-bound
+        scheme into a single global pool let a never-composed decoy scheme
+        inject an equality license (e.g. ``Y == Z`` over two independent
+        opaque proof parameters) that then rewrote the sampling domain of an
+        UNRELATED theorem game -- silently narrowing an unconditional
+        theorem to the diagonal. Scoping to the cone rejects that hop while
+        leaving every scheme the theorem actually composes unaffected.
         """
-        for node in self.proof_namespace.values():
+        used_names = self._theorem_dependency_cone(proof_file)
+        for name, node in self.proof_namespace.items():
+            if name not in used_names:
+                continue
             if isinstance(node, frog_ast.Scheme):
                 for req in node.requirements:
                     if not isinstance(req, frog_ast.BinaryOperation):

--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -279,34 +279,75 @@ def _z3_residual_equivalence(
             ),
         )
 
-    # Walk if-conditions in lockstep.
-    found_ifs: list[frog_ast.IfStatement] = []
+    # Walk if-conditions and return statements in positional lockstep.
+    #
+    # SOUNDNESS (F-328/F-329): each game's statements are enumerated
+    # independently, excluding only nodes already yielded from THAT game
+    # and excluding them by object IDENTITY. An earlier version filtered
+    # both games' searches through a single shared list with structural
+    # `==` membership, so a game containing two structurally identical
+    # returns (or ifs) had its second occurrence skipped; the walk
+    # desynced, hit None, broke out, and fell through to valid=True with
+    # a genuinely differing pair never Z3-checked. Positional pairing is
+    # licensed by the neutralized-skeleton equality check above: the two
+    # games have structurally identical statement skeletons, so the i-th
+    # enumerated statement of each game occupies the same structural
+    # position. Any residual mismatch (count or condition arity) is a
+    # broken invariant and fails CLOSED.
+    def _enumerate_lockstep(
+        node_type: type[frog_ast.ASTNode],
+    ) -> Optional[list[tuple[frog_ast.ASTNode, frog_ast.ASTNode]]]:
+        """Enumerate all nodes of `node_type` from both games in visit
+        order, paired positionally. Returns None on a count mismatch."""
 
-    def search_for_if(
-        found_ifs: list[frog_ast.IfStatement], node: frog_ast.ASTNode
-    ) -> bool:
-        return isinstance(node, frog_ast.IfStatement) and node not in found_ifs
+        def collect(game: frog_ast.Game) -> list[frog_ast.ASTNode]:
+            found: list[frog_ast.ASTNode] = []
 
-    while True:
-        partial = functools.partial(search_for_if, found_ifs)
-        if_current = visitors.SearchVisitor[frog_ast.IfStatement](partial).visit(
-            current_game_ast
+            def search(node: frog_ast.ASTNode) -> bool:
+                return isinstance(node, node_type) and all(
+                    node is not seen for seen in found
+                )
+
+            while True:
+                match = visitors.SearchVisitor[frog_ast.ASTNode](search).visit(game)
+                if match is None:
+                    return found
+                found.append(match)
+
+        current_nodes = collect(current_game_ast)
+        next_nodes = collect(next_game_ast)
+        if len(current_nodes) != len(next_nodes):
+            return None
+        return list(zip(current_nodes, next_nodes))
+
+    if_pairs = _enumerate_lockstep(frog_ast.IfStatement)
+    if if_pairs is None:
+        return EquivalenceResult(
+            valid=False,
+            failure_detail=(
+                "Z3 residual walk: if-statement count mismatch despite "
+                "identical neutralized skeletons"
+            ),
         )
-        if_next = visitors.SearchVisitor[frog_ast.IfStatement](partial).visit(
-            next_game_ast
-        )
-        if if_current is None or if_next is None:
-            break
-        found_ifs.append(if_current)
-        found_ifs.append(if_next)
-        for i, condition in enumerate(if_current.conditions):
-            if condition == if_next.conditions[i]:
+    for if_current_node, if_next_node in if_pairs:
+        assert isinstance(if_current_node, frog_ast.IfStatement)
+        assert isinstance(if_next_node, frog_ast.IfStatement)
+        if len(if_current_node.conditions) != len(if_next_node.conditions):
+            return EquivalenceResult(
+                valid=False,
+                failure_detail=(
+                    "Z3 residual walk: if-condition arity mismatch despite "
+                    "identical neutralized skeletons"
+                ),
+            )
+        for i, condition in enumerate(if_current_node.conditions):
+            if condition == if_next_node.conditions[i]:
                 continue
             failure = _z3_check_expression_pair(
                 current_game_ast,
                 next_game_ast,
                 condition,
-                if_next.conditions[i],
+                if_next_node.conditions[i],
                 proof_let_types,
                 proof_namespace,
                 "if-condition",
@@ -314,33 +355,25 @@ def _z3_residual_equivalence(
             if failure is not None:
                 return failure
 
-    # Walk return statements in lockstep.
-    found_returns: list[frog_ast.ReturnStatement] = []
-
-    def search_for_return(
-        found_returns: list[frog_ast.ReturnStatement], node: frog_ast.ASTNode
-    ) -> bool:
-        return isinstance(node, frog_ast.ReturnStatement) and node not in found_returns
-
-    while True:
-        partial_r = functools.partial(search_for_return, found_returns)
-        ret_current = visitors.SearchVisitor[frog_ast.ReturnStatement](partial_r).visit(
-            current_game_ast
+    return_pairs = _enumerate_lockstep(frog_ast.ReturnStatement)
+    if return_pairs is None:
+        return EquivalenceResult(
+            valid=False,
+            failure_detail=(
+                "Z3 residual walk: return-statement count mismatch despite "
+                "identical neutralized skeletons"
+            ),
         )
-        ret_next = visitors.SearchVisitor[frog_ast.ReturnStatement](partial_r).visit(
-            next_game_ast
-        )
-        if ret_current is None or ret_next is None:
-            break
-        found_returns.append(ret_current)
-        found_returns.append(ret_next)
-        if ret_current.expression == ret_next.expression:
+    for ret_current_node, ret_next_node in return_pairs:
+        assert isinstance(ret_current_node, frog_ast.ReturnStatement)
+        assert isinstance(ret_next_node, frog_ast.ReturnStatement)
+        if ret_current_node.expression == ret_next_node.expression:
             continue
         failure = _z3_check_expression_pair(
             current_game_ast,
             next_game_ast,
-            ret_current.expression,
-            ret_next.expression,
+            ret_current_node.expression,
+            ret_next_node.expression,
             proof_let_types,
             proof_namespace,
             "return",

--- a/proof_frog/transforms/_base.py
+++ b/proof_frog/transforms/_base.py
@@ -113,6 +113,7 @@ def has_nondeterministic_call(
     expr: frog_ast.Expression,
     proof_namespace: frog_ast.Namespace,
     proof_let_types: Optional[NameTypeMap] = None,
+    shadowed_names: Optional[set[str]] = None,
 ) -> bool:
     """Return True if *expr* contains a FuncCall to a non-deterministic method.
 
@@ -120,6 +121,15 @@ def has_nondeterministic_call(
     ``Function<D, R>`` variables are treated as pure for inlining and CSE
     purposes.  Any other FuncCall (including calls to scheme methods, game
     methods, or unannotated primitive methods) is considered non-deterministic.
+
+    *shadowed_names* (F-267): names that are locally bound (declared) in the
+    method whose expression this is. A proof-level ``let: Function<D,R> H;`` is
+    a known deterministic function, but a same-named METHOD-LOCAL declaration
+    ``Function<D,R> H;`` shadows it -- and an unassigned local Function is an
+    uninitialized value, so calling it is an observable undefined read, not the
+    deterministic let-function. When a callee name is in *shadowed_names* the
+    let-``Function`` classification is NOT applied (the call is treated as
+    potentially non-deterministic).
     """
     from ..visitors import SearchVisitor  # pylint: disable=import-outside-toplevel
 
@@ -130,8 +140,13 @@ def has_nondeterministic_call(
         m = _lookup_primitive_method(node.func, proof_namespace)
         if m is not None:
             return not m.deterministic
-        # Function<D, R> calls are always deterministic (same input → same output)
-        if proof_let_types is not None and isinstance(node.func, frog_ast.Variable):
+        # Function<D, R> calls are always deterministic (same input → same
+        # output) -- UNLESS the name is shadowed by a method-local binding.
+        if (
+            proof_let_types is not None
+            and isinstance(node.func, frog_ast.Variable)
+            and (shadowed_names is None or node.func.name not in shadowed_names)
+        ):
             var_type = proof_let_types.get(node.func.name)
             if isinstance(var_type, frog_ast.FunctionType):
                 return False

--- a/proof_frog/transforms/_wrappers.py
+++ b/proof_frog/transforms/_wrappers.py
@@ -570,12 +570,24 @@ def _expr_is_group_elem_on_game(
         for param in game.parameters:
             if param.name == name and isinstance(param.type, frog_ast.GroupElemType):
                 return param.type.group
+        # F-249: a bare variable may be a method PARAMETER, but this helper has
+        # no method context. Scanning every method's parameters and taking the
+        # FIRST same-named one launders a `requires: G1.order is prime;`
+        # certificate from one method's `GroupElem<G1>` param onto a foreign
+        # `GroupElem<G2>` operand (rewriting `x^k == y^k -> x == y` where the
+        # map is not injective). Resolve against method parameters ONLY when
+        # every method that declares a same-named GroupElem parameter agrees on
+        # the SAME group -- then the type is unambiguous regardless of which
+        # method the expression is in. If the groups disagree, decline.
+        method_groups: list[frog_ast.Expression] = []
         for method in game.methods:
             for param in method.signature.parameters:
                 if param.name == name and isinstance(
                     param.type, frog_ast.GroupElemType
                 ):
-                    return param.type.group
+                    method_groups.append(param.type.group)
+        if method_groups and all(g == method_groups[0] for g in method_groups):
+            return method_groups[0]
         return None
     if isinstance(expr, frog_ast.GroupGenerator):
         return expr.group

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -1066,7 +1066,7 @@ class ReflexiveComparisonTransformer(Transformer):
         return transformed
 
 
-class BooleanIdentityTransformer(Transformer):
+class BooleanIdentityTransformer(MethodScopedTypeMapMixin):
     """Simplifies boolean AND/OR with literal true/false operands.
 
     OR rules (only when at least one operand is a Boolean literal,
@@ -1081,6 +1081,9 @@ class BooleanIdentityTransformer(Transformer):
       x && false / false && x -> false
     """
 
+    def __init__(self, type_map: Optional[NameTypeMap] = None) -> None:
+        self.type_map = type_map
+
     def transform_binary_operation(
         self, binary_operation: frog_ast.BinaryOperation
     ) -> frog_ast.Expression:
@@ -1093,6 +1096,23 @@ class BooleanIdentityTransformer(Transformer):
         right = transformed.right_expression
 
         if transformed.operator == frog_ast.BinaryOperators.OR:
+            # F-278: `||` is overloaded (boolean OR vs BitString concatenation).
+            # The boolean identities are valid only for a boolean OR. A
+            # Boolean-literal operand implies boolean OR in a well-typed program,
+            # but a directly constructed ill-typed AST (`bs || true`, `bs` a
+            # BitString) would otherwise collapse to `Boolean(True)`, destroying
+            # the bitstring. Skip when either operand is a known BitString.
+            if self.type_map is not None and (
+                isinstance(
+                    _get_expression_type(left, self.type_map),
+                    frog_ast.BitStringType,
+                )
+                or isinstance(
+                    _get_expression_type(right, self.type_map),
+                    frog_ast.BitStringType,
+                )
+            ):
+                return transformed
             # Only simplify when at least one operand is a Boolean literal
             # (BitString concatenation uses || but never has Boolean literals)
             if isinstance(left, frog_ast.Boolean) and left.bool:
@@ -1480,7 +1500,12 @@ class BooleanIdentity(TransformPass):
     name = "Boolean Identity"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return BooleanIdentityTransformer().transform(game)
+        type_map = build_game_type_map(game, ctx.proof_let_types)
+        return (
+            BooleanIdentityTransformer(type_map)
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 class XorCancellation(TransformPass):

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -942,6 +942,36 @@ class ReflexiveComparisonTransformer(Transformer):
     ) -> None:
         self._proof_namespace: frog_ast.Namespace = proof_namespace or {}
         self._proof_let_types = proof_let_types
+        self._shadowed_names: set[str] = set()
+
+    def transform_method(self, method: frog_ast.Method) -> frog_ast.ASTNode:
+        # F-267: collect the method's locally-bound names (parameters, typed
+        # local declarations, bare `Function<D,R> H;` declarations). A local
+        # binding of a proof-let `Function` name shadows the deterministic
+        # let-function, so `has_nondeterministic_call` must not treat a call to
+        # that name as the pure let-function within this method.
+        bound: set[str] = {p.name for p in method.signature.parameters}
+
+        def _collect(n: frog_ast.ASTNode) -> bool:
+            if isinstance(n, frog_ast.VariableDeclaration):
+                bound.add(n.name)
+            elif (
+                isinstance(
+                    n, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
+                )
+                and n.the_type is not None
+                and isinstance(n.var, frog_ast.Variable)
+            ):
+                bound.add(n.var.name)
+            return False
+
+        SearchVisitor(_collect).visit(method.block)
+        old = self._shadowed_names
+        self._shadowed_names = bound
+        try:
+            return self._transform_children(method)
+        finally:
+            self._shadowed_names = old
 
     def transform_binary_operation(
         self, binary_operation: frog_ast.BinaryOperation
@@ -958,6 +988,7 @@ class ReflexiveComparisonTransformer(Transformer):
                 transformed.left_expression,
                 self._proof_namespace,
                 self._proof_let_types,
+                self._shadowed_names,
             )
         ):
             return frog_ast.Boolean(True)
@@ -968,6 +999,7 @@ class ReflexiveComparisonTransformer(Transformer):
                 transformed.left_expression,
                 self._proof_namespace,
                 self._proof_let_types,
+                self._shadowed_names,
             )
         ):
             return frog_ast.Boolean(False)

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -2486,6 +2486,14 @@ class TupleEqualityDecomposeTransformer(MethodScopedTypeMapMixin):
             t = self.type_map.get(expr.name)
             if isinstance(t, frog_ast.ProductType):
                 return len(t.types)
+        # F-258: a call returning a product type has that product's arity (e.g.
+        # `F.Coin() : [Bool, Bool]`). Needed so `t != F.Coin()` cross-checks as
+        # a same-arity pair rather than declining; the F-257 purity gate still
+        # blocks a NON-deterministic such call from being projected per element.
+        if isinstance(expr, frog_ast.FuncCall):
+            m = _lookup_primitive_method(expr.func, self.ctx.proof_namespace)
+            if m is not None and isinstance(m.return_type, frog_ast.ProductType):
+                return len(m.return_type.types)
         return None
 
     def transform_binary_operation(
@@ -2501,10 +2509,20 @@ class TupleEqualityDecomposeTransformer(MethodScopedTypeMapMixin):
             return transformed
         left = transformed.left_expression
         right = transformed.right_expression
-        arity = self._product_arity(left)
-        if arity is None:
-            arity = self._product_arity(right)
-        if arity is None or arity < 1:
+        # F-258: BOTH operands must be products of the SAME arity. The old
+        # one-sided read (left's arity, falling back to right's) let a product
+        # be compared against a NON-product operand -- e.g. a `[Int,Int]?`
+        # variable holding `None`. Projecting `right[i]` then manufactured
+        # `None[i]`, an undefined read that corrupted an everywhere-defined
+        # game (`[1,2] != None` is just `true`) into an always-aborting one, so
+        # a VALID hop was wrongly REJECTED. Require both arities present and
+        # equal; a non-product / optional operand declines the decomposition.
+        left_arity = self._product_arity(left)
+        right_arity = self._product_arity(right)
+        if left_arity is None or right_arity is None or left_arity != right_arity:
+            return transformed
+        arity = left_arity
+        if arity < 1:
             return transformed
         # Purity gate: `project` deep-copies a non-Tuple operand once per
         # component (arity copies via ArrayAccess). A bare Variable is a

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -777,12 +777,29 @@ def _exponents_compatible(
     return False
 
 
-def _is_group_identity(expr: frog_ast.Expression) -> bool:
-    """Check if an expression is a group identity element (G.identity)."""
-    return (
+def _is_group_identity(
+    expr: frog_ast.Expression, type_map: Optional[NameTypeMap] = None
+) -> bool:
+    """Check if an expression is a group identity element (``G.identity``).
+
+    The object ``G`` must be typed ``Group`` in *type_map*. A bare name-match
+    on ``.identity`` (with no type check) would also cancel a non-group field
+    literally named ``identity`` -- e.g. an ``Int identity`` scheme field --
+    out of a product, which is unsound (audit F-285/F-286: ``x * E.identity``
+    where ``E`` is a scheme instance and ``identity`` an ``Int``). Without a
+    type_map the check is conservative and returns False, since the group
+    identity cannot be confirmed on the name alone.
+    """
+    if not (
         isinstance(expr, frog_ast.FieldAccess)
         and expr.name == "identity"
         and isinstance(expr.the_object, frog_ast.Variable)
+    ):
+        return False
+    if type_map is None:
+        return False
+    return isinstance(
+        _get_expression_type(expr.the_object, type_map), frog_ast.GroupType
     )
 
 
@@ -2603,15 +2620,15 @@ class GroupElemSimplificationTransformer(MethodScopedTypeMapMixin):
         # --- Multiplicative identity rules ---
         if op == frog_ast.BinaryOperators.MULTIPLY:
             # identity * g  -->  g
-            if _is_group_identity(left):
+            if _is_group_identity(left, self.type_map):
                 return right
             # g * identity  -->  g
-            if _is_group_identity(right):
+            if _is_group_identity(right, self.type_map):
                 return left
 
         if op == frog_ast.BinaryOperators.DIVIDE:
             # g / identity  -->  g
-            if _is_group_identity(right):
+            if _is_group_identity(right, self.type_map):
                 return left
 
         return transformed

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -1324,6 +1324,14 @@ class UniformGroupElemSimplificationTransformer(BlockTransformer):
                 and isinstance(statement.var, frog_ast.Variable)
                 and isinstance(statement.the_type, frog_ast.GroupElemType)
                 and isinstance(statement.sampled_from, frog_ast.GroupElemType)
+                # F-282: the absorption `u * c -> u` is sound only when `u` is
+                # uniform over the SAME group as the multiplication is carried
+                # out in (the declared type's group). If the sampled group
+                # differs (`GroupElem<G> u <- GroupElem<H>`), `u` is uniform over
+                # H but `u * g` lands in the coset `gH` -- a different support --
+                # so `u * g` is not distributed as `u`. Require the two groups to
+                # match structurally.
+                and statement.the_type.group == statement.sampled_from.group
             ):
                 continue
 

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -24,6 +24,7 @@ from ..visitors import (
     build_game_type_map,
     build_method_type_map,
     MethodScopedTypeMapMixin,
+    reassigns_or_rebinds,
 )
 from ._base import (
     TransformPass,
@@ -1558,21 +1559,10 @@ class InjectiveEqualitySimplifyTransformer(Transformer):
         }
         # Gap D: drop bindings whose call args reference free variables
         # that may differ between the binding site and the comparison
-        # site. A free variable is "stable" iff it has at most one write
-        # in the method (parameters and write-once typed-locals qualify;
-        # fields written anywhere in the method do not).
-        param_names = {p.name for p in method.signature.parameters}
-        field_names = {f.name for f in self.game.fields}
-        stable_field_names = {
-            f for f in field_names if _count_field_assigns(method.block, f) == 0
-        }
-        # Top-level single-write typed-init locals are stable (write once,
-        # read many). A locally-rebound name is excluded.
-        all_locals, all_reassigned = _scan_top_level_single_writes(
-            method.block, value_predicate=lambda v: True
-        )
-        single_write_locals = set(all_locals.keys()) - all_reassigned
-        stable_names = param_names | stable_field_names | single_write_locals
+        # site. A free variable is "stable" iff its value is fixed across
+        # the method (params, fields unwritten in this method, write-once
+        # typed-locals -- nested-aware). See _stable_value_names.
+        stable_names = _stable_value_names(method, self.game)
         for name in list(funccall_bindings.keys()):
             call = funccall_bindings[name]
             free = {
@@ -1818,7 +1808,8 @@ class InjectiveEqualitySimplifyTransformer(Transformer):
         if init is None:
             return expr
         rhs: Optional[frog_ast.Expression] = None
-        for stmt in init.block.statements:
+        def_idx = -1
+        for idx, stmt in enumerate(init.block.statements):
             if (
                 isinstance(stmt, frog_ast.Assignment)
                 and stmt.the_type is None
@@ -1828,6 +1819,7 @@ class InjectiveEqualitySimplifyTransformer(Transformer):
                 if rhs is not None:
                     return expr  # multiple top-level assignments
                 rhs = stmt.value
+                def_idx = idx
         if rhs is None:
             return expr
         # No assignment may exist anywhere else in the game.
@@ -1843,12 +1835,30 @@ class InjectiveEqualitySimplifyTransformer(Transformer):
         # Free vars in rhs must be cross-method visible.  Anything else
         # (Init-local declarations) cannot legally be referenced from the
         # site where this resolved expression will be substituted in.
-        visible = {f.name for f in self.game.fields} | {
-            p.name for p in self.game.parameters
-        }
+        field_names = {f.name for f in self.game.fields}
+        visible = field_names | {p.name for p in self.game.parameters}
         free = {v.name for v in VariableCollectionVisitor().visit(copy.deepcopy(rhs))}
         if not free.issubset(visible):
             return expr
+        # F-248: the resolved RHS is substituted at an arbitrary comparison
+        # site (any oracle, any time), so each free variable must hold the
+        # SAME value it had at Init when the field was frozen. Params are
+        # immutable; a field free var is stable only if it is never written
+        # AFTER the field's defining assignment -- neither later in Init nor
+        # in any non-Init method. Otherwise `F == E.Enc(t)` would collapse to
+        # `t == t` even though `F` holds the stale Init-time `E.Enc(t)`.
+        for t in free & field_names:
+            if any(
+                reassigns_or_rebinds({t}, s)
+                for s in init.block.statements[def_idx + 1 :]
+            ):
+                return expr
+            if any(
+                _count_field_assigns(m.block, t) > 0
+                for m in self.game.methods
+                if m is not init
+            ):
+                return expr
         return rhs
 
     @staticmethod
@@ -1916,12 +1926,19 @@ def _scan_top_level_single_writes(
     ``GenericFor`` statements. (Loop iteration overwrites the variable,
     so any earlier binding cannot be relied on at later use sites.)
 
-    Bindings declared inside nested blocks (if/for bodies) are NOT
+    Bindings *declared* inside nested blocks (if/for bodies) are NOT
     collected: a declaration inside a nested scope is not visible
-    outside it. This is the AST-level analogue of FrogLang's surface
-    scoping rules.
+    outside it. But a *write* to a top-level-bound name that occurs
+    inside a nested block DOES invalidate the binding: the name is still
+    in scope there, so the nested write can change its value before a
+    later use at the top level. A scan that ignored nested writes would
+    treat a stale binding as write-once and substitute it incorrectly
+    (audit F-247 / F-251), so the nested-aware invalidation below is
+    mandatory for soundness -- it uses the node-kind-complete,
+    recursive :func:`reassigns_or_rebinds`.
     """
     bindings: dict[str, frog_ast.Expression] = {}
+    binding_stmt: dict[str, frog_ast.Statement] = {}
     reassigned: set[str] = set()
     for stmt in block.statements:
         if isinstance(stmt, frog_ast.Assignment) and isinstance(
@@ -1934,6 +1951,7 @@ def _scan_top_level_single_writes(
                     reassigned.add(name)
                 else:
                     bindings[name] = stmt.value
+                    binding_stmt[name] = stmt
             else:
                 if name in bindings:
                     reassigned.add(name)
@@ -1948,7 +1966,45 @@ def _scan_top_level_single_writes(
         elif isinstance(stmt, frog_ast.GenericFor):
             if stmt.var_name in bindings:
                 reassigned.add(stmt.var_name)
+    # Nested-aware invalidation: any write to a bound name anywhere OTHER
+    # than its single defining init statement -- including element/field
+    # writes and writes inside if/for bodies -- means the binding is not
+    # write-once and must not be relied upon at later use sites.
+    for name, def_stmt in binding_stmt.items():
+        if name in reassigned:
+            continue
+        for stmt in block.statements:
+            if stmt is def_stmt:
+                continue
+            if reassigns_or_rebinds({name}, stmt):
+                reassigned.add(name)
+                break
     return bindings, reassigned
+
+
+def _stable_value_names(method: frog_ast.Method, game: frog_ast.Game) -> set[str]:
+    """Names whose VALUE is fixed across *method*'s execution.
+
+    A name is value-stable if it is a method parameter (immutable), a game
+    field never written in this method (``_count_field_assigns == 0``), or a
+    top-level write-once typed-init local (nested-aware via
+    :func:`_scan_top_level_single_writes`).
+
+    Used to decide whether a local binding ``v = f(...free...)`` /
+    ``v = a || b`` may be substituted at a later comparison site: the
+    substitution re-evaluates the RHS there, so every free variable of the
+    RHS must hold the same value it did at the binding site (audit F-252,
+    and the Gap-D stability set of InjectiveEqualitySimplify / F-247).
+    """
+    param_names = {p.name for p in method.signature.parameters}
+    stable_field_names = {
+        f.name for f in game.fields if _count_field_assigns(method.block, f.name) == 0
+    }
+    all_locals, all_reassigned = _scan_top_level_single_writes(
+        method.block, value_predicate=lambda v: True
+    )
+    single_write_locals = set(all_locals.keys()) - all_reassigned
+    return param_names | stable_field_names | single_write_locals
 
 
 def _flatten_concat(expr: frog_ast.Expression) -> list[frog_ast.Expression]:
@@ -2076,6 +2132,22 @@ class ConcatEqualityDecomposeTransformer(MethodScopedTypeMapMixin):
         )
         for name in reassigned:
             bindings.pop(name, None)
+        # F-252: a concat binding `v = a || b` is substituted textually at
+        # the comparison site, re-evaluating its RHS there. Drop any binding
+        # whose RHS free variables are not all value-stable (a later write to
+        # `a` -- even at top level, or nested -- would make the substituted
+        # `a || b` read the mutated value, diverging from the frozen `v`).
+        if self._scope_game is not None:
+            stable_names = _stable_value_names(method, self._scope_game)
+            for name in list(bindings.keys()):
+                free = {
+                    v.name
+                    for v in VariableCollectionVisitor().visit(
+                        copy.deepcopy(bindings[name])
+                    )
+                }
+                if not free.issubset(stable_names):
+                    bindings.pop(name, None)
         old = self.local_concat_bindings
         self.local_concat_bindings = bindings
         # Scope the type map to THIS method (fields + this method's

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -75,6 +75,29 @@ def _use_node_inside_loop(block: frog_ast.Block, use_node: frog_ast.ASTNode) -> 
     return SearchVisitor(_loop_contains).visit(block) is not None
 
 
+def _count_variable_uses(name: str, block: frog_ast.Block) -> int:
+    """Count occurrences of ``Variable(name)`` in *block*, one per AST POSITION.
+
+    F-281: the uniform-absorption passes previously counted uses by replacing one
+    occurrence at a time with an ``is``-identity ``ReplaceTransformer``. Two live
+    reads that happen to SHARE a single ``Variable`` object (e.g. produced by a
+    transform that did not deep-copy) were both replaced at once and tallied as
+    ONE use, so a value used twice looked single-use and was wrongly absorbed.
+    Visiting each position (a shared object at two slots is visited twice) counts
+    correctly. Capped at 2 -- callers only need exactly-once vs not.
+    """
+    count = 0
+
+    def _matches(node: frog_ast.ASTNode) -> bool:
+        nonlocal count
+        if isinstance(node, frog_ast.Variable) and node.name == name:
+            count += 1
+        return count > 1
+
+    SearchVisitor(_matches).visit(block)
+    return count
+
+
 def _use_node_inside_type(block: frog_ast.Block, use_node: frog_ast.ASTNode) -> bool:
     """True if *use_node* occurs inside a ``Type`` node's subtree within *block*.
 
@@ -144,23 +167,9 @@ class UniformXorSimplificationTransformer(BlockTransformer):
             )
 
             # Count uses of var_name — must be exactly 1
-            def uses_var(name: str, node: frog_ast.ASTNode) -> bool:
-                return isinstance(node, frog_ast.Variable) and node.name == name
-
-            total_uses = 0
-            count_block = copy.deepcopy(remaining_block)
-            while True:
-                found = SearchVisitor(functools.partial(uses_var, var_name)).visit(
-                    count_block
-                )
-                if found is None:
-                    break
-                total_uses += 1
-                if total_uses > 1:
-                    break
-                count_block = ReplaceTransformer(
-                    found, frog_ast.Variable(var_name + "__counted__")
-                ).transform(count_block)
+            # F-281: count by AST position (not is-identity replacement) so two
+            # live reads sharing one Variable object are not tallied as one.
+            total_uses = _count_variable_uses(var_name, remaining_block)
 
             if total_uses != 1:
                 if total_uses > 1 and self.ctx is not None:
@@ -306,23 +315,9 @@ class UniformModIntSimplificationTransformer(BlockTransformer):
             )
 
             # Count uses of var_name — must be exactly 1
-            def uses_var(name: str, node: frog_ast.ASTNode) -> bool:
-                return isinstance(node, frog_ast.Variable) and node.name == name
-
-            total_uses = 0
-            count_block = copy.deepcopy(remaining_block)
-            while True:
-                found = SearchVisitor(functools.partial(uses_var, var_name)).visit(
-                    count_block
-                )
-                if found is None:
-                    break
-                total_uses += 1
-                if total_uses > 1:
-                    break
-                count_block = ReplaceTransformer(
-                    found, frog_ast.Variable(var_name + "__counted__")
-                ).transform(count_block)
+            # F-281: count by AST position (not is-identity replacement) so two
+            # live reads sharing one Variable object are not tallied as one.
+            total_uses = _count_variable_uses(var_name, remaining_block)
 
             if total_uses != 1:
                 if total_uses > 1 and self.ctx is not None:
@@ -1361,23 +1356,9 @@ class UniformGroupElemSimplificationTransformer(BlockTransformer):
                 copy.deepcopy(list(block.statements[index + 1 :]))
             )
 
-            def uses_var(name: str, node: frog_ast.ASTNode) -> bool:
-                return isinstance(node, frog_ast.Variable) and node.name == name
-
-            total_uses = 0
-            count_block = copy.deepcopy(remaining_block)
-            while True:
-                found = SearchVisitor(functools.partial(uses_var, var_name)).visit(
-                    count_block
-                )
-                if found is None:
-                    break
-                total_uses += 1
-                if total_uses > 1:
-                    break
-                count_block = ReplaceTransformer(
-                    found, frog_ast.Variable(var_name + "__counted__")
-                ).transform(count_block)
+            # F-281: count by AST position (not is-identity replacement) so two
+            # live reads sharing one Variable object are not tallied as one.
+            total_uses = _count_variable_uses(var_name, remaining_block)
 
             if total_uses != 1:
                 if total_uses > 1 and self.ctx is not None:

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -1183,11 +1183,18 @@ class BooleanAbsorptionTransformer(Transformer):
                         )
         if all(keep):
             return transformed
+        # F-245: keep the surviving conjuncts in SOURCE order. `&&` is
+        # left-to-right strict (SEMANTICS 3.4): a later conjunct may depend on
+        # an earlier one as a guard -- `x in M && M[x] == 0` evaluates `M[x]`
+        # only when `x in M`, so it never performs an absent-key read. Sorting
+        # by `node_sort_key` moved `M[x] == 0` ahead of its guard (`"EQUALS" <
+        # "IN"`), making the read unconditional and changing observable
+        # behaviour. (The previous rationale -- matching a form
+        # NormalizeCommutativeChains produces -- was mistaken: AND/OR are NOT in
+        # its commutative-op sets, so it never reorders a boolean chain. Source
+        # order is already the canonical form for a non-absorbed chain, so
+        # dropping absorbed conjuncts in place stays consistent with it.)
         kept_conjuncts = [c for c, k in zip(conjuncts, keep) if k]
-        # Sort by node_sort_key so the rebuilt chain is canonical and
-        # matches the form produced when no absorption was needed (where
-        # NormalizeCommutativeChains sorts the chain in a separate pass).
-        kept_conjuncts.sort(key=node_sort_key)
         if len(kept_conjuncts) == 1:
             return kept_conjuncts[0]
         result: frog_ast.Expression = kept_conjuncts[0]

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -669,15 +669,59 @@ def _is_integer_literal(expr: frog_ast.Expression, value: int) -> bool:
     return isinstance(expr, frog_ast.Integer) and expr.num == value
 
 
+def _modulus_is_group_order(
+    modulus: frog_ast.Expression,
+    base: Optional[frog_ast.Expression],
+    type_map: Optional[NameTypeMap],
+) -> bool:
+    """True if *modulus* is provably a multiple of *base*'s group order.
+
+    The soundness condition for folding ModInt<M> group exponents
+    (``g^a * g^b -> g^(a+b)`` with the ADD taken mod M) is ``g^M ==
+    identity``, i.e. the group order divides M. The provable case checked
+    here is ``M`` syntactically equal to the base group's order --
+    ``GroupOrder(G)`` (the canonical/desugared form of ``G.order``) or the
+    ``FieldAccess(G, "order")`` surface form. Any other modulus (a bare
+    parameter, a smaller ``ModInt<2>``, an unrelated group's order) is not
+    provably order-dividing, so the fold is refused (audit F-272/F-273/F-283).
+    """
+    if base is None or type_map is None:
+        return False
+    base_type = _get_expression_type(base, type_map)
+    if not isinstance(base_type, frog_ast.GroupElemType):
+        return False
+    group = base_type.group
+    if isinstance(modulus, frog_ast.GroupOrder) and modulus.group == group:
+        return True
+    if (
+        isinstance(modulus, frog_ast.FieldAccess)
+        and modulus.name == "order"
+        and modulus.the_object == group
+    ):
+        return True
+    return False
+
+
 def _exponents_compatible(
     e1: frog_ast.Expression,
     e2: frog_ast.Expression,
     type_map: Optional[NameTypeMap],
+    base: Optional[frog_ast.Expression] = None,
 ) -> bool:
-    """Check that two exponents have compatible types for arithmetic.
+    """Check that two group exponents may be soundly combined arithmetically.
 
-    Returns True if both are ModInt (same modulus) or both are Int.
-    Also returns True if type information is unavailable (optimistic).
+    Both Int: sound (integer exponent arithmetic; no modular wrap).
+
+    Both ModInt: the fold reduces the combined exponent modulo the shared
+    modulus M, which matches the group law only when ``g^M == identity``.
+    So it requires (a) the SAME modulus on both -- two different moduli give
+    an ill-typed ADD the typechecker rejects (F-274) -- AND (b) that modulus
+    to be provably a multiple of *base*'s group order (F-272/F-273/F-283),
+    checked via :func:`_modulus_is_group_order`. Without *base* the modular
+    case cannot be shown sound and is refused.
+
+    Returns True when type information is unavailable (optimistic), matching
+    the historical contract for the untyped case.
     """
     if type_map is None:
         return True
@@ -686,7 +730,9 @@ def _exponents_compatible(
     if t1 is None or t2 is None:
         return True
     if isinstance(t1, frog_ast.ModIntType) and isinstance(t2, frog_ast.ModIntType):
-        return True
+        if t1.modulus != t2.modulus:
+            return False
+        return _modulus_is_group_order(t1.modulus, base, type_map)
     if isinstance(t1, frog_ast.IntType) and isinstance(t2, frog_ast.IntType):
         return True
     return False
@@ -2361,10 +2407,16 @@ class GroupElemSimplificationTransformer(MethodScopedTypeMapMixin):
         return isinstance(expr, frog_ast.GroupGenerator)
 
     def _exponents_multipliable(
-        self, e1: frog_ast.Expression, e2: frog_ast.Expression
+        self,
+        e1: frog_ast.Expression,
+        e2: frog_ast.Expression,
+        base: Optional[frog_ast.Expression] = None,
     ) -> bool:
-        """Check that e1 * e2 is well-typed (both ModInt or both Int)."""
-        return _exponents_compatible(e1, e2, self.type_map)
+        """Check that ``base ^ (e1 * e2)`` soundly folds ``(base^e1)^e2``.
+
+        Both Int, or both ModInt sharing a modulus that is the base group's
+        order (see :func:`_exponents_compatible`)."""
+        return _exponents_compatible(e1, e2, self.type_map, base)
 
     def transform_binary_operation(
         self, binary_operation: frog_ast.BinaryOperation
@@ -2397,7 +2449,9 @@ class GroupElemSimplificationTransformer(MethodScopedTypeMapMixin):
             and isinstance(left, frog_ast.BinaryOperation)
             and left.operator == frog_ast.BinaryOperators.EXPONENTIATE
             and self._is_groupelem_expr(left.left_expression)
-            and self._exponents_multipliable(left.right_expression, right)
+            and self._exponents_multipliable(
+                left.right_expression, right, left.left_expression
+            )
         ):
             return frog_ast.BinaryOperation(
                 frog_ast.BinaryOperators.EXPONENTIATE,
@@ -2639,7 +2693,9 @@ class GroupElemExponentCombinationTransformer(MethodScopedTypeMapMixin):
                         if (
                             ex_pair is not None
                             and ex_pair[0] == base
-                            and _exponents_compatible(ex_pair[1], exp, self.type_map)
+                            and _exponents_compatible(
+                                ex_pair[1], exp, self.type_map, base
+                            )
                         ):
                             new_pos[i] = frog_ast.BinaryOperation(
                                 frog_ast.BinaryOperators.EXPONENTIATE,
@@ -2673,7 +2729,7 @@ class GroupElemExponentCombinationTransformer(MethodScopedTypeMapMixin):
                             pos_pair is not None
                             and pos_pair[0] == neg_base
                             and _exponents_compatible(
-                                pos_pair[1], neg_exp, self.type_map
+                                pos_pair[1], neg_exp, self.type_map, neg_base
                             )
                         ):
                             new_pos[i] = frog_ast.BinaryOperation(

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -253,6 +253,14 @@ class UniformModIntSimplificationTransformer(BlockTransformer):
                 and isinstance(statement.var, frog_ast.Variable)
                 and isinstance(statement.the_type, frog_ast.ModIntType)
                 and isinstance(statement.sampled_from, frog_ast.ModIntType)
+                # F-292: the absorption `u + c -> u` is sound only when `u` is
+                # uniform over the SAME modulus as the carrier the addition is
+                # computed in (the declared type). If the sampled modulus differs
+                # (`ModInt<4> u <- ModInt<2>`), `u` is uniform over {0..q_s-1}
+                # but `u + c` lands in {c..c+q_s-1} mod q_t -- a shifted,
+                # generally disjoint support -- so `u + c` is not distributed as
+                # `u`. Require the two moduli to match structurally.
+                and statement.the_type.modulus == statement.sampled_from.modulus
             ):
                 continue
 

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -1020,7 +1020,33 @@ class BooleanAbsorptionTransformer(Transformer):
                     and self._is_subset(disj_sets[i], disj_sets[j])
                     and self._is_subset(disj_sets[j], disj_sets[i])
                 ):
-                    keep[j] = False
+                    # Gap F (dual): dropping conjunct j removes its evaluation.
+                    # If it contains a non-deterministic call, i and j are
+                    # INDEPENDENT draws (i.i.d. per ruling 7.A.6) even when
+                    # structurally equal, so `f() && f()` is not `f()` and
+                    # `_is_subset` multiplicity-blindness (F-243) does not make
+                    # them equal. Only dedup deterministic duplicates (F-242).
+                    if not has_nondeterministic_call(
+                        conjuncts[j],
+                        self.ctx.proof_namespace,
+                        self.ctx.proof_let_types,
+                    ):
+                        keep[j] = False
+                    elif self.ctx is not None:
+                        self.ctx.near_misses.append(
+                            NearMiss(
+                                transform_name="Boolean Absorption",
+                                reason=(
+                                    "duplicate conjuncts not deduplicated: the "
+                                    "conjunct contains a non-deterministic call, "
+                                    "so the two copies are independent draws"
+                                ),
+                                location=None,
+                                suggestion=None,
+                                variable=None,
+                                method=None,
+                            )
+                        )
         if all(keep):
             return transformed
         kept_conjuncts = [c for c, k in zip(conjuncts, keep) if k]
@@ -1992,6 +2018,31 @@ class ConcatEqualityDecomposeTransformer(MethodScopedTypeMapMixin):
         else:
             return transformed
 
+        # Gap A (other): `other` is sliced once per concat term below (a
+        # copy.deepcopy at each slice). If it contains a non-deterministic
+        # call, the k slices become k INDEPENDENT draws (i.i.d. per ruling
+        # 7.A.6) instead of k views of one value, so the decomposition is
+        # unsound. Decline (the resolved-binding RHS is already guarded in
+        # `_resolve_to_concat`; this guards the un-resolved `other`). (F-254)
+        if has_nondeterministic_call(
+            other, self.ctx.proof_namespace, self.ctx.proof_let_types
+        ):
+            self.ctx.near_misses.append(
+                NearMiss(
+                    transform_name="Concat Equality Decompose",
+                    reason=(
+                        "the non-concat operand contains a non-deterministic "
+                        "call; slicing it per concat term would duplicate the "
+                        "call into independent draws"
+                    ),
+                    location=binary_operation.origin,
+                    suggestion=None,
+                    variable=None,
+                    method=None,
+                )
+            )
+            return transformed
+
         terms = _flatten_concat(concat_expr)
         if len(terms) < 2:
             return transformed
@@ -2223,6 +2274,35 @@ class TupleEqualityDecomposeTransformer(MethodScopedTypeMapMixin):
             arity = self._product_arity(right)
         if arity is None or arity < 1:
             return transformed
+        # Purity gate: `project` deep-copies a non-Tuple operand once per
+        # component (arity copies via ArrayAccess). A bare Variable is a
+        # deterministic re-read and a Tuple literal projects its distinct
+        # components, but any OTHER operand carrying a non-deterministic call
+        # (e.g. `Coin()` returning a tuple) would be evaluated `arity` times
+        # -- k INDEPENDENT draws (i.i.d. per ruling 7.A.6) instead of k views
+        # of one value. Decline. (F-257)
+        if arity >= 2:
+            for operand in (left, right):
+                if not isinstance(
+                    operand, (frog_ast.Tuple, frog_ast.Variable)
+                ) and has_nondeterministic_call(
+                    operand, self.ctx.proof_namespace, self.ctx.proof_let_types
+                ):
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Tuple Equality Decompose",
+                            reason=(
+                                "a tuple operand contains a non-deterministic "
+                                "call; projecting it per component would "
+                                "duplicate the call into independent draws"
+                            ),
+                            location=binary_operation.origin,
+                            suggestion=None,
+                            variable=None,
+                            method=None,
+                        )
+                    )
+                    return transformed
         # op is restricted to NOTEQUALS at the gate above; product
         # disequality decomposes via OR of per-component disequalities.
         combiner = frog_ast.BinaryOperators.OR

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -54,6 +54,26 @@ def _count_field_assigns(node: frog_ast.ASTNode, name: str) -> int:
     return count
 
 
+def _use_node_inside_loop(block: frog_ast.Block, use_node: frog_ast.ASTNode) -> bool:
+    """True if *use_node* occurs inside a loop body within *block*.
+
+    A "used exactly once" textual occurrence count is blind to loop
+    multiplicity: a single syntactic use inside a ``NumericFor``/``GenericFor``
+    body is dynamically evaluated once per iteration, so a uniform value
+    combined there is consumed against a fresh partner each iteration and the
+    uniform-absorption rewrite is unsound (audit F-132c / F-279 / F-288).
+
+    *use_node* must be an object still present in *block* (identity match).
+    """
+
+    def _loop_contains(node: frog_ast.ASTNode) -> bool:
+        return isinstance(node, (frog_ast.NumericFor, frog_ast.GenericFor)) and (
+            SearchVisitor(lambda n: n is use_node).visit(node) is not None
+        )
+
+    return SearchVisitor(_loop_contains).visit(block) is not None
+
+
 # ---------------------------------------------------------------------------
 # Transformer classes (moved from visitors.py)
 # ---------------------------------------------------------------------------
@@ -154,6 +174,33 @@ class UniformXorSimplificationTransformer(BlockTransformer):
                 functools.partial(is_xor_with_uniform, var_name)
             ).visit(remaining_block)
             if xor_node is None:
+                continue
+
+            # The "used exactly once" count above is textual.  If the single
+            # textual use sits inside a loop body while the sample is outside,
+            # the same uniform value is XORed against a fresh partner each
+            # iteration (`u <- BitString<n>; for(...) { acc = acc + u; }`),
+            # so the absorption is unsound (audit F-288).
+            if _use_node_inside_loop(remaining_block, xor_node):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Uniform XOR Simplification",
+                            reason=(
+                                f"XOR-with-uniform did not fire for '{var_name}': "
+                                f"its single use is inside a loop while the sample "
+                                f"is outside, so the value is XORed against a fresh "
+                                f"partner each iteration (not single-use)"
+                            ),
+                            location=statement.origin,
+                            suggestion=(
+                                f"Sample '{var_name}' inside the loop body if a "
+                                f"fresh uniform value is intended each iteration"
+                            ),
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
                 continue
 
             # Replace the BinaryOperation with just the uniform variable
@@ -288,16 +335,7 @@ class UniformModIntSimplificationTransformer(BlockTransformer):
             # -- e.g. `t <- ModInt<q>; for (...) { acc = acc + t; }` over a
             # two-element range leaves acc = 2t (even-only support), not the
             # uniform t the absorption would produce.  Decline (audit F-132c).
-            def _loop_contains_use(
-                node: frog_ast.ASTNode, target: frog_ast.ASTNode = add_node
-            ) -> bool:
-                return isinstance(
-                    node, (frog_ast.NumericFor, frog_ast.GenericFor)
-                ) and (
-                    SearchVisitor(lambda n, t=target: n is t).visit(node) is not None
-                )
-
-            if SearchVisitor(_loop_contains_use).visit(remaining_block) is not None:
+            if _use_node_inside_loop(remaining_block, add_node):
                 if self.ctx is not None:
                     self.ctx.near_misses.append(
                         NearMiss(
@@ -1242,6 +1280,33 @@ class UniformGroupElemSimplificationTransformer(BlockTransformer):
                 functools.partial(is_multiplicative_with_uniform, var_name)
             ).visit(remaining_block)
             if mul_node is None:
+                continue
+
+            # The "used exactly once" count above is textual.  If the single
+            # textual use sits inside a loop body while the sample is outside,
+            # the same uniform value is multiplied by a fresh partner each
+            # iteration (`u <- GroupElem<G>; for(...) { M[i] = u * g^i; }`),
+            # so the absorption is unsound (audit F-279).
+            if _use_node_inside_loop(remaining_block, mul_node):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Uniform GroupElem Simplification",
+                            reason=(
+                                f"Uniform-GroupElem did not fire for '{var_name}': "
+                                f"its single use is inside a loop while the sample "
+                                f"is outside, so the value is combined with a fresh "
+                                f"partner each iteration (not single-use)"
+                            ),
+                            location=statement.origin,
+                            suggestion=(
+                                f"Sample '{var_name}' inside the loop body if a "
+                                f"fresh uniform value is intended each iteration"
+                            ),
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
                 continue
 
             assert isinstance(mul_node, frog_ast.BinaryOperation)

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -449,17 +449,26 @@ def _is_bitstring_add_chain(
     """
     if type_map is None:
         return True
+    # F-264: scan ALL terms rather than returning on the first evidence. A
+    # ModInt term in an ADD chain is DEFINITIVE evidence of ModInt addition
+    # (where `z + z` is `2z`, not `0`), so it must override any BitString
+    # evidence -- returning True on a leading `0^n` while a later term is
+    # `z: ModInt<q>` (`0^n + z + z`) would XOR-cancel `z + z` to `0`, an unsound
+    # rewrite. Returning True wrongly is the unsound direction (it enables the
+    # cancellation), so require BitString evidence AND the absence of any ModInt
+    # evidence.
     terms = _flatten_add_chain(expr)
+    has_bitstring_evidence = False
     for term in terms:
         if isinstance(term, frog_ast.BitStringLiteral):
-            return True
-        if isinstance(term, frog_ast.Variable):
+            has_bitstring_evidence = True
+        elif isinstance(term, frog_ast.Variable):
             var_type = type_map.get(term.name)
             if isinstance(var_type, frog_ast.ModIntType):
                 return False
             if isinstance(var_type, frog_ast.BitStringType):
-                return True
-    return False
+                has_bitstring_evidence = True
+    return has_bitstring_evidence
 
 
 def _flatten_add_chain(expr: frog_ast.Expression) -> list[frog_ast.Expression]:

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -1487,6 +1487,14 @@ class NormalizeCommutativeChainsTransformer(Transformer):
     structurally smaller one is on the left.
     """
 
+    def __init__(
+        self,
+        proof_namespace: frog_ast.Namespace | None = None,
+        proof_let_types: NameTypeMap | None = None,
+    ) -> None:
+        self._proof_namespace: frog_ast.Namespace = proof_namespace or {}
+        self._proof_let_types = proof_let_types
+
     def transform_binary_operation(
         self, expr: frog_ast.BinaryOperation
     ) -> frog_ast.Expression:
@@ -1496,6 +1504,18 @@ class NormalizeCommutativeChainsTransformer(Transformer):
             self.transform(expr.left_expression),
             self.transform(expr.right_expression),
         )
+
+        # F-260: reordering operands is sound only when it cannot change the
+        # order in which observable side effects fire. Operands that reduce to
+        # pure values commute freely, but a stateful call
+        # (`challenger.Inc() + challenger.Get()`) does not: swapping it past
+        # another call changes which side effect runs first, so two genuinely
+        # distinguishable expressions would canonicalize to the same form.
+        # Decline to reorder any chain containing a non-deterministic call.
+        if has_nondeterministic_call(
+            transformed, self._proof_namespace, self._proof_let_types
+        ):
+            return transformed
 
         # Commutative + associative: flatten and sort the full chain.
         if transformed.operator in _COMMUTATIVE_ASSOCIATIVE_OPS:
@@ -1527,7 +1547,10 @@ class NormalizeCommutativeChains(TransformPass):
     name = "Normalize Commutative Chains"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return NormalizeCommutativeChainsTransformer().transform(game)
+        return NormalizeCommutativeChainsTransformer(
+            proof_namespace=ctx.proof_namespace,
+            proof_let_types=ctx.proof_let_types,
+        ).transform(game)
 
 
 class FlattenConcatChainTransformer(Transformer):

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -75,6 +75,34 @@ def _use_node_inside_loop(block: frog_ast.Block, use_node: frog_ast.ASTNode) -> 
     return SearchVisitor(_loop_contains).visit(block) is not None
 
 
+def _use_node_inside_type(block: frog_ast.Block, use_node: frog_ast.ASTNode) -> bool:
+    """True if *use_node* occurs inside a ``Type`` node's subtree within *block*.
+
+    The visitor descends into every attribute, including a ``Type``'s
+    parameterization expression, so a match like ``u + 3`` found for the
+    uniform-absorption rewrite may actually be a TYPE parameter (the modulus in
+    ``z <- ModInt<u + 3>``), not a value expression. Rewriting it edits the type
+    and changes the sampled variable's distribution (audit F-293), so the pass
+    must decline. *use_node* must be an object still present in *block* (identity
+    match).
+    """
+
+    def _type_contains(node: frog_ast.ASTNode) -> bool:
+        # A genuine type ANNOTATION is a ``Type`` that is not an ``Expression``
+        # (``Expression`` subclasses ``Type`` because an expression may name a
+        # type alias, so ``isinstance(_, Type)`` alone also matches every
+        # Variable/BinaryOperation). Only the annotation nodes (``ModIntType``,
+        # ``BitStringType``, ...) carry a value-expression parameterization that
+        # a match could wrongly land in.
+        return (
+            isinstance(node, frog_ast.Type)
+            and not isinstance(node, frog_ast.Expression)
+            and SearchVisitor(lambda n: n is use_node).visit(node) is not None
+        )
+
+    return SearchVisitor(_type_contains).visit(block) is not None
+
+
 # ---------------------------------------------------------------------------
 # Transformer classes (moved from visitors.py)
 # ---------------------------------------------------------------------------
@@ -175,6 +203,13 @@ class UniformXorSimplificationTransformer(BlockTransformer):
                 functools.partial(is_xor_with_uniform, var_name)
             ).visit(remaining_block)
             if xor_node is None:
+                continue
+
+            # F-293 (sibling sweep): the search descends into Type
+            # parameterizations, so a matched `u + c` could be a type parameter
+            # rather than a value expression. Rewriting it would edit a type;
+            # decline.
+            if _use_node_inside_type(remaining_block, xor_node):
                 continue
 
             # The "used exactly once" count above is textual.  If the single
@@ -336,6 +371,14 @@ class UniformModIntSimplificationTransformer(BlockTransformer):
                 functools.partial(is_additive_with_uniform, var_name)
             ).visit(remaining_block)
             if add_node is None:
+                continue
+
+            # F-293: the search descends into Type parameterizations, so
+            # `add_node` may be a `u + c` in a type modulus position
+            # (`z <- ModInt<u + 3>`). Rewriting it to `u` edits the TYPE and
+            # changes the sampled variable's distribution. A type parameter is
+            # not a value expression; decline.
+            if _use_node_inside_type(remaining_block, add_node):
                 continue
 
             # The "used exactly once" count above is textual.  If the single
@@ -1354,6 +1397,13 @@ class UniformGroupElemSimplificationTransformer(BlockTransformer):
                 functools.partial(is_multiplicative_with_uniform, var_name)
             ).visit(remaining_block)
             if mul_node is None:
+                continue
+
+            # F-293 (sibling sweep): the search descends into Type
+            # parameterizations, so a matched `u * c` could be a type parameter
+            # rather than a value expression. Rewriting it would edit a type;
+            # decline.
+            if _use_node_inside_type(remaining_block, mul_node):
                 continue
 
             # The "used exactly once" count above is textual.  If the single

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -22,6 +22,8 @@ from ..visitors import (
     NameTypeMap,
     VariableCollectionVisitor,
     build_game_type_map,
+    build_method_type_map,
+    MethodScopedTypeMapMixin,
 )
 from ._base import (
     TransformPass,
@@ -450,7 +452,7 @@ def _rebuild_add_chain(terms: list[frog_ast.Expression]) -> frog_ast.Expression:
     return result
 
 
-class XorCancellationTransformer(Transformer):
+class XorCancellationTransformer(MethodScopedTypeMapMixin):
     """Cancels pairs of identical terms in XOR (ADD on bitstrings) chains.
 
     Since XOR is self-inverse (a ^ a = 0) and associative/commutative,
@@ -572,7 +574,7 @@ class XorCancellationTransformer(Transformer):
         return None
 
 
-class XorIdentityTransformer(Transformer):
+class XorIdentityTransformer(MethodScopedTypeMapMixin):
     """Removes 0^n terms from XOR (ADD) chains, since x XOR 0 = x.
 
     Only fires when the ADD chain is in a bitstring context (not ModInt
@@ -716,7 +718,7 @@ def _get_group_var_from_type(
     return None
 
 
-class ModIntSimplificationTransformer(Transformer):
+class ModIntSimplificationTransformer(MethodScopedTypeMapMixin):
     """Applies algebraic identities for ModInt arithmetic.
 
     Requires a type map to determine when operands are ModInt.
@@ -1217,7 +1219,11 @@ class XorCancellation(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return XorCancellationTransformer(type_map, ctx).transform(game)
+        return (
+            XorCancellationTransformer(type_map, ctx)
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 class XorIdentity(TransformPass):
@@ -1225,7 +1231,11 @@ class XorIdentity(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return XorIdentityTransformer(type_map).transform(game)
+        return (
+            XorIdentityTransformer(type_map)
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 class ModIntSimplification(TransformPass):
@@ -1233,11 +1243,15 @@ class ModIntSimplification(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return ModIntSimplificationTransformer(
-            type_map,
-            proof_namespace=ctx.proof_namespace,
-            proof_let_types=ctx.proof_let_types,
-        ).transform(game)
+        return (
+            ModIntSimplificationTransformer(
+                type_map,
+                proof_namespace=ctx.proof_namespace,
+                proof_let_types=ctx.proof_let_types,
+            )
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 def _flatten_chain(
@@ -1860,7 +1874,7 @@ def _bitstring_length(
     return None
 
 
-class ConcatEqualityDecomposeTransformer(Transformer):
+class ConcatEqualityDecomposeTransformer(MethodScopedTypeMapMixin):
     """Rewrites ``x == (a1 || a2 || ... || ak)`` (or the mirror form)
     to ``x[0:n1] == a1 && x[n1:n1+n2] == a2 && ... && x[s:s+nk] == ak``,
     where ``ni`` is the statically-derivable BitString length of ``ai``.
@@ -1927,10 +1941,21 @@ class ConcatEqualityDecomposeTransformer(Transformer):
             bindings.pop(name, None)
         old = self.local_concat_bindings
         self.local_concat_bindings = bindings
+        # Scope the type map to THIS method (fields + this method's
+        # params/locals) so a sibling method's same-named binding cannot
+        # launder a wrong BitString length onto this method's operands
+        # (audit F-255). Mirrors MethodScopedTypeMapMixin.transform_method,
+        # which this override replaces.
+        saved_type_map = self.type_map
+        if self._scope_game is not None:
+            self.type_map = build_method_type_map(
+                self._scope_game, method, self._scope_let_types
+            )
         try:
             new_block = self.transform(method.block)
         finally:
             self.local_concat_bindings = old
+            self.type_map = saved_type_map
         if new_block is method.block:
             return method
         return frog_ast.Method(method.signature, new_block)
@@ -2133,7 +2158,11 @@ class ConcatEqualityDecompose(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return ConcatEqualityDecomposeTransformer(ctx, type_map).transform(game)
+        return (
+            ConcatEqualityDecomposeTransformer(ctx, type_map)
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2141,7 +2170,7 @@ class ConcatEqualityDecompose(TransformPass):
 # ---------------------------------------------------------------------------
 
 
-class TupleEqualityDecomposeTransformer(Transformer):
+class TupleEqualityDecomposeTransformer(MethodScopedTypeMapMixin):
     """Rewrites ``a != b`` between tuple-typed expressions to the
     component-wise disjunction ``a[0]!=b[0] || ... || a[k-1]!=b[k-1]``.
 
@@ -2218,7 +2247,11 @@ class TupleEqualityDecompose(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return TupleEqualityDecomposeTransformer(ctx, type_map).transform(game)
+        return (
+            TupleEqualityDecomposeTransformer(ctx, type_map)
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2226,7 +2259,7 @@ class TupleEqualityDecompose(TransformPass):
 # ---------------------------------------------------------------------------
 
 
-class GroupElemSimplificationTransformer(Transformer):
+class GroupElemSimplificationTransformer(MethodScopedTypeMapMixin):
     """Simplifies GroupElem expressions using group algebra identities.
 
     Rules:
@@ -2318,7 +2351,11 @@ class GroupElemSimplification(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return GroupElemSimplificationTransformer(type_map).transform(game)
+        return (
+            GroupElemSimplificationTransformer(type_map)
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 def _flatten_mul_div_chain(
@@ -2373,7 +2410,7 @@ def _is_groupelem_mul_div_chain(
     return isinstance(left_type, frog_ast.GroupElemType)
 
 
-class GroupElemCancellationTransformer(Transformer):
+class GroupElemCancellationTransformer(MethodScopedTypeMapMixin):
     """Cancels matching terms in GroupElem MULTIPLY/DIVIDE chains.
 
     In an abelian group, ``x * m / x`` simplifies to ``m`` when ``x``
@@ -2447,11 +2484,15 @@ class GroupElemCancellation(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return GroupElemCancellationTransformer(
-            type_map,
-            proof_namespace=ctx.proof_namespace,
-            proof_let_types=ctx.proof_let_types,
-        ).transform(game)
+        return (
+            GroupElemCancellationTransformer(
+                type_map,
+                proof_namespace=ctx.proof_namespace,
+                proof_let_types=ctx.proof_let_types,
+            )
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 def _get_exponent_base(
@@ -2466,7 +2507,7 @@ def _get_exponent_base(
     return None
 
 
-class GroupElemExponentCombinationTransformer(Transformer):
+class GroupElemExponentCombinationTransformer(MethodScopedTypeMapMixin):
     """Combines same-base exponentiations in GroupElem multiply/divide chains.
 
     ``g^a * g^b`` -> ``g^(a + b)``
@@ -2584,8 +2625,12 @@ class GroupElemExponentCombination(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         type_map = build_game_type_map(game, ctx.proof_let_types)
-        return GroupElemExponentCombinationTransformer(
-            type_map,
-            proof_namespace=ctx.proof_namespace,
-            proof_let_types=ctx.proof_let_types,
-        ).transform(game)
+        return (
+            GroupElemExponentCombinationTransformer(
+                type_map,
+                proof_namespace=ctx.proof_namespace,
+                proof_let_types=ctx.proof_let_types,
+            )
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )

--- a/proof_frog/transforms/alpha_rename.py
+++ b/proof_frog/transforms/alpha_rename.py
@@ -48,9 +48,9 @@ from .. import frog_ast
 from ..visitors import Transformer
 from ._base import TransformPass, PipelineContext
 
-# Reserved prefix for engine-internal names.  We never rename a binder whose
-# name already begins with ``__`` (idempotency + don't clobber other passes).
-_RESERVED_PREFIX = "__"
+# AlphaRename's own fresh-name pattern.  These -- and ONLY these -- are left
+# unrenamed on later fixed-point iterations, so renaming converges.  Every
+# other binder (including user-written ``__``-prefixed locals) is renamed.
 _FRESH = "__a{0}__"
 _FRESH_RE = re.compile(r"__a(\d+)__")
 
@@ -131,17 +131,43 @@ class _AlphaRenamer:
     ) -> frog_ast.Expression:
         return _RefRewriter(self._active(scopes)).transform(node)
 
+    def _rewrite_type(
+        self, the_type: frog_ast.Type | None, scopes: list[dict[str, str]]
+    ) -> frog_ast.Type | None:
+        """Rewrite name references inside a type annotation (e.g. the ``n`` in
+        ``BitString<n>``) through the active scope.
+
+        A binder's declared type is evaluated in the scope BEFORE the binder
+        itself binds, so callers pass ``scopes`` as it stands before
+        ``_maybe_bind``. Without this, a length/parameter naming a shadowing
+        local re-binds to the outer field and the recorded type is falsified
+        (audit F-239; and the ``sampled_from`` sibling F-238)."""
+        if the_type is None:
+            return None
+        return _RefRewriter(self._active(scopes)).transform(the_type)
+
     def _maybe_bind(self, name: str, local: dict[str, str]) -> str | None:
         """Allocate a fresh name for binder *name* and record it, or skip.
 
-        Returns the fresh name, or ``None`` if *name* should not be renamed
-        (already reserved-prefixed).
+        Returns the fresh name, or ``None`` if *name* should not be renamed.
+
+        The ONLY names left alone are AlphaRename's OWN already-minted fresh
+        names (``__aN__``, matched by :data:`_FRESH_RE`): re-renaming them
+        every fixed-point iteration would never converge. Every other binder
+        -- including a *user-written* ``__``-prefixed local -- IS renamed. The
+        old code skipped every ``__``-prefixed name on the assumption they were
+        all engine-internal; a victim who named a local ``__x`` was then left
+        un-renamed, so the capture AlphaRename exists to prevent survived and a
+        downstream name-blind splice (BranchElimination) conflated the shadow
+        -- an advantage-1 false accept (audit F-237). Other engine temporaries
+        (``__cse_slice_...``, ``__rf_extract_...``) are just as capture-prone
+        and are safely renamed too: their producing passes re-mint by a
+        within-block counter, so a renamed temp is never re-matched.
         """
-        if name.startswith(_RESERVED_PREFIX):
-            # Leave engine-internal names alone; still record an identity
-            # binding so a later same-name reference resolves to it (not to an
-            # outer local with the same reserved name, which cannot happen, but
-            # keeps the scope model exact).
+        if _FRESH_RE.fullmatch(name):
+            # Already an AlphaRename fresh name: keep it (identity binding so a
+            # later same-name reference resolves to it) to guarantee
+            # fixed-point convergence.
             local[name] = name
             return None
         fresh = self._fresh()
@@ -161,10 +187,11 @@ class _AlphaRenamer:
         if isinstance(statement, frog_ast.UniqueSample):
             return self._rename_unique_sample(statement, scopes, local)
         if isinstance(statement, frog_ast.VariableDeclaration):
+            new_type = self._rewrite_type(statement.type, scopes)
             fresh = self._maybe_bind(statement.name, local)
-            if fresh is None:
-                return statement
-            return frog_ast.VariableDeclaration(statement.type, fresh)
+            name = fresh if fresh is not None else statement.name
+            assert new_type is not None
+            return frog_ast.VariableDeclaration(new_type, name)
         if isinstance(statement, frog_ast.ReturnStatement):
             return frog_ast.ReturnStatement(self._rewrite(statement.expression, scopes))
         if isinstance(statement, frog_ast.IfStatement):
@@ -184,6 +211,7 @@ class _AlphaRenamer:
         local: dict[str, str],
     ) -> frog_ast.Assignment:
         new_value = self._rewrite(statement.value, scopes)
+        new_type = self._rewrite_type(statement.the_type, scopes)
         if statement.the_type is not None and isinstance(
             statement.var, frog_ast.Variable
         ):
@@ -196,7 +224,7 @@ class _AlphaRenamer:
             # not a binder.  Rewrite the lvalue's references with the scope as
             # it stands (the target name, if a renamed local, must follow).
             new_var = self._rewrite(statement.var, scopes)
-        return frog_ast.Assignment(statement.the_type, new_var, new_value)
+        return frog_ast.Assignment(new_type, new_var, new_value)
 
     def _rename_sample(
         self,
@@ -205,6 +233,7 @@ class _AlphaRenamer:
         local: dict[str, str],
     ) -> frog_ast.Sample:
         new_from = self._rewrite(statement.sampled_from, scopes)
+        new_type = self._rewrite_type(statement.the_type, scopes)
         if statement.the_type is not None and isinstance(
             statement.var, frog_ast.Variable
         ):
@@ -214,7 +243,7 @@ class _AlphaRenamer:
             )
         else:
             new_var = self._rewrite(statement.var, scopes)
-        return frog_ast.Sample(statement.the_type, new_var, new_from)
+        return frog_ast.Sample(new_type, new_var, new_from)
 
     def _rename_unique_sample(
         self,
@@ -223,6 +252,7 @@ class _AlphaRenamer:
         local: dict[str, str],
     ) -> frog_ast.UniqueSample:
         new_set = self._rewrite(statement.unique_set, scopes)
+        new_type = self._rewrite_type(statement.the_type, scopes)
         if statement.the_type is not None and isinstance(
             statement.var, frog_ast.Variable
         ):
@@ -232,11 +262,18 @@ class _AlphaRenamer:
             )
         else:
             new_var = self._rewrite(statement.var, scopes)
+        # `sampled_from` (the draw's domain type in `<-uniq[S] T` / `<- T \ E`)
+        # can reference a shadowed field or local; it must be rewritten
+        # through the active scope like the exclusion set, or the domain
+        # re-binds to the wrong name (audit F-238). It is a Type, so it goes
+        # through `_rewrite_type` (cf. Sample.sampled_from, an Expression).
+        new_from = self._rewrite_type(statement.sampled_from, scopes)
+        assert new_from is not None
         return frog_ast.UniqueSample(
-            statement.the_type,
+            new_type,
             new_var,
             new_set,
-            statement.sampled_from,
+            new_from,
             statement.surface_form,
         )
 

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -1925,7 +1925,15 @@ class IfFalseReturnToConjunctionTransformer(BlockTransformer):
                 continue
             trailing = block.statements[trailing_idx]
             assert isinstance(trailing, frog_ast.ReturnStatement)
-            if trailing.expression is None:
+            # F-117: ``trailing.expression is None`` is a Python None test for a
+            # bare ``return;``. It does NOT catch a FrogLang ``None`` literal
+            # (``frog_ast.NoneExpression``), which a well-typed ``T?`` method may
+            # return. Conjoining it (``!P && None``) is type-invalid and would
+            # canonicalize a well-typed game into a meaningless one, so decline
+            # -- the rewrite's soundness argument assumes a boolean trailing.
+            if trailing.expression is None or isinstance(
+                trailing.expression, frog_ast.NoneExpression
+            ):
                 continue
             # RC4 capture/movement guard: the negated guard ``!P`` is moved
             # from BEFORE the intervening declarations to AFTER them (into the

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -714,7 +714,14 @@ class IfToBooleanAssignmentTransformer(BlockTransformer):
                 and then_stmt.var.name == else_stmt.var.name
                 and isinstance(then_stmt.value, frog_ast.Boolean)
                 and isinstance(else_stmt.value, frog_ast.Boolean)
-                and then_stmt.value.bool != else_stmt.value.bool
+                # F-085: compare the branch literals by TRUTH VALUE, not by raw
+                # Python payload. A `!=` on the payloads fires on a non-canonical
+                # pair such as Boolean(2) vs Boolean(True) (2 != True), even
+                # though both mean `true`, then rewrites `x = c` -- a
+                # probability-changing merge where the sound result is the
+                # constant `x = true`. The parser only builds genuine bools, so
+                # this normalises a value only a future transform could produce.
+                and bool(then_stmt.value.bool) != bool(else_stmt.value.bool)
             ):
                 continue
             # RC4 binding-kind guard: both branches must be the same kind of

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -790,6 +790,20 @@ class SimplifyReturnTransformer(BlockTransformer):
         new_game.methods = [self.transform(method) for method in new_game.methods]
         return new_game
 
+    def transform_reduction(self, reduction: frog_ast.Reduction) -> frog_ast.Reduction:
+        # F-127: a Reduction is a Game subclass but dispatches to
+        # ``transform_reduction`` (not ``transform_game``), so without this hook
+        # ``self.fields`` stayed empty and the trailing-return inlining below
+        # deleted a Reduction field write (``f = 7; return f;`` -> ``return 7;``,
+        # dropping an observable state mutation). Populate fields the same way,
+        # preserving the Reduction's ``to_use`` / ``play_against`` via deepcopy.
+        self.fields = [field.name for field in reduction.fields]
+        new_reduction = copy.deepcopy(reduction)
+        new_reduction.methods = [
+            self.transform(method) for method in new_reduction.methods
+        ]
+        return new_reduction
+
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         if not block.statements:
             return block

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -88,9 +88,23 @@ class BranchEliminiationTransformer(BlockTransformer):
                     len(new_if_statement.conditions) == 1
                     and isinstance(new_if_statement.conditions[0], frog_ast.Boolean)
                     and new_if_statement.conditions[0].bool
-                ) or not new_if_statement.conditions:
+                ):
+                    # ``if (true) { B } ...`` -> splice the then-branch B.
                     return self.transform_block(
                         prior_block + new_if_statement.blocks[0] + remaining_block
+                    )
+
+                if not new_if_statement.conditions:
+                    # No arm condition holds, so the else executes. F-125: splice
+                    # ``blocks[-1]`` -- the block ``has_else_block()`` designates
+                    # as the else -- not ``blocks[0]``. On the reachable path the
+                    # paired condition+block deletion above leaves a single block
+                    # (``blocks[-1] == blocks[0]``); the two differ only on a
+                    # malformed, directly-constructed ``IfStatement([], [b1, b2])``,
+                    # where splicing ``blocks[0]`` would run the wrong block and
+                    # drop the else.
+                    return self.transform_block(
+                        prior_block + new_if_statement.blocks[-1] + remaining_block
                     )
 
                 if new_if_statement != if_statement:

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -2331,6 +2331,13 @@ class ElseUnwrapTransformer(BlockTransformer):
                 continue
             if not statement.has_else_block():
                 continue
+            # F-123: has_else_block() only checks for a block surplus
+            # (len(blocks) > len(conditions)); it accepts a malformed
+            # IfStatement([C], [B0, B1, B2]) where blocks[1] is spliced as the
+            # else and blocks[2] would be silently dropped. A well-formed
+            # single-else if has exactly len(conditions)+1 blocks. Require it.
+            if len(statement.blocks) != len(statement.conditions) + 1:
+                continue
             # True branch must unconditionally return
             if not block_unconditionally_returns(statement.blocks[0]):
                 continue

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2632,7 +2632,12 @@ def _is_groupelem_field(fld: frog_ast.Field) -> bool:
 
 
 def _free_var_names(expr: frog_ast.Expression) -> set[str]:
-    return {v.name for v in VariableCollectionVisitor().visit(copy.deepcopy(expr))}
+    # F-168/F-227: use the FieldAccess-complete scanner so a read through a
+    # field/array/slice access (`M.keys`, `M[k]`, `X.f`) counts as a free
+    # reference to its base. `VariableCollectionVisitor` suppresses those
+    # bases, so a hoist/alias could move an expression while missing its
+    # dependency on (or a later write to) the accessed field.
+    return referenced_variable_names(expr)
 
 
 def _stmt_writes_var(stmt: frog_ast.Statement, name: str) -> bool:

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -4732,8 +4732,19 @@ class HoistDeterministicCallToInitializeTransformer:
                     alias_assign_counts[name] = alias_assign_counts.get(name, 0) + 1
                     aliases[name] = stmt.value
             # Only use aliases for variables assigned exactly once.
+            # F-170: the loop above counts only TOP-LEVEL Assignment nodes, so
+            # it misses a re-binding nested in an if/for (`if (b) { x = k2; }`)
+            # or a top-level Sample (`x <- ...`). Such a name is coin-dependent,
+            # not a stable alias -- expanding `F(x)` to `F(<top-level RHS>)`
+            # would then match a hoisted `F(k)` unsoundly. Require the COMPLETE
+            # recursive write count (nested + samples, peeling l-values) to be
+            # exactly 1.
+            init_prefix = frog_ast.Block(list(new_stmts[:-1]))
             stable_aliases = {
-                n: v for n, v in aliases.items() if alias_assign_counts[n] == 1
+                n: v
+                for n, v in aliases.items()
+                if alias_assign_counts[n] == 1
+                and _count_assigns_recursive(init_prefix, n) == 1
             }
 
             def _expand(expr: frog_ast.ASTNode) -> frog_ast.ASTNode:

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1169,6 +1169,15 @@ class ForwardExpressionAliasTransformer(BlockTransformer):
             var_name = statement.var.name
             expr = statement.value
 
+            # F-184: a self-referential definition `v = f(v)` (the assigned
+            # variable is a free variable of its own RHS) does NOT establish
+            # `v == f(v)` afterward -- the assignment changes `v`, so a later
+            # occurrence of `f(v)` reads the NEW `v`, not the value `v` now
+            # holds (`ctr = ctr + 1; return ctr + 1` must NOT alias to
+            # `return ctr`). Never alias such a definition.
+            if var_name in referenced_variable_names(expr):
+                continue
+
             # Only handle pure expressions (no non-deterministic function calls)
             if has_nondeterministic_call(
                 expr, self._proof_namespace, self._proof_let_types

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -514,17 +514,22 @@ class InlineMultiUsePureExpressionTransformer(BlockTransformer):
             # FrogLang (same input → same output) AND their canonical
             # form should match the inline-form of games that don't
             # extract the call to a local; allow inlining for those.
-            if (
-                SearchVisitor(lambda n: isinstance(n, frog_ast.FuncCall)).visit(expr)
-                is not None
-            ):
-                if not (
-                    self._function_var_names
-                    and isinstance(expr, frog_ast.FuncCall)
-                    and isinstance(expr.func, frog_ast.Variable)
-                    and expr.func.name in self._function_var_names
-                ):
-                    continue
+            #
+            # F-194: the exception must hold for EVERY call in expr, not just
+            # the outermost one. A nested non-deterministic argument -- e.g.
+            # `H(P.Sample(0^n))` with `H` a Function-let but `P.Sample(...)`
+            # abstract-primitive -- was inlined and its i.i.d. draw duplicated
+            # per use. Decline if ANY call (nested included) is not a
+            # deterministic Function-let call.
+            def _is_non_function_let_call(node: frog_ast.ASTNode) -> bool:
+                return isinstance(node, frog_ast.FuncCall) and not (
+                    bool(self._function_var_names)
+                    and isinstance(node.func, frog_ast.Variable)
+                    and node.func.name in self._function_var_names
+                )
+
+            if SearchVisitor(_is_non_function_let_call).visit(expr) is not None:
+                continue
 
             # Skip expressions containing array access or slicing.
             # Inlining these spreads references to the indexed variable,
@@ -3194,6 +3199,16 @@ class RefactorGroupElemFieldExpTransformer:
                 elif f2_exp == b:
                     other = a
                 if other is None:
+                    continue
+                # F-223: the SHARED exponent factor (`f2_exp`, structurally
+                # equal to `a` or `b`) must be deterministic. If it contains a
+                # non-deterministic call, `Field2 = g^<factor>` and the same
+                # factor inside `Field1 = g^(a*b)` are independent i.i.d. draws
+                # (ruling 7.A.6), so rewriting `Field1 = Field2 ^ other` would
+                # correlate them -- unsound despite the syntactic `==` match.
+                if has_nondeterministic_call(
+                    f2_exp, self.ctx.proof_namespace, self.ctx.proof_let_types
+                ):
                     continue
                 matched_any = True
                 # Soundness: at f1's def, f2 must already hold its value.

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2729,8 +2729,17 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                 free_vars = referenced_variable_names(assign_expr) - set(
                     self._proof_namespace
                 )
+                # F-215: include the LAST-USE statement in the scan. The slice
+                # `[assign+1 : last_use]` excluded it, so a write to a free var
+                # INSIDE a compound last-use statement -- executed before the
+                # field's use within that statement (`if (c) { ctr = 100;
+                # return A; }`) -- escaped, and inlining `A -> ctr` then read the
+                # post-write value. Scanning the whole last-use statement is
+                # conservatively sound: it may also flag a write that happens
+                # AFTER the use in that statement (where inlining would be safe),
+                # but that only costs a missed simplification, never soundness.
                 intermediate_stmts = game.methods[assign_method_idx].block.statements[
-                    assign_stmt_idx + 1 : last_use_idx
+                    assign_stmt_idx + 1 : last_use_idx + 1
                 ]
                 intermediate = frog_ast.Block(list(intermediate_stmts))
 

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -4975,6 +4975,30 @@ class SplitOpaqueTupleFieldTransformer:
                     )
                 return None
 
+        # F-189: an INITIALIZED tuple field must not silently become an
+        # undefined read. A tuple-literal initializer (`[1, 2]`) is decomposed
+        # into per-component initializers below; a non-decomposable initializer
+        # (an opaque call) cannot be split into components without duplicating
+        # it, so decline rather than drop the initializer (which would turn a
+        # readable initialized field into an undefined read -- attack init_drop).
+        if field.value is not None and not isinstance(field.value, frog_ast.Tuple):
+            if self._ctx is not None:
+                self._ctx.near_misses.append(
+                    NearMiss(
+                        transform_name="Split Opaque Tuple Field",
+                        reason=(
+                            f"Field '{field.name}' has a non-tuple-literal "
+                            f"initializer that cannot be decomposed into "
+                            f"per-index initializers; splitting would drop it"
+                        ),
+                        location=None,
+                        suggestion=None,
+                        variable=field.name,
+                        method=None,
+                    )
+                )
+            return None
+
         # 5. Build the rewritten game.
         assert isinstance(field.type, frog_ast.ProductType)
         component_types = field.type.types
@@ -4990,8 +5014,15 @@ class SplitOpaqueTupleFieldTransformer:
         for f in new_game.fields:
             if f.name == field.name:
                 for k in sorted(used_indices):
+                    # F-189: carry the k-th component of a tuple-literal
+                    # initializer so the split field keeps its initial value.
+                    init_k = (
+                        copy.deepcopy(field.value.values[k])
+                        if isinstance(field.value, frog_ast.Tuple)
+                        else None
+                    )
                     new_fields.append(
-                        frog_ast.Field(component_types[k], new_field_names[k], None)
+                        frog_ast.Field(component_types[k], new_field_names[k], init_k)
                     )
             else:
                 new_fields.append(f)

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -36,6 +36,23 @@ from ._base import (
 )
 
 
+def _contains_potential_undefined_read(node: frog_ast.ASTNode) -> bool:
+    """True if *node* contains a map/array index access ``M[k]``.
+
+    Reading an absent map key or an out-of-bounds array index is an observable
+    undefined-read abort (SEMANTICS 6.7). Relocating an evaluation that can
+    perform such a read to a position with BROADER reachability -- hoisting it
+    before a branch it only ran inside, forcing it onto a never-taken branch,
+    or making it unconditional -- changes the set of traces on which the abort
+    occurs, so a pass that hoists or duplicates an expression across control
+    flow must decline when it contains one (ruling 7.A.1).
+    """
+    return (
+        SearchVisitor(lambda n: isinstance(n, frog_ast.ArrayAccess)).visit(node)
+        is not None
+    )
+
+
 def _stmt_mutates_var(node: frog_ast.ASTNode, name: str) -> bool:
     """True if statement *node* mutates the variable *name*.
 
@@ -3495,8 +3512,15 @@ class DeduplicateDeterministicCallsTransformer(BlockTransformer):
                 self.proof_namespace, self._function_var_names
             )
             if isinstance(statement, frog_ast.IfStatement):
-                for condition in statement.conditions:
-                    collector.visit(condition)
+                # F-200: only the FIRST condition is always evaluated when the
+                # if is reached. An else-if condition (`conditions[1:]`) is
+                # reached only when every earlier condition was false, so a call
+                # extracted from it to a pre-if local would be evaluated on
+                # traces the earlier guards short-circuited past -- e.g. moving
+                # `F.Eval(M[x])` out of `else if (...)` past a `!(x in M)` guard
+                # makes the absent-key read unconditional.
+                if statement.conditions:
+                    collector.visit(statement.conditions[0])
             else:
                 collector.visit(statement)
             all_calls.extend(collector.result())
@@ -3582,8 +3606,10 @@ class DeduplicateDeterministicCallsTransformer(BlockTransformer):
                 self.proof_namespace, self._function_var_names
             )
             if isinstance(statement, frog_ast.IfStatement):
-                for condition in statement.conditions:
-                    collector.visit(condition)
+                # F-200: match only the first (always-evaluated) condition, so
+                # the insert point is never chosen from an else-if occurrence.
+                if statement.conditions:
+                    collector.visit(statement.conditions[0])
             else:
                 collector.visit(statement)
             for found_call in collector.result():
@@ -3844,6 +3870,12 @@ class HoistDuplicateBranchCallTransformer(BlockTransformer):
                 continue
             insert_index = containing[0]
             if not self._args_available(block, rep, insert_index):
+                continue
+            # F-206: hoisting the call before the branches evaluates it on the
+            # fall-through trace too. If its argument can perform an undefined
+            # read (`M[c]` on an absent key), the eager evaluation aborts on a
+            # trace where the original returned a value. Decline.
+            if _contains_potential_undefined_read(rep):
                 continue
             return_type = self._return_type(rep)
             if return_type is None:

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2552,7 +2552,19 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
             #   - be assigned at most once in the entire game (stable value)
             #   - be assigned in the same method and BEFORE the current
             #     field's assignment (so its value was already determined)
-            free_vars = VariableCollectionVisitor().visit(copy.deepcopy(assign_expr))
+            # F-218: use the FieldAccess-complete read-set so a view-carried
+            # read (`0 in M.keys`) contributes its backing field `M`. The
+            # VariableCollectionVisitor skips variables under a FieldAccess, so
+            # such an expression yielded an EMPTY free-var set and both
+            # stability gates below became vacuous -- letting a field whose RHS
+            # reads a mutated map inline cross-method as if it were stable.
+            # Subtract proof-namespace names: a primitive object like `G` in
+            # `G.evaluate(1)` is a FieldAccess object that
+            # referenced_variable_names reports but is not a game variable whose
+            # stability matters (VariableCollectionVisitor skipped it).
+            free_vars = referenced_variable_names(assign_expr) - set(
+                self._proof_namespace
+            )
             # Use the game's actual fields (not ``self.field_names``,
             # which is only refreshed at the ``transform_game`` level).
             field_name_set = {f.name for f in game.fields}
@@ -2573,12 +2585,9 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                 isinstance(assign_expr, frog_ast.BinaryOperation)
                 and assign_expr.operator == frog_ast.BinaryOperators.OR
             )
-            local_fv_names: list[str] = []
-            seen: set[str] = set()
-            for fv in free_vars:
-                if fv.name not in field_name_set and fv.name not in seen:
-                    local_fv_names.append(fv.name)
-                    seen.add(fv.name)
+            local_fv_names: list[str] = sorted(
+                n for n in free_vars if n not in field_name_set
+            )
             if local_fv_names and is_concat_chain:
                 promoted = self._try_promote_locals(
                     game,
@@ -2591,14 +2600,14 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                     return None
                 return self._try_inline_field(promoted, field_name)
             can_cross_method = True
-            for fv in free_vars:
-                if fv.name not in field_name_set:
+            for fv in sorted(free_vars):
+                if fv not in field_name_set:
                     can_cross_method = False
                     break
                 # Check that this free-variable field is assigned/sampled
                 # at most once across the whole game (stable value).
                 fv_assign_count = sum(
-                    _count_assigns_recursive(m.block, fv.name) for m in game.methods
+                    _count_assigns_recursive(m.block, fv) for m in game.methods
                 )
                 if fv_assign_count > 1:
                     can_cross_method = False
@@ -2620,7 +2629,7 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                             ),
                         )
                         and isinstance(stmt.var, frog_ast.Variable)
-                        and stmt.var.name == fv.name
+                        and stmt.var.name == fv
                     ):
                         fv_assigned_before = True
                         break
@@ -2691,8 +2700,12 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
             # 5. Check that no free variable in expr is modified between
             #    def and last use
             if last_use_idx >= 0:
-                free_vars = VariableCollectionVisitor().visit(
-                    copy.deepcopy(assign_expr)
+                # F-218: FieldAccess-complete read-set (sees `M` in `0 in
+                # M.keys`) so the interference window is not vacuous for
+                # view-carried reads; drop proof-namespace objects (`G` in
+                # `G.evaluate(..)`) which are not game variables.
+                free_vars = referenced_variable_names(assign_expr) - set(
+                    self._proof_namespace
                 )
                 intermediate_stmts = game.methods[assign_method_idx].block.statements[
                     assign_stmt_idx + 1 : last_use_idx
@@ -2704,7 +2717,7 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                 # `<-uniq[S]` insertion that grows S (ATK-3/ATK-3u) -- the
                 # private bare-Variable scan missed both. (The F-079 counter
                 # fix never reached this step-5 scan.)
-                if reassigns_or_rebinds({fv.name for fv in free_vars}, intermediate):
+                if reassigns_or_rebinds(free_vars, intermediate):
                     return None
 
         # 6. Perform the inlining — replace occurrences across methods.

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -991,7 +991,13 @@ class RedundantFieldCopyTransformer(BlockTransformer):
                 # decl_index == -1 implies we weren't able to find
                 # the declaration of the variable on the RHS of the assignment. This means
                 # it is a field, and isn't a redundant copy
-                if not no_other_uses or decl_index == -1:
+                # F-199: the reconstruction below assumes the declaration comes
+                # BEFORE the field copy (`decl_index < index`); it slices the
+                # block as ``[:decl_index] + [moved] + [decl_index+1:index] +
+                # [index+1:]``. If ``decl_index >= index`` those slices overlap
+                # / drop statements, the block never shrinks, and the
+                # self-recursive transform diverges. Require the ordering.
+                if not no_other_uses or decl_index == -1 or decl_index >= index:
                     continue
                 # Check that the field is not accessed (read or written)
                 # between the declaration and the field assignment.
@@ -1104,6 +1110,18 @@ class ForwardExpressionAliasTransformer(BlockTransformer):
             if is_field_assign and isinstance(statement.value, frog_ast.Variable):
                 local_name = statement.value.name
                 field_name = statement.var.name
+                # F-187: a self-copy `F = F;` is a no-op (F is unchanged).
+                # Propagating F -> F rewrites nothing but re-runs this pass on
+                # an unchanged block, driving unbounded recursion ("maximum
+                # recursion depth exceeded"). Drop the no-op statement (trivially
+                # sound) and re-run so the block still converges.
+                if local_name == field_name:
+                    return self._transform_block_wrapper(
+                        frog_ast.Block(
+                            list(block.statements[:index])
+                            + list(block.statements[index + 1 :])
+                        )
+                    )
                 remaining_block = frog_ast.Block(
                     copy.deepcopy(block.statements[index + 1 :])
                 )
@@ -1568,19 +1586,19 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
     loop body source writes ``m = e[0]`` explicitly against games whose
     loop body obtains the same accesses via inlining a helper method.
 
-    (Method parameters are intentionally NOT eligible for tuple
-    extraction: doing so breaks the ``[v[0], v[1], ...] -> v`` fold in
-    ``SimplifyTuple`` when a reconstructed tuple literal elsewhere
-    references the same indices.)
+    Method parameters of product (tuple) type ARE eligible:
+    ``transform_method`` records them in ``_scope_types`` so a game whose
+    source writes ``v = ct0[1]`` matches one that accesses ``ct0[1]``
+    inline (a block-local declaration of the same name still shadows the
+    parameter).
 
     **Slice phase.** When a ``v[A:B]`` slice expression (variable base,
     syntactically-equal bounds) appears 2+ times in a block, inserts
     ``BitString<B - A> __cse_slice_v_N__ = v[A:B];`` at the definition
     point (after ``v``'s block-local assignment, or at position 0 for
     method parameters / fields / enclosing-scope bases) and replaces
-    every matching slice with the new variable. Unlike the tuple phase,
-    method parameters ARE eligible, because no canonicalization pass
-    folds a concatenation of slices back into the base variable.
+    every matching slice with the new variable. Method parameters are
+    eligible here as well.
 
     The slice phase symmetrises canonical forms between games that
     hoist a named slice at source level (``k2enc = m[A:B];`` then using
@@ -5361,6 +5379,12 @@ class SplitOpaqueTupleFieldTransformer:
         # 5. Build the rewritten game.
         assert isinstance(field.type, frog_ast.ProductType)
         component_types = field.type.types
+        # F-193: a constant tuple index out of range (`field[5]` on a 2-tuple)
+        # is a malformed/undefined read. The typechecker shields it from source,
+        # but earlier AST transforms can synthesize one; ``component_types[k]``
+        # below would then raise IndexError. Decline instead of crashing.
+        if any(k < 0 or k >= len(component_types) for k in used_indices):
+            return None
         new_field_names: dict[int, str] = {}
         existing_names = {f.name for f in game.fields}
         for k in sorted(used_indices):

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -166,11 +166,15 @@ def _stmt_mutates_var(node: frog_ast.ASTNode, name: str) -> bool:
     inserts the sampled value into its exclusion set ``S`` -- so when *name* is
     ``S`` (or a base of it), the draw grows it and counts as a write (RC2 uniq
     growth; ruling 6.6). The `\\`-set-minus form does NOT grow its set and is
-    excluded via ``surface_form``.
+    excluded via ``surface_form``. Also counts a ``for`` binder
+    (``NumericFor`` / ``GenericFor``) that rebinds *name*, shadowing it inside
+    the loop body (F-183/F-188): the interference scans substitute structurally
+    and are not scope-aware, so a binder capturing the name must block the
+    rewrite.
 
     This is the single write-detector for the inlining passes' interference /
     stability scans; using it keeps every scan complete on both blind spots at
-    once (audit A.1 element writes + A.2 uniq insertion).
+    once (audit A.1 element writes + A.2 uniq insertion + loop-binder capture).
     """
     if isinstance(
         node, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
@@ -181,6 +185,10 @@ def _stmt_mutates_var(node: frog_ast.ASTNode, name: str) -> bool:
         and node.surface_form == "uniq"
         and name in referenced_variable_names(node.unique_set)
     ):
+        return True
+    if isinstance(node, frog_ast.NumericFor) and node.name == name:
+        return True
+    if isinstance(node, frog_ast.GenericFor) and node.var_name == name:
         return True
     return False
 

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2427,6 +2427,17 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
         def uses_field(node: frog_ast.ASTNode) -> bool:
             return isinstance(node, frog_ast.Variable) and node.name == field_name
 
+        # F-219: a field used inside ANOTHER field's declared type (`q` in
+        # `Array<Int, q>`) is a type parameter -- genuine size/shape state --
+        # not a value use. The whole-game use count below WOULD count such an
+        # occurrence, but the replacement step rewrites only method bodies, so
+        # the field's defining assignment and declaration would be deleted while
+        # the dangling type reference survives (`Array<Int, q>` with `q` gone).
+        # Inlining a value into a type is never valid, so decline outright.
+        for fld in game.fields:
+            if SearchVisitor(uses_field).visit(fld.type) is not None:
+                return None
+
         # F-228 (route 2): a method that locally binds `field_name` (parameter,
         # typed local, or `for` binder) shadows the field, so an occurrence of
         # the name there reads the LOCAL, not the field -- it is not a field use

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -80,6 +80,84 @@ def _use_inside_loop(node: frog_ast.ASTNode, name: str) -> bool:
     return found
 
 
+def _binder_captures_free_var(
+    use_stmt: frog_ast.ASTNode, free_var_names: set[str], var_name: str
+) -> bool:
+    """True if inlining an expression into *use_stmt* would capture a free var.
+
+    A ``for`` binder inside *use_stmt* whose name is one of the inlined
+    expression's *free_var_names*, and whose body contains the use of
+    *var_name*, would rebind that free variable: after inlining, the free
+    variable reads the loop binder instead of its original binding (audit
+    F-150 -- `v = i + 1; for (Int i = ...) { ... v ... }`). AlphaRename leaves
+    loop binders in place, so this capture survives canonicalization.
+    """
+
+    def _check(node: frog_ast.ASTNode) -> bool:
+        if isinstance(node, frog_ast.NumericFor):
+            binder = node.name
+        elif isinstance(node, frog_ast.GenericFor):
+            binder = node.var_name
+        else:
+            return False
+        return binder in free_var_names and _use_inside_loop(node, var_name)
+
+    return SearchVisitor(_check).visit(use_stmt) is not None
+
+
+def _is_loop_binder(node: frog_ast.ASTNode, name: str) -> bool:
+    """True if *name* is bound by a ``for`` binder anywhere within *node*."""
+
+    def _check(n: frog_ast.ASTNode) -> bool:
+        return (isinstance(n, frog_ast.NumericFor) and n.name == name) or (
+            isinstance(n, frog_ast.GenericFor) and n.var_name == name
+        )
+
+    return SearchVisitor(_check).visit(node) is not None
+
+
+def _method_bound_names(method: frog_ast.Method) -> set[str]:
+    """The set of names *method* binds locally, i.e. introduces a NEW binding
+    for: signature parameters, typed local declarations / samples
+    (``T x = ...`` / ``T x <- ...``), and ``for`` binders.
+
+    A plain write to an existing name (``x = ...`` / ``M[k] <- ...`` with no
+    declared type) is NOT a binding -- it mutates the field/local already in
+    scope and does not create a capturing shadow. A name in this set, when it
+    occurs inside *method*, refers to the local binding rather than any
+    same-named game field/parameter, so a name-based mover that trusts
+    field/param membership must treat it as shadowed (audit RC4:
+    F-173/F-178/F-190/F-228)."""
+    names = {p.name for p in method.signature.parameters}
+
+    def _collect(n: frog_ast.ASTNode) -> bool:
+        if isinstance(n, frog_ast.NumericFor):
+            names.add(n.name)
+        elif isinstance(n, frog_ast.GenericFor):
+            names.add(n.var_name)
+        elif (
+            isinstance(n, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample))
+            and getattr(n, "the_type", None) is not None
+            and isinstance(n.var, frog_ast.Variable)
+        ):
+            names.add(n.var.name)
+        return False
+
+    SearchVisitor(_collect).visit(method.block)
+    return names
+
+
+def _name_shadowed_in_method(method: frog_ast.Method, name: str) -> bool:
+    """True if *method* introduces a local binding for *name* (parameter,
+    typed local declaration, or ``for`` binder) that shadows a same-named game
+    field. Name-based movers that splice a bare ``Variable(field)`` (or
+    rewrite ``field[k]``) must decline for such a method, else the spliced
+    reference is captured by the local binding (audit RC4:
+    F-178/F-190). A plain field write does not shadow -- see
+    :func:`_method_bound_names`."""
+    return name in _method_bound_names(method)
+
+
 def _stmt_mutates_var(node: frog_ast.ASTNode, name: str) -> bool:
     """True if statement *node* mutates the variable *name*.
 
@@ -363,6 +441,31 @@ class InlineSingleUseVariableTransformer(BlockTransformer):
                                 f"not modified between the declaration and use "
                                 f"of '{var_name}'"
                             ),
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
+                continue
+
+            # F-150: the intermediate-block scan above stops before the use
+            # statement, so it misses a for-binder INSIDE the use statement
+            # that shadows a free variable of expr. Inlining under such a
+            # binder captures the free variable (it would read the loop binder
+            # instead of its outer binding). Decline.
+            if _binder_captures_free_var(
+                remaining_block.statements[first_use_idx], free_var_names, var_name
+            ):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Inline Single-Use Variable",
+                            reason=(
+                                f"Cannot inline '{var_name}': a loop binder at the "
+                                f"use site shadows a free variable of the inlined "
+                                f"expression, which would capture it"
+                            ),
+                            location=statement.origin,
+                            suggestion=None,
                             variable=var_name,
                             method=None,
                         )
@@ -2302,6 +2405,19 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
         def uses_field(node: frog_ast.ASTNode) -> bool:
             return isinstance(node, frog_ast.Variable) and node.name == field_name
 
+        # F-228 (route 2): a method that locally binds `field_name` (parameter,
+        # typed local, or `for` binder) shadows the field, so an occurrence of
+        # the name there reads the LOCAL, not the field -- it is not a field use
+        # and must never be a substitution target (inlining the field value
+        # into `Chal(Int e) { h ^ e }` where `e` is the parameter freezes the
+        # per-call exponent to the Initialize-time field value). Exclude such
+        # methods from both the use count and the inlining.
+        shadowing_midxs = {
+            mi
+            for mi, m in enumerate(game.methods)
+            if _name_shadowed_in_method(m, field_name)
+        }
+
         total_uses = 0
         count_game = copy.deepcopy(game)
         # Don't count the definition itself — replace the LHS variable name
@@ -2311,6 +2427,20 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
         ]
         assert isinstance(count_def, frog_ast.Assignment)
         count_def.var = frog_ast.Variable("__placeholder__")
+        # Neutralize shadowed occurrences so they are not counted as field uses.
+        for mi in shadowing_midxs:
+            neu = count_game.methods[mi]
+            while True:
+                hit = SearchVisitor(uses_field).visit(neu.block)
+                if hit is None:
+                    break
+                neu = frog_ast.Method(
+                    neu.signature,
+                    ReplaceTransformer(
+                        hit, frog_ast.Variable(field_name + "__shadowed__")
+                    ).transform(neu.block),
+                )
+            count_game.methods[mi] = neu
 
         while True:
             found = SearchVisitor(uses_field).visit(count_game)
@@ -2583,6 +2713,8 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
         new_game = copy.deepcopy(game)
 
         for mi, method in enumerate(new_game.methods):
+            if mi in shadowing_midxs:
+                continue  # occurrences here are the shadowing local, not the field
             new_stmts = list(method.block.statements)
             for si, stmt in enumerate(new_stmts):
                 if mi == assign_method_idx and si <= assign_stmt_idx:
@@ -2986,11 +3118,18 @@ class HoistGroupExpToInitializeTransformer:
                 if hit is None:
                     continue
                 exp_x = hit.right_expression
-                # X must be stable: free vars all in fields or params.
+                # X must be stable: free vars all in fields or params, AND not
+                # locally shadowed in this method. F-228: a parameter or `for`
+                # binder of `method` reusing a field's name makes the per-call
+                # binding masquerade as the stable field, so the exponent is
+                # wrongly frozen to the Initialize-time field value. Treat any
+                # shadowed free var as unstable.
+                method_bound = _method_bound_names(method)
                 unstable = sorted(
                     n
                     for n in _free_var_names(exp_x)
-                    if n not in field_names and n not in param_names
+                    if (n not in field_names and n not in param_names)
+                    or n in method_bound
                 )
                 if unstable:
                     self.ctx.near_misses.append(
@@ -4010,6 +4149,14 @@ class HoistDuplicateBranchCallTransformer(BlockTransformer):
         arg_vars: set[str] = set()
         for arg in rep.args:
             arg_vars |= referenced_variable_names(arg)
+        # F-210: `self._writes` does not recognise a `for` binder, so an
+        # argument that is actually a loop variable (`F.enc(i)` inside
+        # `for (Int i ...)`) reads total_writes == 0 and looks like an outer
+        # constant -- letting the call hoist above the loop, out of the
+        # binder's scope. A loop binder rebinds the arg per iteration, so the
+        # call is not available for hoisting.
+        if any(_is_loop_binder(block, name) for name in arg_vars):
+            return False
         for name in arg_vars:
             total_writes = 0
             for stmt in block.statements:
@@ -4078,6 +4225,7 @@ def _is_stable_arg(  # pylint: disable=too-many-arguments, too-many-positional-a
     function_var_names: set[str] | None = None,
     proof_let_names: set[str] | None = None,
     local_alias_names: set[str] | None = None,
+    shadowed_names: set[str] | None = None,
 ) -> bool:
     """Return True if *expr* is stable across method invocations.
 
@@ -4098,6 +4246,11 @@ def _is_stable_arg(  # pylint: disable=too-many-arguments, too-many-positional-a
     each name in this set is bound exactly once (in the relevant method's top
     level) to an expression that is itself stable, so that the variable's value
     is invariant across the lifetime of the game state it depends on.
+
+    When *shadowed_names* is provided, a ``Variable`` whose name appears in it
+    is NEVER stable, even if it matches a field/parameter name: the target
+    method locally binds that name (parameter / local / ``for`` binder), so the
+    occurrence refers to the per-call binding, not the game field (audit F-173).
     """
     if isinstance(
         expr,
@@ -4119,14 +4272,22 @@ def _is_stable_arg(  # pylint: disable=too-many-arguments, too-many-positional-a
             function_var_names,
             proof_let_names,
             local_alias_names,
+            shadowed_names,
         )
 
     if isinstance(expr, frog_ast.Variable):
+        # A verified single-assignment local alias (the caller guarantees it is
+        # bound once to a stable expression) is stable and takes precedence: a
+        # shadowing per-call binding (loop binder / parameter) is never a
+        # verified alias, so this does not weaken the F-173 shadow check below.
+        if local_alias_names is not None and expr.name in local_alias_names:
+            return True
+        if shadowed_names is not None and expr.name in shadowed_names:
+            return False
         return (
             expr.name in field_names
             or expr.name in param_names
             or (proof_let_names is not None and expr.name in proof_let_names)
-            or (local_alias_names is not None and expr.name in local_alias_names)
         )
     if isinstance(expr, frog_ast.FieldAccess):
         return _recurse(expr.the_object)
@@ -4444,6 +4605,7 @@ class CrossMethodFieldAliasTransformer:
                         proof_namespace=self.proof_namespace,
                         proof_let_names=proof_let_names,
                         local_alias_names=set(init_aliases),
+                        shadowed_names=_method_bound_names(method),
                     )
                     for a in call.args
                 ):
@@ -4555,6 +4717,12 @@ class CrossMethodFieldAliasTransformer:
         del alias_call  # alias_call is referenced only via expanded_call now
         for midx, method in enumerate(game.methods):
             if midx == alias_midx:
+                continue
+            # F-178: the replacement splices `Variable(alias_field_name)` into
+            # this method. If the method locally binds that name (parameter,
+            # local, or `for` binder), the spliced variable is captured by the
+            # binding instead of referring to the field. Skip such a method.
+            if _name_shadowed_in_method(method, alias_field_name):
                 continue
             target_aliases = method_aliases[midx]
             collector = _DeterministicCallCollector(
@@ -4785,6 +4953,7 @@ class HoistDeterministicCallToInitializeTransformer:
                         proof_namespace=self.proof_namespace,
                         function_var_names=function_var_names,
                         proof_let_names=proof_let_names,
+                        shadowed_names=_method_bound_names(method),
                     )
                     for a in call.args
                 ):
@@ -4834,7 +5003,16 @@ class HoistDeterministicCallToInitializeTransformer:
         if candidate is None or candidate_return_type is None:
             return game
 
-        new_name = self._fresh_field_name(field_names)
+        # F-169: the fresh field name must avoid EVERY name in scope anywhere
+        # in the game, not just existing field names -- the hoisted field is
+        # spliced into oracle bodies, where a like-named oracle parameter (or
+        # local/binder) would capture it (`_hoisted_0` collides with a
+        # parameter `_hoisted_0`, collapsing a one-time-pad to a constant).
+        occupied_names = set(field_names) | set(param_names)
+        for occ_method in game.methods:
+            occupied_names |= {p.name for p in occ_method.signature.parameters}
+            occupied_names |= referenced_variable_names(occ_method.block)
+        new_name = self._fresh_field_name(occupied_names)
         new_game = copy.deepcopy(game)
         new_game.fields.append(frog_ast.Field(candidate_return_type, new_name, None))
         # Pin the newly introduced field so ``Inline Single-Use Field`` leaves
@@ -5033,6 +5211,13 @@ class SplitOpaqueTupleFieldTransformer:
     def _try_split_field(
         self, game: frog_ast.Game, field: frog_ast.Field
     ) -> frog_ast.Game | None:
+        # F-190: the split rewrites `field[k]` reads across all methods into
+        # new per-index fields, keyed purely on the name `field`. If any method
+        # locally binds that name (parameter / typed local / `for` binder), a
+        # shadowed `p[k]` read would be wrongly rewritten into a per-index
+        # field. Decline the split entirely when the name is shadowed anywhere.
+        if any(_name_shadowed_in_method(m, field.name) for m in game.methods):
+            return None
         # 1. Find every assignment to *field* across all methods. Reject if
         # any sits at non-top level (inside if/for) or if there is more than
         # one top-level assignment in total.

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -53,6 +53,33 @@ def _contains_potential_undefined_read(node: frog_ast.ASTNode) -> bool:
     )
 
 
+def _use_inside_loop(node: frog_ast.ASTNode, name: str) -> bool:
+    """True if *name* is referenced inside a for-loop body within *node*.
+
+    A single SYNTACTIC use of a variable inside a loop is DYNAMICALLY
+    evaluated once per iteration. Inlining a non-deterministic expression into
+    such a use multiplies its draw (one sample becomes q i.i.d. samples), so a
+    single-use inliner must decline when the (declaration-external) use sits
+    inside a loop and the inlined expression is non-deterministic (audit
+    F-148/F-156/F-162).
+    """
+    found = False
+
+    def _check(n: frog_ast.ASTNode) -> bool:
+        nonlocal found
+        if isinstance(n, (frog_ast.NumericFor, frog_ast.GenericFor)) and (
+            SearchVisitor(
+                lambda x: isinstance(x, frog_ast.Variable) and x.name == name
+            ).visit(n.block)
+            is not None
+        ):
+            found = True
+        return False
+
+    SearchVisitor(_check).visit(node)
+    return found
+
+
 def _stmt_mutates_var(node: frog_ast.ASTNode, name: str) -> bool:
     """True if statement *node* mutates the variable *name*.
 
@@ -277,6 +304,33 @@ class InlineSingleUseVariableTransformer(BlockTransformer):
                     )
                 continue
 
+            # F-148: the single syntactic use may sit inside a loop the
+            # declaration is not in, so it is dynamically evaluated once per
+            # iteration. Inlining a NON-DETERMINISTIC expr there multiplies its
+            # draw (`c=E.Enc(k,m); for(...){L[i]=c}` -- all L equal -- becomes
+            # `for(...){L[i]=E.Enc(k,m)}` -- fresh each). Decline.
+            proof_ns = self.ctx.proof_namespace if self.ctx is not None else {}
+            proof_lets = self.ctx.proof_let_types if self.ctx is not None else None
+            if has_nondeterministic_call(
+                expr, proof_ns, proof_lets
+            ) and _use_inside_loop(remaining_block.statements[first_use_idx], var_name):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Inline Single-Use Variable",
+                            reason=(
+                                f"Cannot inline '{var_name}': its single use is "
+                                f"inside a loop, so inlining the non-deterministic "
+                                f"expression would draw a fresh value per iteration"
+                            ),
+                            location=statement.origin,
+                            suggestion=None,
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
+                continue
+
             # Collect free variables in expr (complete read-set: sees variables
             # under FieldAccess such as `M` in `|M.keys|`) and check none are
             # mutated between the declaration and the single use site -- where a
@@ -448,6 +502,13 @@ class IfSplitBranchAssignmentTransformer(BlockTransformer):
                 counter = _VarCountVisitor(var_name)
                 counter.visit(frog_ast.Block(list(subsequent)))
                 if counter.result() > 1:
+                    continue
+                # F-162: a single SYNTACTIC use inside a loop is evaluated once
+                # per iteration, so substituting a non-deterministic branch
+                # value there multiplies its draw (`if(c){x=p.f(0)}...;
+                # for(i){M[i]=x}` -- all M equal -- becomes
+                # `if(c){for(i){M[i]=p.f(0)}}...` -- fresh each). Decline.
+                if _use_inside_loop(frog_ast.Block(list(subsequent)), var_name):
                     continue
 
             # Build new blocks: for each branch, replace trailing assignment
@@ -1240,12 +1301,20 @@ class InlineLocalTupleLiteralTransformer(BlockTransformer):
                     )
                 continue
 
-            # Per-element purity check: dropped or duplicated elements must
-            # be free of non-deterministic calls.
+            # Per-element purity check: a non-deterministic element must be
+            # used exactly once AND that use must not be inside a loop. A
+            # dropped/duplicated element (count != 1) obviously changes the
+            # draw count; F-156: a SINGLE syntactic use inside a loop
+            # (`v = [P.Sample(), 0]; for(i){acc += v[0]}`) is dynamically
+            # evaluated once per iteration, so inlining `v[0] -> P.Sample()`
+            # into the loop draws a fresh value each time -- the count-1
+            # exemption conflated syntactic occurrence with dynamic eval count.
             purity_blocked = False
             for i, e_i in enumerate(tuple_values):
                 count_i = counts.get(i, 0)
-                if count_i != 1 and has_nondeterministic_call(
+                if (
+                    count_i != 1 or _use_inside_loop(remaining, var_name)
+                ) and has_nondeterministic_call(
                     e_i, self._proof_namespace, self._proof_let_types
                 ):
                     purity_blocked = True

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -36,6 +36,33 @@ from ._base import (
 )
 
 
+def _stmt_mutates_var(node: frog_ast.ASTNode, name: str) -> bool:
+    """True if statement *node* mutates the variable *name*.
+
+    Covers a direct/element/slice/field write (peeled via ``lvalue_base_name``,
+    so ``M[k]=v`` / ``X.f=v`` count) AND a ``<-uniq[S]`` draw that implicitly
+    inserts the sampled value into its exclusion set ``S`` -- so when *name* is
+    ``S`` (or a base of it), the draw grows it and counts as a write (RC2 uniq
+    growth; ruling 6.6). The `\\`-set-minus form does NOT grow its set and is
+    excluded via ``surface_form``.
+
+    This is the single write-detector for the inlining passes' interference /
+    stability scans; using it keeps every scan complete on both blind spots at
+    once (audit A.1 element writes + A.2 uniq insertion).
+    """
+    if isinstance(
+        node, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
+    ) and (lvalue_base_name(node.var) == name):
+        return True
+    if (
+        isinstance(node, frog_ast.UniqueSample)
+        and node.surface_form == "uniq"
+        and name in referenced_variable_names(node.unique_set)
+    ):
+        return True
+    return False
+
+
 class _VarCountVisitor(Visitor[int]):
     """Count occurrences of a variable name in an AST subtree."""
 
@@ -113,23 +140,9 @@ class RedundantCopyTransformer(BlockTransformer):
                 )
 
             def written_to(copy_name: str, node: frog_ast.ASTNode) -> bool:
-                # F-179: peel the l-value via `lvalue_base_name` so an
-                # element/slice/field write to the copy or original
-                # (`copy[0] = v`, `copy.f = v`) counts as a write. Gating on
-                # `isinstance(node.var, Variable)` missed these, so a copy
-                # mutated only through an element write was still substituted,
-                # leaving the transformed game reading post-mutation state.
-                return (
-                    isinstance(
-                        node,
-                        (
-                            frog_ast.Sample,
-                            frog_ast.Assignment,
-                            frog_ast.UniqueSample,
-                        ),
-                    )
-                    and lvalue_base_name(node.var) == copy_name
-                )
+                # F-179 element/slice/field write + F-180 `<-uniq[S]` growth of
+                # the copy source S: both via the shared `_stmt_mutates_var`.
+                return _stmt_mutates_var(node, copy_name)
 
             remaining_block = frog_ast.Block(
                 copy.deepcopy(block.statements[index + 1 :])
@@ -880,19 +893,9 @@ class ForwardExpressionAliasTransformer(BlockTransformer):
                 )
 
                 def is_written_to_fv(name: str, node: frog_ast.ASTNode) -> bool:
-                    # F-185: peel the l-value (Path P had the element/slice/
-                    # field blind spot Path E already fixed).
-                    return (
-                        isinstance(
-                            node,
-                            (
-                                frog_ast.Sample,
-                                frog_ast.Assignment,
-                                frog_ast.UniqueSample,
-                            ),
-                        )
-                        and lvalue_base_name(node.var) == name
-                    )
+                    # F-185 element/slice/field write + F-186 `<-uniq[S]`
+                    # growth of the retargeted exclusion set: shared detector.
+                    return _stmt_mutates_var(node, name)
 
                 # Only propagate if the local is not reassigned after
                 if (
@@ -1153,22 +1156,9 @@ class InlineLocalTupleLiteralTransformer(BlockTransformer):
                 continue
 
             def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
-                # F-152/F-153: peel the l-value so a tuple-element write
-                # (`v[k] = e`) counts as writing `v` -- otherwise the element
-                # write was invisible here (and miscounted as a use by
-                # `_classify_uses`), and the tuple literal was inlined into
-                # reads that should have seen the written value.
-                return (
-                    isinstance(
-                        node,
-                        (
-                            frog_ast.Sample,
-                            frog_ast.Assignment,
-                            frog_ast.UniqueSample,
-                        ),
-                    )
-                    and lvalue_base_name(node.var) == name
-                )
+                # F-152/F-153 tuple-element write (`v[k]=e`) + F-154 `<-uniq[S]`
+                # growth of a free-var set S: both via `_stmt_mutates_var`.
+                return _stmt_mutates_var(node, name)
 
             # v itself must not be reassigned later.
             if (
@@ -1826,18 +1816,10 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
 
             def _modifies_var(name: str, node: frog_ast.ASTNode) -> bool:
                 """Check if a statement modifies a variable, including nested
-                element / slice / field mutations (`v[i][j] = e`, `X.f = e`)
-                -- F-166: peel the full l-value via `lvalue_base_name`."""
-                if not isinstance(
-                    node,
-                    (
-                        frog_ast.Sample,
-                        frog_ast.Assignment,
-                        frog_ast.UniqueSample,
-                    ),
-                ):
-                    return False
-                return lvalue_base_name(node.var) == name
+                element / slice / field mutations (`v[i][j] = e`, `X.f = e`;
+                F-166) and `<-uniq[S]` growth of the exclusion set (F-167) --
+                via the shared `_stmt_mutates_var`."""
+                return _stmt_mutates_var(node, name)
 
             for j in range(i):
                 earlier = block.statements[j]
@@ -3675,16 +3657,10 @@ class HoistDuplicateBranchCallTransformer(BlockTransformer):
 
     @staticmethod
     def _writes(name: str, node: frog_ast.ASTNode) -> bool:
-        # F-207: peel the l-value via `lvalue_base_name` so a nested element /
-        # slice / field / map write (`M[a][b]=v`, `M[k]<-T`) to *name* counts,
-        # not just a bare `name = ...`. Otherwise a hoisted call reads the
-        # pre-write value.
-        return (
-            isinstance(
-                node, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
-            )
-            and lvalue_base_name(node.var) == name
-        )
+        # F-207 nested element/slice/field/map write + F-208 `<-uniq[S]` growth
+        # of S: both via the shared `_stmt_mutates_var`. Otherwise a hoisted
+        # call reads the pre-write value.
+        return _stmt_mutates_var(node, name)
 
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         # Only consider deterministic calls that are the ENTIRE expression of
@@ -3969,6 +3945,10 @@ def _fields_assigned_in_block(block: frog_ast.Block, field_names: set[str]) -> s
             base = lvalue_base_name(stmt.var)
             if base is not None and base in field_names:
                 assigned.add(base)
+            # F-175: a `<-uniq[S]` draw implicitly inserts into its exclusion
+            # set S, so a set FIELD used as S is mutated every call.
+            if isinstance(stmt, frog_ast.UniqueSample) and stmt.surface_form == "uniq":
+                assigned |= referenced_variable_names(stmt.unique_set) & field_names
         if isinstance(stmt, frog_ast.IfStatement):
             for blk in stmt.blocks:
                 assigned |= _fields_assigned_in_block(blk, field_names)

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -4173,8 +4173,7 @@ class HoistDuplicateBranchCallTransformer(BlockTransformer):
             if return_type is None:
                 continue
 
-            var_name = f"__hoist_{self.counter}__"
-            self.counter += 1
+            var_name = self._fresh_hoist_name(block)
             new_block = block
             for call in group:
                 new_block = ReplaceTransformer(
@@ -4229,6 +4228,28 @@ class HoistDuplicateBranchCallTransformer(BlockTransformer):
                 return False  # assigned at/after the hoist point
         return True
 
+    def _fresh_hoist_name(self, block: frog_ast.Block) -> str:
+        # F-211(a): mint a name fresh w.r.t. every name already present in
+        # this block. The per-instance counter resets each pipeline iteration
+        # (a fresh transformer per ``apply``), so a ``__hoist_N__`` produced by
+        # an EARLIER iteration and preserved by InlineMultiUsePureExpression is
+        # still a live statement in the block; reusing the index would emit a
+        # second, differently-valued declaration of the same name -- a
+        # capture-unsafe clobber (RC4 fresh-naming discipline). Advance the
+        # counter past any collision before minting. (``apply`` additionally
+        # seeds the counter above the game-wide max so nested-block mints stay
+        # fresh w.r.t. survivors in enclosing scopes.)
+        existing = {
+            node.name
+            for node in _iter_matches(block, lambda n: isinstance(n, frog_ast.Variable))
+            if isinstance(node, frog_ast.Variable)
+        }
+        while f"__hoist_{self.counter}__" in existing:
+            self.counter += 1
+        name = f"__hoist_{self.counter}__"
+        self.counter += 1
+        return name
+
     def _return_type(self, call: frog_ast.FuncCall) -> frog_ast.Type | None:
         method = _lookup_primitive_method(call.func, self.proof_namespace)
         if method is not None:
@@ -4254,13 +4275,31 @@ def _iter_matches(
     return found
 
 
+def _max_hoist_index(node: frog_ast.ASTNode) -> int:
+    """Largest ``N`` among ``__hoist_N__`` variable names in *node*, else -1."""
+    max_idx = -1
+    for var in _iter_matches(node, lambda n: isinstance(n, frog_ast.Variable)):
+        assert isinstance(var, frog_ast.Variable)
+        name = var.name
+        if name.startswith("__hoist_") and name.endswith("__"):
+            middle = name[len("__hoist_") : -len("__")]
+            if middle.isdigit():
+                max_idx = max(max_idx, int(middle))
+    return max_idx
+
+
 class HoistDuplicateBranchCall(TransformPass):
     name = "Hoist Duplicate Branch Call"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return HoistDuplicateBranchCallTransformer(
+        transformer = HoistDuplicateBranchCallTransformer(
             proof_namespace=ctx.proof_namespace
-        ).transform(game)
+        )
+        # F-211(a): seed the counter above any ``__hoist_N__`` already in the
+        # game (produced by an earlier fixed-point iteration) so freshly minted
+        # names never clobber a surviving declaration in an enclosing scope.
+        transformer.counter = _max_hoist_index(game) + 1
+        return transformer.transform(game)
 
 
 # ---------------------------------------------------------------------------

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -842,6 +842,8 @@ class ForwardExpressionAliasTransformer(BlockTransformer):
                 )
 
                 def is_written_to_fv(name: str, node: frog_ast.ASTNode) -> bool:
+                    # F-185: peel the l-value (Path P had the element/slice/
+                    # field blind spot Path E already fixed).
                     return (
                         isinstance(
                             node,
@@ -851,8 +853,7 @@ class ForwardExpressionAliasTransformer(BlockTransformer):
                                 frog_ast.UniqueSample,
                             ),
                         )
-                        and isinstance(node.var, frog_ast.Variable)
-                        and node.var.name == name
+                        and lvalue_base_name(node.var) == name
                     )
 
                 # Only propagate if the local is not reassigned after
@@ -1776,8 +1777,9 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                 return SearchVisitor(matcher).visit(stmt)
 
             def _modifies_var(name: str, node: frog_ast.ASTNode) -> bool:
-                """Check if a statement modifies a variable, including
-                element mutations like v[i] = expr."""
+                """Check if a statement modifies a variable, including nested
+                element / slice / field mutations (`v[i][j] = e`, `X.f = e`)
+                -- F-166: peel the full l-value via `lvalue_base_name`."""
                 if not isinstance(
                     node,
                     (
@@ -1787,15 +1789,7 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                     ),
                 ):
                     return False
-                var = node.var
-                if isinstance(var, frog_ast.Variable) and var.name == name:
-                    return True
-                if isinstance(var, frog_ast.ArrayAccess) and isinstance(
-                    var.the_array, frog_ast.Variable
-                ):
-                    if var.the_array.name == name:
-                        return True
-                return False
+                return lvalue_base_name(node.var) == name
 
             for j in range(i):
                 earlier = block.statements[j]
@@ -3509,21 +3503,15 @@ class DeduplicateDeterministicCallsTransformer(BlockTransformer):
 
         # Check that no argument variable is reassigned or element-mutated
         def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
+            # F-203: peel the full l-value via `lvalue_base_name` so a nested
+            # element write (`M[a][b] = v`) between two deduplicated calls is
+            # seen -- the manual depth-1 ArrayAccess check missed it.
             if not isinstance(
                 node,
                 (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample),
             ):
                 return False
-            var = node.var
-            if isinstance(var, frog_ast.Variable) and var.name == name:
-                return True
-            # Element mutation: v[i] = expr, M[k] = expr
-            if isinstance(var, frog_ast.ArrayAccess) and isinstance(
-                var.the_array, frog_ast.Variable
-            ):
-                if var.the_array.name == name:
-                    return True
-            return False
+            return lvalue_base_name(node.var) == name
 
         # The intermediate region (between the first and last call's evaluation
         # points) excludes the call statements themselves. When the first
@@ -3933,17 +3921,13 @@ def _fields_assigned_in_block(block: frog_ast.Block, field_names: set[str]) -> s
         if isinstance(
             stmt, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
         ):
-            var = stmt.var
-            # Direct variable assignment: k = expr, k <- Type
-            if isinstance(var, frog_ast.Variable) and var.name in field_names:
-                assigned.add(var.name)
-            # Element mutation: arr[i] = expr, M[k] = expr
-            if (
-                isinstance(var, frog_ast.ArrayAccess)
-                and isinstance(var.the_array, frog_ast.Variable)
-                and var.the_array.name in field_names
-            ):
-                assigned.add(var.the_array.name)
+            # F-172/F-176: peel the full l-value via `lvalue_base_name` so a
+            # nested element write (`M[a][b] = v`), a slice write, or a field
+            # write (`X.f = v`) is attributed to its base field -- the manual
+            # depth-1 ArrayAccess check missed all of these.
+            base = lvalue_base_name(stmt.var)
+            if base is not None and base in field_names:
+                assigned.add(base)
         if isinstance(stmt, frog_ast.IfStatement):
             for blk in stmt.blocks:
                 assigned |= _fields_assigned_in_block(blk, field_names)

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2252,6 +2252,34 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                 # Producer pinned this field; reject cross-method inline to
                 # avoid oscillation with the producer's re-fire.
                 return None
+            # F-216: cross-method inlining substitutes the field's definition
+            # into a use in ANOTHER method. That is sound only if the def runs
+            # before any oracle can observe the field -- i.e. the def is in
+            # Initialize (which runs once, before every oracle). If the def is
+            # in an oracle, the adversary can call the USING oracle first and
+            # observe the field's UNINITIALIZED value, which the inlined RHS
+            # would mask (ATK-4: `b = 5` in Store, `return b` in Get; a
+            # Get-before-Store call reads an undefined `b`, not 5).
+            if game.methods[assign_method_idx].signature.name != "Initialize":
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Inline Single-Use Field",
+                            reason=(
+                                f"Cannot inline field '{field_name}' across "
+                                f"methods: its single definition is in "
+                                f"'{game.methods[assign_method_idx].signature.name}'"
+                                f", not Initialize, so another oracle could "
+                                f"observe it uninitialized before that method "
+                                f"runs"
+                            ),
+                            location=None,
+                            suggestion=None,
+                            variable=field_name,
+                            method=None,
+                        )
+                    )
+                return None
             if not is_pure:
                 if self.ctx is not None:
                     self.ctx.near_misses.append(

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -4226,6 +4226,32 @@ class CrossMethodFieldAliasTransformer:
                 if method.signature.name != "Initialize":
                     continue
 
+                # F-174: if Initialize has an early return (nested in an
+                # if/for), the field assignment may be skipped on that trace,
+                # leaving the field undefined; rewriting another oracle's
+                # `det_call(args)` to read that field would then read an
+                # uninitialized value on the early-return path. Three sibling
+                # Initialize-targeting passes already carry this guard; add it
+                # here too.
+                if _has_early_return_in_init(list(method.block.statements)):
+                    if self._ctx is not None:
+                        self._ctx.near_misses.append(
+                            NearMiss(
+                                transform_name="Cross Method Field Alias",
+                                reason=(
+                                    "Initialize has an early return (nested in "
+                                    "if/for); the aliased field assignment may "
+                                    "be skipped, so cross-method reads of it "
+                                    "could see an uninitialized value"
+                                ),
+                                location=stmt.origin,
+                                suggestion=None,
+                                variable=stmt.var.name,
+                                method="Initialize",
+                            )
+                        )
+                    continue
+
                 # Compute the expanded form of the call (with stable locals
                 # resolved). Use this for downstream cross-method matching
                 # and for collecting the underlying field dependencies, so

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1437,6 +1437,9 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
 
             # Skip if the base variable is reassigned after its definition
             def _is_reassigned(name: str, node: frog_ast.ASTNode) -> bool:
+                # F-233: peel the l-value so an element write `v[0]=e` (state
+                # mutation) blocks the CSE; a bare-Variable check missed it and
+                # `return v` was left reading the pre-mutation value.
                 return (
                     isinstance(
                         node,
@@ -1446,8 +1449,7 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
                             frog_ast.UniqueSample,
                         ),
                     )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == name
+                    and lvalue_base_name(node.var) == name
                 )
 
             remaining_after_def = frog_ast.Block(
@@ -1568,6 +1570,8 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
             # in block for scope-external case). Reassignment would
             # invalidate the hoist.
             def _is_reassigned_slice(name: str, node: frog_ast.ASTNode) -> bool:
+                # F-233: peel the l-value so an element/slice write to the
+                # slice's base blocks the slice CSE too.
                 return (
                     isinstance(
                         node,
@@ -1577,8 +1581,7 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
                             frog_ast.UniqueSample,
                         ),
                     )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == name
+                    and lvalue_base_name(node.var) == name
                 )
 
             check_from = def_idx + 1 if def_idx >= 0 else 0
@@ -2345,27 +2348,12 @@ class InlineSingleUseFieldTransformer(BlockTransformer):
                 ]
                 intermediate = frog_ast.Block(list(intermediate_stmts))
 
-                def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
-                    return (
-                        isinstance(
-                            node,
-                            (
-                                frog_ast.Sample,
-                                frog_ast.Assignment,
-                                frog_ast.UniqueSample,
-                            ),
-                        )
-                        and isinstance(node.var, frog_ast.Variable)
-                        and node.var.name == name
-                    )
-
-                if any(
-                    SearchVisitor(functools.partial(is_written_to, fv.name)).visit(
-                        intermediate
-                    )
-                    is not None
-                    for fv in free_vars
-                ):
+                # F-214: use the complete shared scanner so the interference
+                # window catches a nested element/slice/field write AND a
+                # `<-uniq[S]` insertion that grows S (ATK-3/ATK-3u) -- the
+                # private bare-Variable scan missed both. (The F-079 counter
+                # fix never reached this step-5 scan.)
+                if reassigns_or_rebinds({fv.name for fv in free_vars}, intermediate):
                     return None
 
         # 6. Perform the inlining — replace occurrences across methods.
@@ -3648,12 +3636,15 @@ class HoistDuplicateBranchCallTransformer(BlockTransformer):
 
     @staticmethod
     def _writes(name: str, node: frog_ast.ASTNode) -> bool:
+        # F-207: peel the l-value via `lvalue_base_name` so a nested element /
+        # slice / field / map write (`M[a][b]=v`, `M[k]<-T`) to *name* counts,
+        # not just a bare `name = ...`. Otherwise a hoisted call reads the
+        # pre-write value.
         return (
             isinstance(
                 node, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
             )
-            and isinstance(node.var, frog_ast.Variable)
-            and node.var.name == name
+            and lvalue_base_name(node.var) == name
         )
 
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -113,6 +113,12 @@ class RedundantCopyTransformer(BlockTransformer):
                 )
 
             def written_to(copy_name: str, node: frog_ast.ASTNode) -> bool:
+                # F-179: peel the l-value via `lvalue_base_name` so an
+                # element/slice/field write to the copy or original
+                # (`copy[0] = v`, `copy.f = v`) counts as a write. Gating on
+                # `isinstance(node.var, Variable)` missed these, so a copy
+                # mutated only through an element write was still substituted,
+                # leaving the transformed game reading post-mutation state.
                 return (
                     isinstance(
                         node,
@@ -122,8 +128,7 @@ class RedundantCopyTransformer(BlockTransformer):
                             frog_ast.UniqueSample,
                         ),
                     )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == copy_name
+                    and lvalue_base_name(node.var) == copy_name
                 )
 
             remaining_block = frog_ast.Block(

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1824,32 +1824,20 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
                     def_idx = idx
                     break
 
-            # Skip if base is reassigned anywhere after def (or anywhere
-            # in block for scope-external case). Reassignment would
-            # invalidate the hoist.
-            def _is_reassigned_slice(name: str, node: frog_ast.ASTNode) -> bool:
-                # F-233: peel the l-value so an element/slice write to the
-                # slice's base blocks the slice CSE too.
-                return (
-                    isinstance(
-                        node,
-                        (
-                            frog_ast.Assignment,
-                            frog_ast.Sample,
-                            frog_ast.UniqueSample,
-                        ),
-                    )
-                    and lvalue_base_name(node.var) == name
-                )
-
+            # Skip if any of the slice's free variables -- the base AND the
+            # bound expressions' variables -- is reassigned or rebound after
+            # the def. Reassignment invalidates the hoist:
+            #   - F-233: an element/slice write to the base (peeled l-value);
+            #   - F-231: a bound variable reassigned between two occurrences
+            #     (`v[t:t+n] ... t = n; ... v[t:t+n]`) makes the two slices span
+            #     different ranges even though they are structurally equal;
+            #   - F-234: a bound variable that is a `for` binder (rebound per
+            #     iteration / per sibling scope) -- the shared, node-kind-complete
+            #     `reassigns_or_rebinds` detects binders too.
+            slice_free = referenced_variable_names(rep_slice)
             check_from = def_idx + 1 if def_idx >= 0 else 0
             remaining_block = frog_ast.Block(list(block.statements[check_from:]))
-            if (
-                SearchVisitor(functools.partial(_is_reassigned_slice, var_name)).visit(
-                    remaining_block
-                )
-                is not None
-            ):
+            if reassigns_or_rebinds(slice_free, remaining_block):
                 continue
 
             insert_at = def_idx + 1 if def_idx >= 0 else 0

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -4001,6 +4001,25 @@ class DeduplicateDeterministicCallsTransformer(BlockTransformer):
                 is not None
             ):
                 return False
+
+        # F-201: the first occurrence's OWN statement is excluded from the
+        # intermediate region, but when it writes an argument variable
+        # (`k = F.Eval(k);`) the write happens AFTER the first call is evaluated
+        # and BEFORE the second, so the two calls read different argument values
+        # (`F(k0)` vs `F(F(k0))`) and must not be merged. An IfStatement first
+        # statement carries the call in its CONDITION (evaluated before any
+        # branch write), and its branch writes are already folded into the
+        # intermediate region above; a plain assignment/sample/uniq is not, so
+        # scan it here.
+        if not isinstance(first_stmt, frog_ast.IfStatement):
+            for var_name in arg_vars:
+                if (
+                    SearchVisitor(functools.partial(is_written_to, var_name)).visit(
+                        first_stmt
+                    )
+                    is not None
+                ):
+                    return False
         return True
 
     def _report_nondet_near_misses(self, block: frog_ast.Block) -> None:

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -225,7 +225,15 @@ class RedundantCopyTransformer(BlockTransformer):
         block: frog_ast.Block,
     ) -> frog_ast.Block:
         for index, statement in enumerate(block.statements):
-            # Potentially, could be a redundant copy
+            # A redundant copy is a plain typed alias ``T v = w;``.
+            #
+            # F-181: a SAMPLE ``v <- w`` is NOT a copy -- it is a genuine
+            # uniform draw (ruling 7.A.8 / SEMANTICS 4.2: sampling from a set
+            # variable draws a uniform element). The old ``elif`` treated
+            # ``v <- w`` (with ``w`` assigned earlier) as a copy and deleted the
+            # draw, substituting the whole set ``w`` for the random element --
+            # erasing the randomness (advantage >= 1/2). Only the assignment
+            # form is a copy.
             if (
                 isinstance(statement, frog_ast.Assignment)
                 and statement.the_type is not None
@@ -234,21 +242,6 @@ class RedundantCopyTransformer(BlockTransformer):
             ):
                 copy_name = statement.var.name
                 original_name = statement.value.name
-            elif (
-                isinstance(statement, frog_ast.Sample)
-                and isinstance(statement.var, frog_ast.Variable)
-                and isinstance(statement.sampled_from, frog_ast.Variable)
-                and any(
-                    isinstance(
-                        s, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample)
-                    )
-                    and isinstance(s.var, frog_ast.Variable)
-                    and s.var.name == statement.sampled_from.name
-                    for s in block.statements[:index]
-                )
-            ):
-                copy_name = statement.var.name
-                original_name = statement.sampled_from.name
             else:
                 continue
 

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -591,6 +591,20 @@ class IfSplitBranchAssignmentTransformer(BlockTransformer):
             ):
                 continue
 
+            # F-160: substitution moves each branch value's evaluation from the
+            # branch point to every use of `var_name` in the tail. If a FREE
+            # VARIABLE of any branch value is reassigned/rebound in the tail,
+            # the substituted value would read the mutated variable instead of
+            # its branch-time value (`x = y; y = y + 1; return x` -- x captured
+            # the OLD y). Decline when the tail could change a branch value.
+            value_free_vars: set[str] = set()
+            for v in branch_values:
+                value_free_vars |= referenced_variable_names(v)
+            if value_free_vars and reassigns_or_rebinds(
+                value_free_vars, frog_ast.Block(list(subsequent))
+            ):
+                continue
+
             # If any branch value contains a non-deterministic call,
             # the variable must be used at most once in subsequent code.
             # Otherwise substitution would duplicate the call, changing

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -2034,6 +2034,14 @@ def _count_assigns_recursive(node: frog_ast.ASTNode, name: str) -> int:
     ``B`` -- otherwise a single-use-field stability check would treat a
     later-mutated free-variable field as stable and inline a stale snapshot
     across methods (audit F-079).
+
+    A ``<-uniq[S]`` draw also counts as an assignment to ``S``: it implicitly
+    inserts the drawn value into the exclusion set (``S = S union {x}``), so a
+    set field used as a uniq domain is mutated on every draw. Without this,
+    the single-use-field check treats such a set as stable and either inlines
+    a stale snapshot of it across methods (F-213) or eliminates it entirely,
+    rewriting ``<-uniq[S]`` to ``<-uniq[{}]`` and destroying distinctness
+    (F-212).
     """
     count = 0
 
@@ -2042,6 +2050,12 @@ def _count_assigns_recursive(node: frog_ast.ASTNode, name: str) -> int:
         if (
             isinstance(n, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample))
             and lvalue_base_name(n.var) == name
+        ):
+            count += 1
+        if (
+            isinstance(n, frog_ast.UniqueSample)
+            and n.surface_form == "uniq"
+            and name in referenced_variable_names(n.unique_set)
         ):
             count += 1
         return False

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -366,6 +366,9 @@ class IfSplitBranchAssignmentTransformer(BlockTransformer):
 
             # Variable must not be reassigned in subsequent statements
             def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
+                # F-161: peel the l-value so an element/slice/field write
+                # (`v[i] = e`) counts as a reassignment and blocks the branch
+                # substitution.
                 return (
                     isinstance(
                         node,
@@ -375,8 +378,7 @@ class IfSplitBranchAssignmentTransformer(BlockTransformer):
                             frog_ast.UniqueSample,
                         ),
                     )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == name
+                    and lvalue_base_name(node.var) == name
                 )
 
             if (
@@ -1115,6 +1117,11 @@ class InlineLocalTupleLiteralTransformer(BlockTransformer):
                 continue
 
             def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
+                # F-152/F-153: peel the l-value so a tuple-element write
+                # (`v[k] = e`) counts as writing `v` -- otherwise the element
+                # write was invisible here (and miscounted as a use by
+                # `_classify_uses`), and the tuple literal was inlined into
+                # reads that should have seen the written value.
                 return (
                     isinstance(
                         node,
@@ -1124,8 +1131,7 @@ class InlineLocalTupleLiteralTransformer(BlockTransformer):
                             frog_ast.UniqueSample,
                         ),
                     )
-                    and isinstance(node.var, frog_ast.Variable)
-                    and node.var.name == name
+                    and lvalue_base_name(node.var) == name
                 )
 
             # v itself must not be reassigned later.

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -818,6 +818,16 @@ class CollapseAssignmentTransformer(BlockTransformer):
             if not isinstance(statement.var, frog_ast.Variable):
                 continue
 
+            # F-146: the FIRST statement is the one whose value the collapse
+            # DELETES (folding the later reassignment onto the declaration). A
+            # Sample (`x <- S`) is a side-effecting draw: sampling a
+            # possibly-empty domain is an observable termination event (ruling
+            # 7.A.5) and `sampled_from` may itself contain a non-deterministic
+            # call, so deleting the draw changes observable behaviour. Only a
+            # pure-valued Assignment initial is safe to collapse away.
+            if isinstance(statement, frog_ast.Sample):
+                continue
+
             # Skip if the statement's value has non-deterministic calls
             if isinstance(statement, frog_ast.Assignment) and has_nondeterministic_call(
                 statement.value, self._proof_namespace, self._proof_let_types

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -324,8 +324,17 @@ class IfSplitBranchAssignmentTransformer(BlockTransformer):
         if (C) { return f(A); } else { return f(B); }
     """
 
-    def __init__(self, ctx: PipelineContext | None = None) -> None:
+    def __init__(
+        self,
+        ctx: PipelineContext | None = None,
+        field_names: set[str] | None = None,
+    ) -> None:
         self.ctx = ctx
+        # Game field names. The rewrite drops each branch's trailing `x = A`
+        # assignment (keeping only its value). For a field that store persists
+        # across oracle calls and is observable, so dropping it is unsound
+        # (F-159); the pass fires only for locals.
+        self._field_names: set[str] = field_names or set()
 
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         for index, statement in enumerate(block.statements):
@@ -357,6 +366,12 @@ class IfSplitBranchAssignmentTransformer(BlockTransformer):
                 branch_values.append(last.value)
 
             if not all_match or var_name is None:
+                continue
+
+            # F-159: the rewrite drops each branch's trailing `var = value`
+            # store. If `var` is a game field, that store is observable across
+            # oracle calls, so dropping it changes behaviour -- decline.
+            if var_name in self._field_names:
                 continue
 
             # Must have subsequent statements
@@ -580,9 +595,15 @@ class CollapseAssignmentTransformer(BlockTransformer):
         self,
         proof_namespace: frog_ast.Namespace | None = None,
         proof_let_types: NameTypeMap | None = None,
+        field_names: set[str] | None = None,
     ) -> None:
         self._proof_namespace: frog_ast.Namespace = proof_namespace or {}
         self._proof_let_types = proof_let_types
+        # Names of game fields (persist across oracle calls). A field's store
+        # is observable on any control-flow exit before it is overwritten, so
+        # collapsing two field stores across an intervening return is unsound
+        # (F-144). Locals are not observable across calls, so they are exempt.
+        self._field_names: set[str] = field_names or set()
 
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         for index, statement in enumerate(block.statements):
@@ -629,6 +650,21 @@ class CollapseAssignmentTransformer(BlockTransformer):
                 # Only an untyped reassignment is a safe collapse target.
                 if later_statement.the_type is not None:
                     break
+                # F-144: if the collapse target is a game field and any
+                # intervening statement can exit the method (contains a
+                # return), the first store is live on that early-exit path
+                # (a later oracle call observes the field), so deleting it is
+                # unsound. Locals are not observable across calls -> exempt.
+                if statement.var.name in self._field_names:
+                    intervening = block.statements[index + 1 : index + later_index + 1]
+                    if any(
+                        SearchVisitor(
+                            lambda n: isinstance(n, frog_ast.ReturnStatement)
+                        ).visit(s)
+                        is not None
+                        for s in intervening
+                    ):
+                        break
                 later_rhs = (
                     later_statement.sampled_from
                     if isinstance(later_statement, frog_ast.Sample)
@@ -1250,7 +1286,9 @@ class IfSplitBranchAssignment(TransformPass):
     name = "If-Split Branch Assignment"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return IfSplitBranchAssignmentTransformer(ctx).transform(game)
+        return IfSplitBranchAssignmentTransformer(
+            ctx, field_names={f.name for f in game.fields}
+        ).transform(game)
 
 
 class InlineSingleUseVariable(TransformPass):
@@ -1267,6 +1305,7 @@ class CollapseAssignment(TransformPass):
         return CollapseAssignmentTransformer(
             proof_namespace=ctx.proof_namespace,
             proof_let_types=ctx.proof_let_types,
+            field_names={f.name for f in game.fields},
         ).transform(game)
 
 

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1170,15 +1170,18 @@ class InlineLocalTupleLiteralTransformer(BlockTransformer):
                 continue
 
             # No free variable of any e_i may be reassigned later.
+            # F-155: `referenced_variable_names` sees a variable read only via a
+            # FieldAccess (e.g. `M` in `|M.keys|`), so a later `M = N` write is
+            # detected -- VariableCollectionVisitor suppressed it, leaving the
+            # tuple literal inlined across the mutation.
             free_var_reassigned = False
             for e_i in tuple_values:
-                free_vars = VariableCollectionVisitor().visit(copy.deepcopy(e_i))
                 if any(
-                    SearchVisitor(functools.partial(is_written_to, fv.name)).visit(
+                    SearchVisitor(functools.partial(is_written_to, name)).visit(
                         remaining
                     )
                     is not None
-                    for fv in free_vars
+                    for name in referenced_variable_names(e_i)
                 ):
                     free_var_reassigned = True
                     break
@@ -1845,13 +1848,21 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                         break
                 if conflict:
                     continue
-                # Verify free variables of expr are all defined before j
-                free_vars = VariableCollectionVisitor().visit(copy.deepcopy(expr))
+                # Definedness uses the FieldAccess-SUPPRESSED read-set: a name
+                # reached only through a field/array access (`M` in `|M.keys|`)
+                # or a method call (`F` in `F.Eval(k)`) does not itself need a
+                # prior local definition -- it is a field or a let/scheme
+                # constant, always available. Requiring it to be assigned-before
+                # would wrongly decline every hoist of a scheme call.
+                defn_names = {
+                    v.name
+                    for v in VariableCollectionVisitor().visit(copy.deepcopy(expr))
+                }
                 all_defined = True
-                for fv in free_vars:
-                    if fv.name in self.fields:
+                for name in defn_names:
+                    if name in self.fields:
                         continue
-                    # Check that fv is assigned in some statement before j
+                    # Check that `name` is assigned in some statement before j
 
                     def assigns_var(name: str, node: frog_ast.ASTNode) -> bool:
                         return (
@@ -1870,9 +1881,9 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                     found_def = False
                     for k in range(j):
                         if (
-                            SearchVisitor(
-                                functools.partial(assigns_var, fv.name)
-                            ).visit(block.statements[k])
+                            SearchVisitor(functools.partial(assigns_var, name)).visit(
+                                block.statements[k]
+                            )
                             is not None
                         ):
                             found_def = True
@@ -1888,13 +1899,18 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                 # position i.  Field-type free variables must also be
                 # checked — a field modified between j and i would cause
                 # the hoisted expression to evaluate to a stale value.
+                # F-168: use the COMPLETE read-set (`referenced_variable_names`,
+                # NOT the FieldAccess-suppressing VariableCollectionVisitor) so
+                # a variable read only via a view -- `M` in `h ^ |M.keys|` -- is
+                # checked; otherwise a `M[7]=1` between j and i is missed and
+                # the hoisted value is stale.
                 stable = True
-                for fv in free_vars:
+                for name in referenced_variable_names(expr):
                     for k in range(j, i):
                         if (
-                            SearchVisitor(
-                                functools.partial(_modifies_var, fv.name)
-                            ).visit(block.statements[k])
+                            SearchVisitor(functools.partial(_modifies_var, name)).visit(
+                                block.statements[k]
+                            )
                             is not None
                         ):
                             stable = False
@@ -3494,10 +3510,12 @@ class DeduplicateDeterministicCallsTransformer(BlockTransformer):
         between the first and last statement containing a call."""
         # Collect all free variable names from call arguments
         representative = call_group[0]
+        # F-204: use `referenced_variable_names` (not VariableCollectionVisitor,
+        # which suppresses variables under a FieldAccess), so an argument like
+        # `|M.keys|` contributes `M` and a later `M[w]=v` write is detected.
         arg_vars: set[str] = set()
         for arg in representative.args:
-            for fv in VariableCollectionVisitor().visit(copy.deepcopy(arg)):
-                arg_vars.add(fv.name)
+            arg_vars |= referenced_variable_names(arg)
         if not arg_vars:
             return True
 
@@ -3741,10 +3759,12 @@ class HoistDuplicateBranchCallTransformer(BlockTransformer):
     def _args_available(
         self, block: frog_ast.Block, rep: frog_ast.FuncCall, insert_index: int
     ) -> bool:
+        # F-209: `referenced_variable_names` sees variables under FieldAccess
+        # (e.g. `M` in a `|M.keys|` argument), so a `M = N` / `M[k]=v` between
+        # the call and the hoist point is no longer vacuously available.
         arg_vars: set[str] = set()
         for arg in rep.args:
-            for fv in VariableCollectionVisitor().visit(copy.deepcopy(arg)):
-                arg_vars.add(fv.name)
+            arg_vars |= referenced_variable_names(arg)
         for name in arg_vars:
             total_writes = 0
             for stmt in block.statements:

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -3415,8 +3415,13 @@ class HoistGroupExpToInitialize(TransformPass):
 
 def _exp_with_generator_base(
     expr: frog_ast.Expression,
-) -> Optional[frog_ast.Expression]:
-    """If *expr* is ``<group>.generator ^ <e>``, return ``<e>``."""
+) -> Optional[tuple[frog_ast.Expression, frog_ast.Expression]]:
+    """If *expr* is ``<group>.generator ^ <e>``, return ``(<group>, <e>)``.
+
+    The group is returned (F-222) so callers can refuse to pair two
+    generator-based fields whose groups differ: ``g_G^(a*b)`` must not be
+    refactored as ``(g_H^a)^b`` -- that crosses groups and is ill-typed.
+    """
     if not isinstance(expr, frog_ast.BinaryOperation):
         return None
     if expr.operator != frog_ast.BinaryOperators.EXPONENTIATE:
@@ -3427,9 +3432,9 @@ def _exp_with_generator_base(
         and base.name == "generator"
         and isinstance(base.the_object, frog_ast.Variable)
     ):
-        return expr.right_expression
+        return (base.the_object, expr.right_expression)
     if isinstance(base, frog_ast.GroupGenerator):
-        return expr.right_expression
+        return (base.group, expr.right_expression)
     return None
 
 
@@ -3475,7 +3480,9 @@ class RefactorGroupElemFieldExpTransformer:
         # guard; refuse to refactor when Initialize can return early.
         if _has_early_return_in_init(init_stmts):
             return None
-        gen_field_assigns: dict[str, tuple[int, frog_ast.Expression]] = {}
+        gen_field_assigns: dict[
+            str, tuple[int, frog_ast.Expression, frog_ast.Expression]
+        ] = {}
         for si, stmt in enumerate(init_stmts):
             if not (
                 isinstance(stmt, frog_ast.Assignment)
@@ -3490,12 +3497,13 @@ class RefactorGroupElemFieldExpTransformer:
             total = sum(_count_assigns_recursive(m.block, name) for m in game.methods)
             if total != 1:
                 continue
-            exponent = _exp_with_generator_base(stmt.value)
-            if exponent is None:
+            gen = _exp_with_generator_base(stmt.value)
+            if gen is None:
                 continue
-            gen_field_assigns[name] = (si, exponent)
+            group, exponent = gen
+            gen_field_assigns[name] = (si, exponent, group)
 
-        for f1_name, (f1_idx, f1_exp) in gen_field_assigns.items():
+        for f1_name, (f1_idx, f1_exp, f1_group) in gen_field_assigns.items():
             if not isinstance(f1_exp, frog_ast.BinaryOperation):
                 # Bare exponent like ``g ^ a`` — not a Field1 candidate;
                 # such fields plausibly serve as Field2.  Stay silent.
@@ -3528,8 +3536,16 @@ class RefactorGroupElemFieldExpTransformer:
                     )
                 continue
             matched_any = False
-            for f2_name, (f2_idx, f2_exp) in gen_field_assigns.items():
+            for f2_name, (f2_idx, f2_exp, f2_group) in gen_field_assigns.items():
                 if f2_name == f1_name:
+                    continue
+                # F-222: both fields are `<group>.generator ^ ...`, but the
+                # power-of-power refactor `Field1 = Field2 ^ other` is only
+                # valid when the two generators are in the SAME group. Pairing
+                # `G.generator^(a*b)` with `H.generator^a` would rewrite the
+                # GroupElem<G> field as `(GroupElem<H>)^b` -- cross-group and
+                # ill-typed.
+                if f1_group != f2_group:
                     continue
                 a, b = f1_exp.left_expression, f1_exp.right_expression
                 other: Optional[frog_ast.Expression] = None

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -818,6 +818,22 @@ class RedundantFieldCopyTransformer(BlockTransformer):
                         break
                 if field_accessed_between:
                     continue
+                # F-197: a control-flow exit (a `return`, possibly nested in
+                # an if/for) between the declaration and the field copy means
+                # the copy `f = v` is skipped on that early-return trace, so
+                # the original never writes the field there. Hoisting the draw
+                # into `f <- ...` at the declaration position writes the field
+                # unconditionally, changing its value on the early-return
+                # trace. Decline. (The between-scan above only saw data refs.)
+                control_exit_between = any(
+                    SearchVisitor(
+                        lambda n: isinstance(n, frog_ast.ReturnStatement)
+                    ).visit(block.statements[k])
+                    is not None
+                    for k in range(decl_index + 1, index)
+                )
+                if control_exit_between:
+                    continue
                 modified_statement = copy.deepcopy(decl_statement)
                 modified_statement.var = statement.var
                 modified_statement.the_type = None
@@ -1923,6 +1939,22 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                     if not stable:
                         break
                 if not stable:
+                    continue
+                # F-165: control-flow barrier. The field write at position i
+                # is hoisted to before j. If any statement in [j, i) can exit
+                # the method early (a `return`, possibly nested in an if/for),
+                # then on that early-return trace the ORIGINAL write at i never
+                # runs (control returned first) while the hoisted write does --
+                # so the field is assigned on a trace where it previously kept
+                # its prior value, observable by another oracle (A1_sep). Only
+                # hoist when control from j always reaches i.
+                if any(
+                    SearchVisitor(
+                        lambda n: isinstance(n, frog_ast.ReturnStatement)
+                    ).visit(block.statements[k])
+                    is not None
+                    for k in range(j, i)
+                ):
                     continue
                 # Hoist: move field assignment to before position j,
                 # replace the subexpression in position j with the field.

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1394,11 +1394,17 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
     decomposition.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        proof_namespace: frog_ast.Namespace | None = None,
+        proof_let_types: NameTypeMap | None = None,
+    ) -> None:
         super().__init__()
         # Loop-binder types visible from the enclosing ``GenericFor``.
         # Extraction for these is inserted at position 0 of the loop body.
         self._scope_types: dict[str, frog_ast.Type] = {}
+        self._proof_namespace: frog_ast.Namespace = proof_namespace or {}
+        self._proof_let_types = proof_let_types
 
     def transform_generic_for(self, gf: frog_ast.GenericFor) -> frog_ast.GenericFor:
         new_over = self.transform(gf.over)
@@ -1613,6 +1619,16 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
         for rep_slice, count in slice_groups:
             if count < 2:
                 continue
+            # F-235: the slice BOUNDS must be deterministic. A non-deterministic
+            # call in a bound (`v[I.Cut():j]`) means two structurally-equal
+            # slices are actually independent draws (i.i.d. per ruling 7.A.6);
+            # merging them into one shared local correlates the draws.
+            if has_nondeterministic_call(
+                rep_slice.start, self._proof_namespace, self._proof_let_types
+            ) or has_nondeterministic_call(
+                rep_slice.end, self._proof_namespace, self._proof_let_types
+            ):
+                continue
             assert isinstance(rep_slice.the_array, frog_ast.Variable)
             var_name = rep_slice.the_array.name
 
@@ -1722,7 +1738,10 @@ class ExtractRepeatedTupleAccess(TransformPass):
     name = "Extract Repeated Tuple Access"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return ExtractRepeatedTupleAccessTransformer().transform(game)
+        return ExtractRepeatedTupleAccessTransformer(
+            proof_namespace=ctx.proof_namespace,
+            proof_let_types=ctx.proof_let_types,
+        ).transform(game)
 
 
 class InlineMultiUsePureExpression(TransformPass):

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -3136,6 +3136,14 @@ class RefactorGroupElemFieldExpTransformer:
         if init_idx is None:
             return None
         init_stmts = list(game.methods[init_idx].block.statements)
+        # F-224: if Initialize has an early return (nested in if/for), the
+        # field assignments this pass reasons over may run on only some
+        # traces, and moving f2 across the early return changes which traces
+        # define it -- turning a guarded/undefined read into an always-defined
+        # one (attack A5). Three sibling Initialize-targeting passes carry this
+        # guard; refuse to refactor when Initialize can return early.
+        if _has_early_return_in_init(init_stmts):
+            return None
         gen_field_assigns: dict[str, tuple[int, frog_ast.Expression]] = {}
         for si, stmt in enumerate(init_stmts):
             if not (
@@ -3210,6 +3218,23 @@ class RefactorGroupElemFieldExpTransformer:
                     f2_exp, self.ctx.proof_namespace, self.ctx.proof_let_types
                 ):
                     continue
+                # F-221: the shared factor must have the SAME value at f1's
+                # position and f2's position. If any of its free variables is
+                # reassigned in the interval between the two field
+                # assignments, `Field2 = g^<factor>` (evaluated at f2) and the
+                # `<factor>` inside `Field1 = g^(a*b)` (evaluated at f1) are
+                # DIFFERENT values -- rewriting `Field1 = Field2 ^ other` then
+                # conflates two independent draws (attack2 re-samples `x`
+                # between `A = g^(x*x)` and `B = g^x`). `_defined_before` only
+                # checks defined-before, not unchanged-since.
+                lo, hi = sorted((f1_idx, f2_idx))
+                factor_free = referenced_variable_names(f2_exp)
+                if any(
+                    _stmt_mutates_var(init_stmts[k], name)
+                    for k in range(lo + 1, hi)
+                    for name in factor_free
+                ):
+                    continue
                 matched_any = True
                 # Soundness: at f1's def, f2 must already hold its value.
                 # If f2 is currently after f1, try to move f2 just before f1
@@ -3226,6 +3251,17 @@ class RefactorGroupElemFieldExpTransformer:
                     }
                     f2_free.discard(f2_name)
                     if not self._defined_before(stmts, f1_idx, f2_free):
+                        continue
+                    # F-225: moving f2's assignment up past an intervening
+                    # statement that READS f2 changes that read's value -- it
+                    # would see f2's new (assigned) value instead of the
+                    # prior/undefined one. Attack A6: `A=g^(x*3); C=B; B=g^x;`
+                    # -- `C=B` reads an unassigned B; hoisting B above it turns
+                    # an observable undefined read into a defined value.
+                    if any(
+                        f2_name in referenced_variable_names(init_stmts[k])
+                        for k in range(f1_idx, f2_idx)
+                    ):
                         continue
                     f2_stmt = stmts.pop(f2_idx)
                     # f2 was after f1; insert before f1 at f1_idx (new index).

--- a/proof_frog/transforms/map_iteration.py
+++ b/proof_frog/transforms/map_iteration.py
@@ -104,7 +104,15 @@ class _TupleAccessSubstitution(Transformer):
 def _bare_references(expr: frog_ast.Expression, var_name: str) -> bool:
     """True iff *expr* contains a ``Variable(var_name)`` reference that is
     NOT the array-base of an ``ArrayAccess(Variable(var_name), Integer(k))``
-    for some literal integer ``k``.
+    for ``k in {0, 1}``.
+
+    F-143: only indices 0 and 1 are whitelisted, because those are the ONLY
+    indices ``_TupleAccessSubstitution`` rewrites. Whitelisting any literal
+    integer (e.g. ``e[2]``) let such an access pass this "bare reference" check
+    but survive the rewrite unsubstituted, leaving a dangling reference to the
+    deleted loop binder and changing the method's free variables. Restricting
+    the whitelist to {0, 1} makes any other index count as a bare reference, so
+    the pass declines rather than emit an ill-formed body.
     """
     allowed_ids: set[int] = set()
 
@@ -113,6 +121,7 @@ def _bare_references(expr: frog_ast.Expression, var_name: str) -> bool:
             isinstance(n, frog_ast.ArrayAccess)
             and _is_var(n.the_array, var_name)
             and isinstance(n.index, frog_ast.Integer)
+            and n.index.num in (0, 1)
         ):
             allowed_ids.add(id(n.the_array))
         return False

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -3103,7 +3103,27 @@ def _stmt_references_maps(stmt: frog_ast.ASTNode, m1: str, m2: str) -> bool:
 
 
 def _fresh_field_name(game: frog_ast.Game, base: str) -> str:
+    # F-010: the injected field name must be fresh w.r.t. EVERY name in the game,
+    # not just the field names. A collision with a method PARAMETER (or a loop
+    # binder / local declaration) would let that binder lexically capture the
+    # injected field -- a reference to the field inside such a method resolves to
+    # the binder instead. Collect field names, parameter names, loop binders, and
+    # every variable reference so the chosen name cannot be captured.
     existing = {f.name for f in game.fields}
+    for method in game.methods:
+        existing |= {p.name for p in method.signature.parameters}
+
+    def _collect(node: frog_ast.ASTNode) -> bool:
+        if isinstance(node, frog_ast.Variable):
+            existing.add(node.name)
+        elif isinstance(node, frog_ast.NumericFor):
+            existing.add(node.name)
+        elif isinstance(node, frog_ast.GenericFor):
+            existing.add(node.var_name)
+        return False
+
+    SearchVisitor(_collect).visit(game)
+
     if base not in existing:
         return base
     i = 1

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -28,6 +28,7 @@ from ..visitors import (
     Transformer,
     lvalue_base_name,
     reassigns_or_rebinds,
+    referenced_variable_names,
 )
 from ._base import (
     TransformPass,
@@ -1678,6 +1679,12 @@ class _GuardInfo:
     slice_param: str | None = None
     slice_start: frog_ast.Expression | None = None
     slice_end: frog_ast.Expression | None = None
+    # F-015: True when the guard is a JOINT tuple equality `[a,b] == [cf1,cf2]`
+    # (>1 component). Such a guard establishes only that the WHOLE tuple differs
+    # from the challenge -- NOT that any individual component does -- so it
+    # cannot individually exclude a single-component RF input (`H(a)` is still
+    # queryable at `a == cf1` when `b != cf2`).
+    is_joint_tuple_guard: bool = False
 
     @property
     def is_slice_guard(self) -> bool:
@@ -1740,11 +1747,19 @@ def _find_challenge_guard(
         # Extract LHS variable names (non-field variables constrained by guard)
         guard_lhs_vars = _extract_non_field_vars(lhs, field_names)
 
+        # F-015: a joint tuple equality whose LHS is a tuple of >1 component
+        # (`[a,b] == [cf1,cf2]`) excludes only the exact tuple, not any single
+        # component -- so a single-component RF input (`H(a)`) is NOT excluded.
+        # (A single-variable LHS `c == [cf1,cf2]` with `H(c)` is fine: the whole
+        # guarded value is the RF input.)
+        is_joint = isinstance(lhs, frog_ast.Tuple) and len(lhs.values) > 1
+
         if challenge_fields:
             return _GuardInfo(
                 challenge_fields=challenge_fields,
                 guard_lhs_vars=guard_lhs_vars,
                 guard_idx=idx,
+                is_joint_tuple_guard=is_joint,
             )
 
     return None
@@ -2392,6 +2407,20 @@ class ChallengeExclusionRFToUniformTransformer:
                     resolved_oracle_arg = _resolve_var_aliases(
                         call.args[0], oracle_aliases, oracle_stop
                     )
+
+                    # F-015: a joint tuple guard (`[a,b] == [cf1,cf2]`) only
+                    # establishes that the WHOLE tuple differs from the
+                    # challenge. For the RF input to differ whenever the tuple
+                    # differs, it must depend on EVERY guarded component -- e.g.
+                    # `RF(E(v1) || E(v2))` references both. A single-component
+                    # input (`H(a)`) can still hit the challenge (`a == cf1` with
+                    # `b != cf2`), so any guarded component missing from the RF
+                    # input means it is not excluded. Decline.
+                    if guard.is_joint_tuple_guard and not original_guard_vars.issubset(
+                        referenced_variable_names(resolved_oracle_arg)
+                    ):
+                        all_oracle_ok = False
+                        break
 
                     # For slice guards where the oracle RF arg IS the
                     # guarded parameter (e.g., RF(m) with guard on

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -507,9 +507,20 @@ class UniqueRFSimplification(TransformPass):
     name = "Unique RF Simplification"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
+        # F-023: the RF-to-uniform rewrite is sound only for a *sampled* random
+        # function (`H <- Function<...>` in Initialize -- a re-samplable ROM).
+        # A `Function` field bound by an ordinary assignment (or never bound: a
+        # known, adversary-computable standard-model function) is deterministic,
+        # and rewriting a unique-input evaluation of it to a fresh uniform draw
+        # is unsound. Restrict to genuinely-sampled fields, mirroring
+        # FreshInputRFToUniform's gate.
+        sampled_fields = _sampled_function_fields_in_init(game)
         rf_types: dict[str, frog_ast.FunctionType] = {}
         for rf_field in game.fields:
-            if isinstance(rf_field.type, frog_ast.FunctionType):
+            if (
+                isinstance(rf_field.type, frog_ast.FunctionType)
+                and rf_field.name in sampled_fields
+            ):
                 rf_types[rf_field.name] = rf_field.type
 
         if not rf_types:

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -33,6 +33,29 @@ from ._base import TransformPass, PipelineContext, NearMiss
 # ---------------------------------------------------------------------------
 
 
+def _concat_operands_in_order(
+    node: frog_ast.Expression,
+) -> list[frog_ast.Variable]:
+    """Flatten an ``||`` concatenation into its leaf operands, left-to-right,
+    preserving duplicates.
+
+    Unlike ``VariableCollectionVisitor`` (which deduplicates and is order-blind),
+    this returns the operands in the exact positional order they concatenate in,
+    with repeats kept -- required for SimplifySplice's positional offset mapping
+    to be sound (F-065). Callers guarantee every leaf is a ``Variable`` via an
+    ``is_all_concatenated`` check before calling.
+    """
+    if (
+        isinstance(node, frog_ast.BinaryOperation)
+        and node.operator is frog_ast.BinaryOperators.OR
+    ):
+        return _concat_operands_in_order(
+            node.left_expression
+        ) + _concat_operands_in_order(node.right_expression)
+    assert isinstance(node, frog_ast.Variable)
+    return [node]
+
+
 class SimplifySpliceTransformer(BlockTransformer):
     """Replaces slice accesses on a concatenated variable with the originals.
 
@@ -77,8 +100,15 @@ class SimplifySpliceTransformer(BlockTransformer):
             if not is_all_concatenated(statement.value):
                 continue
 
-            # Get variables all concatenated together
-            concatenated_var_names = VariableCollectionVisitor().visit(statement.value)
+            # Get variables all concatenated together, LEFT-TO-RIGHT and WITH
+            # DUPLICATES preserved. F-065: VariableCollectionVisitor
+            # deduplicates, so `z = a || a || b` collapsed to [a, b]; the
+            # positional offsets in Step 2 then mapped the slice at
+            # [len_a : len_a+len_b] (physically the SECOND copy of `a`) onto
+            # `b`, rewriting `z[len_a : 2*len_a]` to `b` -- a false equivalence
+            # when len_a == len_b. Preserving order + duplicates makes each
+            # positional slice map to the operand actually occupying that range.
+            concatenated_var_names = _concat_operands_in_order(statement.value)
 
             def find_declaration(variable: str, node: frog_ast.ASTNode) -> bool:
                 return (

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -27,7 +27,12 @@ from ..visitors import (
     reassigns_or_rebinds,
     lvalue_base_name,
 )
-from ._base import TransformPass, PipelineContext, NearMiss
+from ._base import (
+    TransformPass,
+    PipelineContext,
+    NearMiss,
+    has_nondeterministic_call,
+)
 
 # ---------------------------------------------------------------------------
 # Transformer classes (moved from visitors.py)
@@ -442,12 +447,26 @@ class SliceOfInlineConcatTransformer(Transformer):
         lhs_len = self._operand_length(lhs)
         rhs_len = self._operand_length(rhs)
 
+        # F-030: `(a || b)[..]` -> a (or b) DROPS the other operand. That is
+        # sound only when the dropped operand has no observable effect --
+        # evaluating a concatenation evaluates both operands, so dropping one
+        # that contains a non-deterministic call erases that call. Gate each
+        # rewrite on the DROPPED operand being pure. (Previously the pass relied
+        # entirely on the external expression-purity + inlining-hoisting
+        # invariant; this makes the guard local.)
+        def _pure(operand: frog_ast.Expression) -> bool:
+            namespace = self._ctx.proof_namespace if self._ctx is not None else {}
+            return not has_nondeterministic_call(
+                operand, namespace, self._proof_let_types
+            )
+
         # Case 1: slice covers exactly the lhs (start == 0, end == |lhs|).
         if (
             lhs_len is not None
             and isinstance(new_start, frog_ast.Integer)
             and new_start.num == 0
             and self._exprs_equal(new_end, lhs_len)
+            and _pure(rhs)
         ):
             return lhs
 
@@ -457,6 +476,7 @@ class SliceOfInlineConcatTransformer(Transformer):
             and rhs_len is not None
             and self._exprs_equal(new_start, lhs_len)
             and self._exprs_equal(new_end, self._add(lhs_len, rhs_len))
+            and _pure(lhs)
         ):
             return rhs
 

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -1712,6 +1712,48 @@ def _method_binds_name(method: frog_ast.Method, name: str) -> bool:
     return found[0]
 
 
+def _count_name_references(node: frog_ast.ASTNode, name: str) -> int:
+    """Count occurrences of *name* as a variable reference in *node*.
+
+    Uses the same name-only predicate as ``_references_name`` so the count is
+    consistent with this pass's liveness checks."""
+    count = [0]
+
+    def _p(n: frog_ast.ASTNode) -> bool:
+        if isinstance(n, frog_ast.Variable) and n.name == name:
+            count[0] += 1
+        return False
+
+    SearchVisitor(_p).visit(node)
+    return count[0]
+
+
+def _count_name_declarations(node: frog_ast.ASTNode, name: str) -> int:
+    """Count local declarations that bind *name* in *node* (typed
+    sample/assignment/declaration, or a loop binder). Mirrors the
+    declaration-detection in ``_method_binds_name``."""
+    count = [0]
+
+    def _p(n: frog_ast.ASTNode) -> bool:
+        if isinstance(n, frog_ast.VariableDeclaration) and n.name == name:
+            count[0] += 1
+        elif (
+            isinstance(n, (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample))
+            and n.the_type is not None
+            and isinstance(n.var, frog_ast.Variable)
+            and n.var.name == name
+        ):
+            count[0] += 1
+        elif isinstance(n, frog_ast.NumericFor) and n.name == name:
+            count[0] += 1
+        elif isinstance(n, frog_ast.GenericFor) and n.var_name == name:
+            count[0] += 1
+        return False
+
+    SearchVisitor(_p).visit(node)
+    return count[0]
+
+
 def _name_shadowed_in_any_oracle(game: frog_ast.Game, name: str) -> bool:
     """True if any non-Initialize method binds *name* (see _method_binds_name)."""
     return any(
@@ -2327,6 +2369,60 @@ class SinkUniformSampleTransformer(BlockTransformer):
 
     def __init__(self, ctx: PipelineContext | None = None) -> None:
         self.ctx = ctx
+        self._current_method: frog_ast.Method | None = None
+
+    def transform_method(self, method: frog_ast.Method) -> frog_ast.Method:
+        # Capture the enclosing method so the sink guard can tell whether a
+        # block-local sample variable escapes the block being transformed
+        # (F-042). Descend normally afterwards.
+        self._current_method = method
+        result = self._transform_children(method)
+        assert isinstance(result, frog_ast.Method)
+        return result
+
+    def _variable_escapes_block(self, block: frog_ast.Block, var_name: str) -> bool:
+        """Defense-in-depth scope guard (F-042).
+
+        A freshly *typed* sample (``Type x <- Type``) declares ``var_name`` with
+        block-local scope, so the within-block liveness analysis below is exact
+        for well-typed input -- per-block scoping (semantic_analysis) guarantees
+        ``var_name`` is never referenced outside ``block``. If the enclosing
+        method nonetheless references ``var_name`` outside ``block`` with no
+        governing outer declaration, the AST is out of scope (the typechecker
+        rejects it) and sinking would leave that outside use reading a variable
+        now defined on only one path. Decline. On well-typed input this never
+        fires (there are no such outside references), so it is pure
+        defense-in-depth against a malformed AST reaching the pass directly."""
+        method = self._current_method
+        if method is None:
+            return False
+        refs_in_method = _count_name_references(method.block, var_name)
+        refs_in_block = _count_name_references(block, var_name)
+        if refs_in_method <= refs_in_block:
+            return False  # no references outside this block -> safe to sink
+        # Outside references exist. They are safe only if a *separate* outer
+        # declaration governs them (legitimate shadowing); otherwise they would
+        # bind to this block-local declaration -> escape.
+        decls_in_method = _count_name_declarations(method.block, var_name)
+        decls_in_block = _count_name_declarations(block, var_name)
+        return decls_in_method <= decls_in_block
+
+    def _decline_scope_near_miss(self, var_name: str) -> None:
+        if self.ctx is not None:
+            self.ctx.near_misses.append(
+                NearMiss(
+                    transform_name="Sink Uniform Sample",
+                    reason=(
+                        f"Sample '{var_name}' not sunk: the variable is "
+                        f"referenced outside the block it would be sunk within, "
+                        f"with no governing outer declaration (out of scope)"
+                    ),
+                    location=None,
+                    suggestion=None,
+                    variable=var_name,
+                    method=None,
+                )
+            )
 
     def _decline_near_miss(self, var_name: str) -> None:
         if self.ctx is not None:
@@ -2396,6 +2492,11 @@ class SinkUniformSampleTransformer(BlockTransformer):
             sample_stmt = stmt
 
             if len(using_branches) == 1 and not after_uses:
+                # F-042 scope guard: never sink a variable that escapes this
+                # block (only reachable via a malformed, out-of-scope AST).
+                if self._variable_escapes_block(block, var_name):
+                    self._decline_scope_near_miss(var_name)
+                    continue
                 # Sink into the one branch that uses the variable. The sample
                 # crosses the skipped intermediate statements [idx+1:next_idx];
                 # if any of them writes a name in the sample's sampled type, the
@@ -2419,6 +2520,11 @@ class SinkUniformSampleTransformer(BlockTransformer):
                 return self.transform_block(frog_ast.Block(new_stmts))
 
             if not using_branches and after_uses:
+                # F-042 scope guard: never sink a variable that escapes this
+                # block (only reachable via a malformed, out-of-scope AST).
+                if self._variable_escapes_block(block, var_name):
+                    self._decline_scope_near_miss(var_name)
+                    continue
                 # Sink past the if-stmt: the sample is used only after the
                 # if, and the if references nothing that involves the sample
                 # variable (checked: not in conditions, not in any branch).

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -1045,6 +1045,34 @@ class SplitUniformSampleTransformer(BlockTransformer):
         return expr
 
     @staticmethod
+    def _nonneg_width_syms(
+        slice_bounds: list[tuple[Symbol | int, Symbol | int]],
+    ) -> set[str]:
+        """Names of symbols provably >= 0 from being (a positive multiple of) a
+        slice WIDTH.
+
+        A slice ``z[a:b]`` yields ``BitString<b - a>``, so ``b - a >= 0`` by
+        well-formedness. A symbol that is exactly a slice width (or a positive
+        integer multiple of one) is therefore nonnegative. This is the sound,
+        robust source of positivity for the disjointness test (F-033): a signed
+        offset like ``c`` in ``z[n+c : n+c+n]`` is never itself a width (that
+        slice's width is ``n``), so ``c`` is not assumed nonnegative and the
+        overlap at ``c = -n`` is caught. Using slice widths avoids traversing
+        declaration type annotations (which the AST visitors do not descend
+        into) and works uniformly for field-access lengths like ``H.lambda``.
+        """
+        names: set[str] = set()
+        for start, end in slice_bounds:
+            width = sympy_simplify(end - start)
+            if getattr(width, "is_Symbol", False):
+                names.add(width.name)  # type: ignore[union-attr]
+            elif getattr(width, "is_Mul", False):
+                coeff, rest = width.as_coeff_Mul()  # type: ignore[union-attr]
+                if coeff.is_positive and getattr(rest, "is_Symbol", False):
+                    names.add(rest.name)
+        return names
+
+    @staticmethod
     def _check_overlaps(
         slice_bounds: list[tuple[Symbol | int, Symbol | int]],
         pos_subs: dict[Symbol, Symbol],
@@ -1289,7 +1317,25 @@ class SplitUniformSampleTransformer(BlockTransformer):
             # Check unique slices are non-overlapping. Two slices [a,b) and
             # [c,d) don't overlap if b <= c or d <= a. Gaps are allowed
             # (unused portions are discarded).
-            overlaps = self._check_overlaps(unique_bounds, pos_subs)
+            #
+            # F-033: the disjointness gap must be provably nonnegative for ALL
+            # legal parameter values, and the sign facts well-formedness supplies
+            # are that each BitString LENGTH is >= 0 -- including every slice
+            # WIDTH (`z[a:b]` yields `BitString<b-a>`). A symbol that is (a
+            # positive multiple of) a slice width is therefore nonnegative; a
+            # symbol occurring only as an offset (e.g. `c` in `z[n+c:n+c+n]`,
+            # whose width is `n`) has unconstrained sign. Assuming every free
+            # symbol positive (as the OOB check does, where it is conservative)
+            # is UNSOUND here: for `z[0:n]` vs `z[n+c:n+c+n]` the gap `c` is
+            # declared >= 0, certifying the slices disjoint -- but at c = -n
+            # (legal: the sampled length n+n+c = n is nonnegative) both slices
+            # are `z[0:n]`, the same bits. Restrict the positivity assumption for
+            # the disjointness test to slice-width symbols.
+            nonneg_names = self._nonneg_width_syms(unique_bounds)
+            disjoint_pos_subs = {
+                s: repl for s, repl in pos_subs.items() if s.name in nonneg_names
+            }
+            overlaps = self._check_overlaps(unique_bounds, disjoint_pos_subs)
             if overlaps:
                 if self.ctx is not None:
                     self.ctx.near_misses.append(

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -2264,6 +2264,20 @@ def _counter_guarded_field_to_local(game: frog_ast.Game) -> frog_ast.Game:
         if _name_shadowed_in_any_oracle(game, field.name):
             continue
 
+        # F-051: the field's init-sample domain is deep-copied verbatim into
+        # the target oracle. A genuine *type* domain (``BitString<n>``,
+        # ``ModInt<q>``, ...) is a fixed set, but an EXPRESSION domain -- e.g.
+        # sampling an element from a set variable ``k <- S`` -- re-evaluates
+        # under the oracle's scope, where ``S`` may be mutated or
+        # adversary-influenced between Initialize and the call, so relocating
+        # the draw changes its distribution. Decline. (``Expression`` subclasses
+        # ``Type`` in frog_ast, so the genuine-type test is ``Type and not
+        # Expression`` -- here, decline exactly when it IS an ``Expression``.
+        # Reachable only via typechecker-rejected set-variable field samples;
+        # latent defense-in-depth.)
+        if isinstance(init_sample.sampled_from, frog_ast.Expression):
+            continue
+
         # Step 2: Find which non-Initialize methods reference this field
         using_methods: list[str] = []
         for method in game.methods:

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -2086,15 +2086,24 @@ def _is_written_in_recursive(node: frog_ast.ASTNode, name: str) -> bool:
 
 
 def _count_assignments_recursive(node: frog_ast.ASTNode, name: str) -> int:
-    """Count how many times *name* is assigned or sampled anywhere in the AST."""
+    """Count how many times *name* is written anywhere in the AST.
+
+    F-052: kept consistent with ``_is_written_in_recursive`` -- peel the full
+    l-value via ``lvalue_base_name`` (so an element / slice / field write like
+    ``ctr[i] = v`` counts) and include ``UniqueSample`` (``ctr <-uniq[E] Int``).
+    The previous bare-``Variable`` + ``Assignment``/``Sample`` check
+    undercounted, so a counter written a second time via a ``<-uniq`` draw or an
+    element write looked written exactly once and the ``!= 1`` guard passed --
+    letting the pass fire while the write-once monotonicity premise was broken.
+    Overcounting only declines (sound); it never fires the pass spuriously.
+    """
     count = 0
 
     def counter(n: frog_ast.ASTNode) -> bool:
         nonlocal count
         if (
-            isinstance(n, (frog_ast.Assignment, frog_ast.Sample))
-            and isinstance(n.var, frog_ast.Variable)
-            and n.var.name == name
+            isinstance(n, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample))
+            and lvalue_base_name(n.var) == name
         ):
             count += 1
         return False

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -25,6 +25,7 @@ from ..visitors import (
     FrogToSympyVisitor,
     referenced_variable_names,
     reassigns_or_rebinds,
+    lvalue_base_name,
 )
 from ._base import TransformPass, PipelineContext, NearMiss
 
@@ -2004,13 +2005,19 @@ def _all_refs_in_counter_guarded_branches(
 
 
 def _is_written_in_recursive(node: frog_ast.ASTNode, name: str) -> bool:
-    """Check if a variable is assigned or sampled anywhere in the AST."""
+    """Check if *name* is written anywhere in the AST.
+
+    F-058: peel the full l-value via ``lvalue_base_name`` so an element / slice /
+    field write to the name (``M[k] = v``, ``M[k][j] = v``, ``obj.f = v``) counts,
+    and include ``UniqueSample`` writes -- the previous bare-``Variable`` +
+    ``Assignment``/``Sample`` check missed both, so a field mutated only via an
+    element write or a ``<-uniq`` draw looked unwritten.
+    """
 
     def check(n: frog_ast.ASTNode) -> bool:
         return (
-            isinstance(n, (frog_ast.Assignment, frog_ast.Sample))
-            and isinstance(n.var, frog_ast.Variable)
-            and n.var.name == name
+            isinstance(n, (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample))
+            and lvalue_base_name(n.var) == name
         )
 
     return SearchVisitor(check).visit(node) is not None

--- a/proof_frog/transforms/sampling.py
+++ b/proof_frog/transforms/sampling.py
@@ -1240,9 +1240,51 @@ class SplitUniformSampleTransformer(BlockTransformer):
                 for expr in sb:
                     if hasattr(expr, "free_symbols"):
                         all_syms.update(expr.free_symbols)
+            # F-036: the sampled length bounds the slices; its symbols (e.g. a
+            # BitString<n> length) also need positive assumptions for the
+            # in-bounds check below.
+            if hasattr(sample_len, "free_symbols"):
+                all_syms.update(sample_len.free_symbols)
             pos_subs = {
                 s: Symbol(s.name, positive=True) for s in all_syms if not s.is_positive
             }
+
+            # F-036: a slice that reads OUTSIDE the sampled range
+            # ``[0, sample_len]`` (`z[4:8]` on BitString<4>) is an undefined
+            # out-of-bounds read (SEMANTICS partial-operation convention), NOT
+            # an independent uniform sub-sample -- splitting it would fabricate
+            # a fresh uniform for undefined bits. Decline only when a slice is
+            # PROVABLY out of bounds (`start < 0` or `end > sample_len`); an
+            # indeterminate symbolic bound is left to fire (a well-typed slice
+            # is in range), matching the pass's existing symbolic tolerance.
+            pos = self._pos
+            out_of_bounds = False
+            for start, end in unique_bounds:
+                start_oob = sympy_simplify(pos(start, pos_subs)).is_negative
+                end_oob = sympy_simplify(
+                    pos(sample_len, pos_subs) - pos(end, pos_subs)
+                ).is_negative
+                if start_oob or end_oob:
+                    out_of_bounds = True
+                    break
+            if out_of_bounds:
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Split Uniform Samples",
+                            reason=(
+                                f"Sample '{var_name}' not split: a slice reads "
+                                f"outside the sampled range [0, {sample_len}] "
+                                f"(an undefined out-of-bounds read, not an "
+                                f"independent uniform sub-sample)"
+                            ),
+                            location=statement.origin,
+                            suggestion=None,
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
+                continue
 
             # Check unique slices are non-overlapping. Two slices [a,b) and
             # [c,d) don't overlap if b <= c or d <= a. Gaps are allowed

--- a/proof_frog/transforms/standardization.py
+++ b/proof_frog/transforms/standardization.py
@@ -135,7 +135,8 @@ class _ParameterStandardizer:
     """
 
     def rename_game(self, game: frog_ast.Game) -> frog_ast.Game:
-        new_methods = [self._rename_method(m) for m in game.methods]
+        field_names = {field.name for field in game.fields}
+        new_methods = [self._rename_method(m, field_names) for m in game.methods]
         return frog_ast.Game((game.name, game.parameters, game.fields, new_methods))
 
     @staticmethod
@@ -164,19 +165,24 @@ class _ParameterStandardizer:
         SearchVisitor(_collect).visit(block)
         return names
 
-    def _rename_method(self, method: frog_ast.Method) -> frog_ast.Method:
+    def _rename_method(
+        self, method: frog_ast.Method, field_names: set[str] | None = None
+    ) -> frog_ast.Method:
         params = method.signature.parameters
         if not params:
             return method
-        # F-306: the canonical target names arg1..argN must be FRESH w.r.t.
-        # names bound inside the body (loop binders, typed local declarations).
-        # AlphaRename does not rename loop binders, so a user-written binder named
-        # `arg1` can survive; renaming a parameter to `arg1` would then be
-        # captured by that binder (the reference resolves to the binder, not the
-        # parameter). Standardization is only canonicalization, so on a collision
-        # decline the rename for this method -- never conflate.
+        # F-306/F-307: the canonical target names arg1..argN must be FRESH w.r.t.
+        # every name that could collide with a renamed parameter -- names bound
+        # inside the body (loop binders, typed local declarations; AlphaRename
+        # does not rename loop binders) AND the game's FIELDS. Renaming a
+        # parameter to `arg1` when a body binder or a field is already named
+        # `arg1` would capture/fuse the parameter with it (a body reference or a
+        # field store silently rebinds). Standardization is only
+        # canonicalization, so on a collision decline the rename for this method
+        # -- never conflate.
         targets = {f"arg{i + 1}" for i in range(len(params))}
-        if targets & self._body_bound_names(method.block):
+        collides_with = self._body_bound_names(method.block) | (field_names or set())
+        if targets & collides_with:
             return method
         seed = {p.name: f"arg{i + 1}" for i, p in enumerate(params)}
         new_method = copy.deepcopy(method)

--- a/proof_frog/transforms/standardization.py
+++ b/proof_frog/transforms/standardization.py
@@ -138,9 +138,45 @@ class _ParameterStandardizer:
         new_methods = [self._rename_method(m) for m in game.methods]
         return frog_ast.Game((game.name, game.parameters, game.fields, new_methods))
 
+    @staticmethod
+    def _body_bound_names(block: frog_ast.Block) -> set[str]:
+        """Names bound WITHIN a method body: ``for`` binders and typed local
+        declarations. Parameters are excluded -- they are what this pass renames.
+        """
+        names: set[str] = set()
+
+        def _collect(node: frog_ast.ASTNode) -> bool:
+            if isinstance(node, frog_ast.NumericFor):
+                names.add(node.name)
+            elif isinstance(node, frog_ast.GenericFor):
+                names.add(node.var_name)
+            elif (
+                isinstance(
+                    node,
+                    (frog_ast.Assignment, frog_ast.Sample, frog_ast.UniqueSample),
+                )
+                and getattr(node, "the_type", None) is not None
+                and isinstance(node.var, frog_ast.Variable)
+            ):
+                names.add(node.var.name)
+            return False
+
+        SearchVisitor(_collect).visit(block)
+        return names
+
     def _rename_method(self, method: frog_ast.Method) -> frog_ast.Method:
         params = method.signature.parameters
         if not params:
+            return method
+        # F-306: the canonical target names arg1..argN must be FRESH w.r.t.
+        # names bound inside the body (loop binders, typed local declarations).
+        # AlphaRename does not rename loop binders, so a user-written binder named
+        # `arg1` can survive; renaming a parameter to `arg1` would then be
+        # captured by that binder (the reference resolves to the binder, not the
+        # parameter). Standardization is only canonicalization, so on a collision
+        # decline the rename for this method -- never conflate.
+        targets = {f"arg{i + 1}" for i in range(len(params))}
+        if targets & self._body_bound_names(method.block):
             return method
         seed = {p.name: f"arg{i + 1}" for i, p in enumerate(params)}
         new_method = copy.deepcopy(method)

--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -511,14 +511,13 @@ class CollapseSingleIndexTupleTransformer(BlockTransformer):
                 ),
             )
 
-            new_stmts = (
-                list(block.statements[:stmt_idx])
-                + [new_decl]
-                + list(block.statements[stmt_idx + 1 :])
-            )
-            new_block = frog_ast.Block(new_stmts)
-
-            # Replace all ArrayAccess(v, idx) with Variable(v)
+            # F-313: the collapse decision is based ONLY on uses in the suffix
+            # (``remaining``), where ``v`` is this declaration's binding. Rewrite
+            # ``v[idx] -> v`` ONLY in the suffix. A ``v[idx]`` in the prefix
+            # refers to an outer/shadowed ``v`` (a different binding), and the
+            # new declaration's own RHS must also stay intact; rewriting the
+            # whole reconstructed block would collapse those unrelated accesses.
+            suffix_block = frog_ast.Block(list(block.statements[stmt_idx + 1 :]))
             target = frog_ast.ArrayAccess(
                 frog_ast.Variable(var_name), frog_ast.Integer(idx)
             )
@@ -527,13 +526,18 @@ class CollapseSingleIndexTupleTransformer(BlockTransformer):
                     lambda n, t=target: (  # type: ignore[misc]
                         isinstance(n, frog_ast.ArrayAccess) and n == t
                     )
-                ).visit(new_block)
+                ).visit(suffix_block)
                 if found is None:
                     break
-                new_block = ReplaceTransformer(
+                suffix_block = ReplaceTransformer(
                     found, frog_ast.Variable(var_name)
-                ).transform(new_block)
+                ).transform(suffix_block)
 
+            new_block = frog_ast.Block(
+                list(block.statements[:stmt_idx])
+                + [new_decl]
+                + list(suffix_block.statements)
+            )
             return self.transform(new_block)
 
         return block

--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -593,7 +593,13 @@ class _ProductLiteralValueRewriter(Transformer):
                     method=None,
                 )
             )
-        return self._transform_children(node)
+        # F-316: a ProductType that is NOT a literal (values is None, or some
+        # member is a genuine type) denotes a *space*, not a tuple value. Do NOT
+        # descend with `_transform_children`: that recurses into `node.types` and
+        # converts any nested literal member into a `Tuple`, grafting a `Tuple`
+        # into `ProductType.types` -- a mixed-representation node that downstream
+        # passes and the Z3 visitor mis-read. Leave the space untouched.
+        return node
 
     def transform_unary_operation(
         self, node: frog_ast.UnaryOperation

--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -32,6 +32,44 @@ from ._base import (
 # ---------------------------------------------------------------------------
 
 
+def _count_var_refs(node: frog_ast.ASTNode, name: str) -> int:
+    """Count occurrences of *name* as a variable reference in *node*."""
+    count = [0]
+
+    def _p(n: frog_ast.ASTNode) -> bool:
+        if isinstance(n, frog_ast.Variable) and n.name == name:
+            count[0] += 1
+        return False
+
+    SearchVisitor(_p).visit(node)
+    return count[0]
+
+
+def _count_var_decls(node: frog_ast.ASTNode, name: str) -> int:
+    """Count local declarations that bind *name* in *node* (typed
+    sample/assignment/declaration, or a loop binder)."""
+    count = [0]
+
+    def _p(n: frog_ast.ASTNode) -> bool:
+        if isinstance(n, frog_ast.VariableDeclaration) and n.name == name:
+            count[0] += 1
+        elif (
+            isinstance(n, (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample))
+            and n.the_type is not None
+            and isinstance(n.var, frog_ast.Variable)
+            and n.var.name == name
+        ):
+            count[0] += 1
+        elif isinstance(n, frog_ast.NumericFor) and n.name == name:
+            count[0] += 1
+        elif isinstance(n, frog_ast.GenericFor) and n.var_name == name:
+            count[0] += 1
+        return False
+
+    SearchVisitor(_p).visit(node)
+    return count[0]
+
+
 class ExpandTupleTransformer(Transformer):
     """Expands product-typed variables into individual component variables.
 
@@ -44,6 +82,38 @@ class ExpandTupleTransformer(Transformer):
     def __init__(self) -> None:
         self.to_transform: list[str] = []
         self.lengths: list[int] = []
+        self._current_method: frog_ast.Method | None = None
+
+    def transform_method(self, method: frog_ast.Method) -> frog_ast.Method:
+        # Capture the enclosing method so the F-324 scope guard can tell whether
+        # a block-local tuple declaration escapes the block being expanded.
+        self._current_method = method
+        result = self._transform_children(method)
+        assert isinstance(result, frog_ast.Method)
+        return result
+
+    def _local_escapes_block(self, block: frog_ast.Block, name: str) -> bool:
+        """F-324 scope guard (mirrors the SinkUniformSample F-042 guard).
+
+        A block-local product declaration is expanded in place, splitting
+        ``v`` into ``v@k`` components only within this block (a local's entry
+        in ``to_transform`` is popped when the block finishes). For well-typed
+        input a block-local is never referenced outside its block, so the
+        existing within-block ``_has_reference`` guard is exact. But on a
+        malformed, out-of-scope AST where ``v`` is also read in an enclosing
+        block, expanding here would leave that outer ``v[k]`` access unrewritten
+        (dangling). Decline when ``name`` is referenced in the method outside
+        ``block`` with no governing outer declaration."""
+        method = self._current_method
+        if method is None:
+            return False
+        refs_in_method = _count_var_refs(method.block, name)
+        refs_in_block = _count_var_refs(block, name)
+        if refs_in_method <= refs_in_block:
+            return False  # no references outside this block -> safe
+        decls_in_method = _count_var_decls(method.block, name)
+        decls_in_block = _count_var_decls(block, name)
+        return decls_in_method <= decls_in_block
 
     def _is_transformable_tuple(
         self, the_type: frog_ast.Type, name: str, search_space: frog_ast.ASTNode
@@ -140,6 +210,9 @@ class ExpandTupleTransformer(Transformer):
                     statement.var.name,
                     frog_ast.Block(list(block.statements[stmt_idx + 1 :])),
                 )
+                # F-324: also decline when the local escapes this block (an
+                # outer-scope ``v[k]`` would be left dangling by the split).
+                and not self._local_escapes_block(block, statement.var.name)
             ):
                 assert isinstance(statement.the_type, frog_ast.ProductType)
                 unfolded_types = statement.the_type.types

--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -1,3 +1,9 @@
+# pylint: disable=duplicate-code
+# The block-local scope-guard count helpers (_count_var_refs / _count_var_decls)
+# and the _local_escapes_block logic mirror the structurally identical helpers in
+# transforms.sampling (SinkUniformSample's F-042 guard); each transform module
+# keeps its own copy rather than coupling the two modules for a few small pure
+# functions.
 """Tuple-related passes: expand and simplify tuples.
 
 Product-typed values are expanded into individual components for

--- a/proof_frog/transforms/types.py
+++ b/proof_frog/transforms/types.py
@@ -16,6 +16,7 @@ from ..visitors import (
     BlockTransformer,
     NameTypeMap,
     build_game_type_map,
+    MethodScopedTypeMapMixin,
 )
 from ._base import TransformPass, PipelineContext
 
@@ -24,7 +25,7 @@ from ._base import TransformPass, PipelineContext
 # ---------------------------------------------------------------------------
 
 
-class DeadNullGuardEliminator(BlockTransformer):
+class DeadNullGuardEliminator(MethodScopedTypeMapMixin, BlockTransformer):
     """Removes if (x == None) { ... } guards that can never execute.
 
     Two cases are handled:
@@ -298,7 +299,11 @@ class DeadNullGuardElimination(TransformPass):
             for k, v in ctx.proof_namespace.items()
             if isinstance(v, (frog_ast.Primitive, frog_ast.Scheme, frog_ast.Game))
         }
-        return DeadNullGuardEliminator(type_map, instantiables).transform(game)
+        return (
+            DeadNullGuardEliminator(type_map, instantiables)
+            .scope_to_game(game, ctx.proof_let_types)
+            .transform(game)
+        )
 
 
 class SubsetTypeNormalization(TransformPass):

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1282,6 +1282,18 @@ def build_game_type_map(
 
     Collects types from fields, method parameters, assignments, and samples.
     Optionally merges with proof-level let types.
+
+    WARNING: this map is *game-wide and scope-blind*. Because
+    :meth:`NameTypeMap.set` is last-write-wins, a parameter or local named
+    ``x`` in one method silently overwrites a same-named binding of a
+    *different* type in a sibling method. A transform that looks up the type
+    of a bare name appearing inside a specific method body must NOT use this
+    map -- it would read a sibling method's type (audit
+    F-255/F-256/F-261/F-263/F-269/F-270/F-287/F-308). Use
+    :func:`build_method_type_map` (or the :class:`MethodScopedTypeMapMixin`)
+    for that. This function remains correct for callers that only need the
+    game's *fields* (module-global, one type each) or that genuinely want the
+    union of all declarations regardless of scope.
     """
     # Use a dummy stopping point that won't match any real node to collect everything
     dummy = frog_ast.Boolean(True)
@@ -1289,6 +1301,95 @@ def build_game_type_map(
     if proof_let_types is not None:
         type_map = type_map + proof_let_types
     return type_map
+
+
+def build_method_type_map(
+    game: frog_ast.Game,
+    method: frog_ast.Method,
+    proof_let_types: Optional[NameTypeMap] = None,
+) -> NameTypeMap:
+    """Build a NameTypeMap scoped to a single *method* of *game*.
+
+    Contains the game's fields (module-global) plus only *method*'s own
+    parameters and local declarations -- crucially NOT other methods'
+    params/locals. A method-local binding shadowing a field name wins within
+    the method. Optionally merges proof-level let types (which win last,
+    matching :func:`build_game_type_map`).
+
+    This is the sound, scope-correct replacement for
+    :func:`build_game_type_map` whenever a transform reasons about the type of
+    a *bare name* appearing inside a method body. The flat game-wide map
+    conflated same-named parameters across sibling methods, letting one
+    method's declaration launder a wrong type onto another's operand -- an
+    unsound rewrite (audit F-256/F-261/F-263/F-270/F-308) as well as a
+    completeness-corrupting one (F-255/F-269/F-287).
+    """
+    dummy = frog_ast.Boolean(True)
+    field_map = NameTypeMap()
+    for field in game.fields:
+        field_map.set(field.name, field.type)
+    method_map = GetTypeMapVisitor(dummy).visit(method)
+    # field_map + method_map: a method-local shadowing a field wins.
+    # + proof_let_types last, matching build_game_type_map's precedence.
+    result = field_map + method_map
+    if proof_let_types is not None:
+        result = result + proof_let_types
+    return result
+
+
+_MethodScopedT = TypeVar("_MethodScopedT", bound="MethodScopedTypeMapMixin")
+
+
+class MethodScopedTypeMapMixin(Transformer):
+    """Mixin for a Transformer that consults ``self.type_map`` for the types
+    of bare names inside method bodies.
+
+    It overrides ``transform_method`` to swap ``self.type_map`` to a map
+    scoped to that method (fields + only that method's params/locals + proof
+    lets, via :func:`build_method_type_map`) for the duration of that method's
+    traversal, then restore it. This removes the cross-method name-collision
+    hazard of the flat game-wide :func:`build_game_type_map` (audit
+    F-255/F-256/F-261/F-263/F-269/F-270/F-287/F-308).
+
+    A concrete transformer opts in by (1) inheriting this mixin, (2) storing
+    its working map in ``self.type_map``, and (3) calling
+    :meth:`scope_to_game` with the game + proof-let types before traversal.
+    If ``scope_to_game`` is never called (``_scope_game is None``), the mixin
+    is inert and the transformer keeps its original game-wide map -- a safe
+    fallback, never a silent behavior change.
+    """
+
+    _scope_game: Optional[frog_ast.Game] = None
+    _scope_let_types: Optional[NameTypeMap] = None
+
+    def scope_to_game(
+        self: _MethodScopedT,
+        game: frog_ast.Game,
+        proof_let_types: Optional[NameTypeMap],
+    ) -> _MethodScopedT:
+        """Record the game + proof-let types so ``transform_method`` can build
+        per-method scoped type maps. Returns ``self`` for call chaining."""
+        self._scope_game = game
+        self._scope_let_types = proof_let_types
+        return self
+
+    def transform_method(self, method: frog_ast.Method) -> frog_ast.ASTNode:
+        if self._scope_game is None:
+            return self._transform_children(method)
+        # Swap ``self.type_map`` to the method-scoped map for this subtree.
+        # ``getattr``/``setattr`` are used so the mixin does not fix the
+        # declared type of the concrete transformer's ``type_map`` attribute
+        # (subclasses declare it themselves, some Optional, some required).
+        saved = getattr(self, "type_map", None)
+        setattr(
+            self,
+            "type_map",
+            build_method_type_map(self._scope_game, method, self._scope_let_types),
+        )
+        try:
+            return self._transform_children(method)
+        finally:
+            setattr(self, "type_map", saved)
 
 
 def assigns_variable(

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1542,7 +1542,14 @@ class SameFieldVisitor(Visitor[Optional[list[frog_ast.Statement]]]):
             return
 
         for index, statement in enumerate(block.statements):
-            if statement in self.paired_statements:
+            # F-299: match by IDENTITY, not structural equality. A `statement in
+            # self.paired_statements` test uses ASTNode.__eq__, so a DIFFERENT
+            # but identical-looking unpaired twin write in another oracle
+            # (`f2 = 1` with no matching `f1 = 1`) is wrongly treated as already
+            # paired and skipped from analysis, yielding a false "always equal".
+            # The visitor runs on the original game, so the genuinely-paired
+            # instances are identity-comparable here.
+            if any(statement is paired for paired in self.paired_statements):
                 continue
 
             if not isinstance(statement, (frog_ast.Sample, frog_ast.Assignment)):

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -781,10 +781,6 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
         self.stack: list[Any] = []
         self.type_map = type_map
         self.variable_version_map = variable_version_map
-        self.bool_num = 0
-        self.expression_formula_map: list[
-            tuple[tuple[frog_ast.Expression, dict[str, int]], z3.AstRef]
-        ] = []
         # Opt-in: when True, FuncCall expressions and BinaryOperations whose
         # operand types Z3 cannot mix (e.g. `||` over BitString operands)
         # are modelled as memoized opaque Z3 constants instead of None.
@@ -863,14 +859,6 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
 
     def set_variable_version_map(self, version_map: dict[str, int]) -> None:
         self.variable_version_map = version_map
-
-    def _search_expression_formula_map(
-        self, potential: tuple[frog_ast.Expression, dict[str, int]]
-    ) -> Optional[z3.AstRef]:
-        for item in self.expression_formula_map:
-            if item[0] == potential:
-                return item[1]
-        return None
 
     def visit_variable(self, var: frog_ast.Variable) -> None:
         name = var.name
@@ -1024,17 +1012,26 @@ class Z3FormulaVisitor(Visitor[z3.AstRef]):
             and operation.operator
             in set([frog_ast.BinaryOperators.IN, frog_ast.BinaryOperators.SUBSETS])
         ):
-            assert self.variable_version_map is not None
-            z3_bool = self._search_expression_formula_map(
-                (operation, self.variable_version_map)
-            )
-            if z3_bool is None:
-                z3_bool = z3.Bool(f"@@@unknown_boolean{self.bool_num}")
-                self.bool_num += 1
-                self.expression_formula_map.append(
-                    ((operation, copy.deepcopy(self.variable_version_map)), z3_bool)
-                )
-            self.stack.append(z3_bool)
+            # A set membership/subset test is a deterministic Bool that Z3
+            # cannot model natively, so intern the WHOLE operation as a
+            # memoized opaque Bool atom keyed on its full structural string
+            # (plus the SSA version map). Two structurally identical tests
+            # under the same versions share the atom -- so `(k in S) || !(k in
+            # S)` still resolves -- while distinct tests (`k in S` vs `k2 in
+            # S`) get distinct atoms.
+            #
+            # SOUNDNESS (F-330/F-331): the previous code asserted
+            # `variable_version_map is not None` (crashing the residual
+            # escape hatch, which builds the visitor with no version map --
+            # F-330) and named the atom `@@@unknown_boolean{counter}` from a
+            # PER-INSTANCE counter. `_z3_check_expression_pair` builds one
+            # visitor per game, so both counters started at 0 and `k in S`
+            # (game 1) collided with `k2 in S` (game 2) as the same atom -- a
+            # cross-instance false accept (F-331). Structural interning via
+            # `_intern_opaque` fixes both: it tolerates a None version map and
+            # its Z3 const name is the structural key, so cross-instance
+            # atoms match iff the expressions match.
+            self.stack.append(self._intern_opaque(operation, sort=z3.BoolSort()))
             return
 
         # Handle tuple equality/inequality

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1486,7 +1486,12 @@ def reassigns_or_rebinds(names: set[str], node: frog_ast.ASTNode) -> bool:
       pure set-difference surface form ``x <- T \\ S`` performs no insertion and
       is therefore not treated as a write;
     - a loop binder (``for (Int i = ...)`` / ``for (T e in ...)``) that rebinds
-      one of *names*, shadowing it.
+      one of *names*, shadowing it;
+    - a bare local re-declaration (``VariableDeclaration``: ``T x;`` with no
+      initializer) that rebinds one of *names*, shadowing the outer binding
+      (F-196: a typed ``T x = e;`` is an ``Assignment`` and already caught by
+      the l-value case above, but a no-initializer declaration was not, so a
+      structural substitution could still capture the inner binding).
 
     Conservative by design: any such occurrence anywhere in *node* -- including
     nested branches and loop bodies -- counts, because callers substitute
@@ -1507,6 +1512,8 @@ def reassigns_or_rebinds(names: set[str], node: frog_ast.ASTNode) -> bool:
         if isinstance(inner, frog_ast.NumericFor) and inner.name in names:
             return True
         if isinstance(inner, frog_ast.GenericFor) and inner.var_name in names:
+            return True
+        if isinstance(inner, frog_ast.VariableDeclaration) and inner.name in names:
             return True
         return False
 

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1513,6 +1513,21 @@ def reassigns_or_rebinds(names: set[str], node: frog_ast.ASTNode) -> bool:
     return SearchVisitor(_mutates).visit(node) is not None
 
 
+def _statement_can_exit(statement: frog_ast.Statement) -> bool:
+    """True if *statement* can cause an early method exit (contains a return).
+
+    Used by SameFieldVisitor (F-298): a return between two paired field writes
+    means the second write is skippable on the early-exit path, so the fields
+    are not equal on every trace and must not be merged.
+    """
+    return (
+        SearchVisitor(lambda n: isinstance(n, frog_ast.ReturnStatement)).visit(
+            statement
+        )
+        is not None
+    )
+
+
 class SameFieldVisitor(Visitor[Optional[list[frog_ast.Statement]]]):
     def __init__(self, field_name_pair: tuple[str, str]):
         self.field_name_pair = field_name_pair
@@ -1571,6 +1586,13 @@ class SameFieldVisitor(Visitor[Optional[list[frog_ast.Statement]]]):
                         copy_paired = True
                         self.paired_statements.append(subsequent_statement)
                         break
+                    # F-298: an intervening statement that can exit the method
+                    # (contains a return) makes the pair write AFTER it
+                    # adversary-skippable -- on the early-exit path the first
+                    # field is written but the pair is not, so they are not equal
+                    # forever. Stop pairing across it.
+                    if _statement_can_exit(subsequent_statement):
+                        break
                     if (
                         SearchVisitor(
                             functools.partial(reads_pair_fc, pair_name)
@@ -1609,6 +1631,15 @@ class SameFieldVisitor(Visitor[Optional[list[frog_ast.Statement]]]):
                     paired = True
                     self.paired_statements.append(subsequent_statement)
                     break
+
+                # F-298: an intervening statement that can exit the method
+                # (contains a return) makes the pair write after it
+                # adversary-skippable -- on the early-exit path the first field
+                # is written but the pair is not, so the two fields are not equal
+                # forever. Do not pair across it.
+                if _statement_can_exit(subsequent_statement):
+                    self.are_same = False
+                    return
 
                 if (
                     SearchVisitor(assigns_variable_partial).visit(subsequent_statement)

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1139,6 +1139,21 @@ class AllConstantFieldAccesses(Visitor[bool]):
         if frog_ast.tuple_literal_values(assignment.value) is None:
             self.all_constant = False
 
+    def visit_sample(self, sample: frog_ast.Sample) -> None:
+        self._decline_on_whole_var_write(sample.var)
+
+    def visit_unique_sample(self, sample: frog_ast.UniqueSample) -> None:
+        self._decline_on_whole_var_write(sample.var)
+
+    def _decline_on_whole_var_write(self, target: frog_ast.ASTNode) -> None:
+        # F-322: a whole-variable sample of the tuple (``v <- ...`` /
+        # ``v <-uniq[S] ...``) draws the aggregate atomically; ExpandTuple
+        # cannot split it into per-component draws (an element sample
+        # ``v[0] <- T`` keeps its ArrayAccess lvalue and is handled by
+        # ``visit_array_access``). Decline so the field/local is left intact.
+        if isinstance(target, frog_ast.Variable) and target.name == self.tuple_name:
+            self.all_constant = False
+
 
 class FieldOrderingVisitor(Visitor[dict[str, str]]):
     def __init__(self) -> None:

--- a/tests/integration/test_requires_scoping.py
+++ b/tests/integration/test_requires_scoping.py
@@ -1,0 +1,132 @@
+"""F-333: scheme ``requires A == B`` equality licenses are scoped to the
+theorem's dependency cone.
+
+A never-composed decoy scheme instantiated only in the ``let:`` block used
+to inject an equality license (``Y == Z`` over two independent opaque
+proof parameters) into a single global pool, which then rewrote the
+sampling domain of an UNRELATED theorem game -- silently narrowing an
+unconditional theorem to the diagonal and false-accepting a hop between
+games distinguishable with advantage 1/2.
+
+`_extract_subsets_pairs` now honors a scheme's ``requires`` only when the
+scheme is reachable from the theorem / games sequence / helpers (see
+`_theorem_dependency_cone`). The decoy is referenced nowhere but ``let:``,
+so its license no longer applies and the false hop is rejected -- while a
+scheme the theorem actually composes (e.g. KEMPRF, whose
+``requires K.SharedSecret == BitString<F.lambda>`` is a legitimate
+hypothesis of the scheme under test) is unaffected.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+_TRIVIAL_PRIMITIVE = """
+Primitive Trivial(Set A0, Set B0) {
+    Set TA = A0;
+    Set TB = B0;
+    Bool Noop();
+}
+"""
+
+_DECOY_SCHEME = """
+import 'trivial.primitive';
+
+Scheme DummyYZ(Set A0, Set B0) extends Trivial {
+    requires A0 == B0;
+
+    Set TA = A0;
+    Set TB = B0;
+
+    Bool Noop() {
+        return true;
+    }
+}
+"""
+
+# Real draws twice from Y and reports a collision (prob 1/|Y|); Random draws
+# from Z (prob 1/|Z|). Distinguishable with advantage 1/2 at |Y|=1, |Z|=2.
+_ATTACK_GAME = """
+Game Real(Set Y, Set Z) {
+    Bool Get() {
+        Y y1 <- Y;
+        Y y2 <- Y;
+        return y1 == y2;
+    }
+}
+
+Game Random(Set Y, Set Z) {
+    Bool Get() {
+        Z z1 <- Z;
+        Z z2 <- Z;
+        return z1 == z2;
+    }
+}
+
+export as AttackYZ;
+"""
+
+# The decoy DummyYZ(Y, Z) is instantiated but NEVER composed into AttackYZ.
+_DECOY_PROOF = """
+import 'trivial.primitive';
+import 'dummy_yz.scheme';
+import 'attack_yz.game';
+
+proof:
+
+let:
+    Set Y;
+    Set Z;
+    DummyYZ D = DummyYZ(Y, Z);
+
+theorem:
+    AttackYZ(Y, Z);
+
+games:
+    AttackYZ(Y, Z).Real against AttackYZ(Y, Z).Adversary;
+    AttackYZ(Y, Z).Random against AttackYZ(Y, Z).Adversary;
+"""
+
+
+def _prove(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "proof_frog", "prove", str(path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_decoy_scheme_requires_license_does_not_leak(tmp_path: Path) -> None:
+    (tmp_path / "trivial.primitive").write_text(_TRIVIAL_PRIMITIVE)
+    (tmp_path / "dummy_yz.scheme").write_text(_DECOY_SCHEME)
+    (tmp_path / "attack_yz.game").write_text(_ATTACK_GAME)
+    proof = tmp_path / "attack_yz.proof"
+    proof.write_text(_DECOY_PROOF)
+
+    result = _prove(proof)
+    # The unconditional theorem AttackYZ(Y, Z) must NOT be narrowed to Y == Z
+    # by a decoy scheme's requires clause: the hop is rejected.
+    assert result.returncode != 0, result.stdout
+    assert "Proof Failed" in result.stdout, result.stdout
+
+
+def test_requires_in_theorem_cone_still_honored() -> None:
+    # Positive control: KEMPRF is the scheme under test, so its
+    # `requires K.SharedSecret == BitString<F.lambda>` is legitimately
+    # honored and the proof succeeds. (Also exercised by the full corpus in
+    # tests/integration/test_proofs.py; asserted here as F-333's paired
+    # in-cone control.)
+    kemprf = REPO_ROOT / "examples/Proofs/KEM/KEMPRF_INDCPA.proof"
+    if not kemprf.exists():
+        import pytest
+
+        pytest.skip("examples submodule not checked out")
+    result = _prove(kemprf)
+    assert result.returncode == 0, result.stdout
+    assert "Proof Succeeded" in result.stdout, result.stdout

--- a/tests/unit/engine/test_extract_subsets_pairs.py
+++ b/tests/unit/engine/test_extract_subsets_pairs.py
@@ -4,17 +4,47 @@ Both ``==`` and ``subsets`` constraints are extracted into ``subsets_pairs``
 (safe for normalizing type annotations).  But only ``==`` constraints are
 added to ``equality_pairs`` (safe for normalizing sampling distributions),
 because ``subsets`` allows A ⊊ B where ``x <- A`` ≠ ``x <- B``.
+
+F-333: constraints are harvested only from schemes in the theorem's
+dependency cone, so each test wires the scheme (bound as ``S``) into the
+theorem game; `test_decoy_scheme_out_of_cone_not_harvested` covers the
+complementary case.
 """
 
 from proof_frog import frog_ast
 from proof_frog.proof_engine import ProofEngine
 
 
-def _make_engine_with_scheme(scheme: frog_ast.Scheme) -> ProofEngine:
-    """Create a ProofEngine and inject a scheme into its namespace."""
+def _proof_file_referencing(*names: str) -> frog_ast.ProofFile:
+    """A minimal ProofFile whose theorem references the given let-names, so
+    schemes bound under those names fall inside the dependency cone."""
+    theorem = frog_ast.ParameterizedGame(
+        "TheoremGame", [frog_ast.Variable(n) for n in names]
+    )
+    return frog_ast.ProofFile(
+        imports=[],
+        helpers=[],
+        lets=[],
+        assumptions=[],
+        lemmas=[],
+        max_calls=None,
+        theorem=theorem,
+        steps=[],
+    )
+
+
+def _make_engine_with_scheme(
+    scheme: frog_ast.Scheme, in_cone: bool = True
+) -> ProofEngine:
+    """Create a ProofEngine, inject a scheme as ``S``, and run the harvest.
+
+    ``in_cone`` controls whether the minimal proof file's theorem references
+    ``S`` (so its requirements are honored) or not (so they are scoped out).
+    """
     engine = ProofEngine()
     engine.proof_namespace["S"] = scheme
-    engine._extract_subsets_pairs()  # pylint: disable=protected-access
+    proof_file = _proof_file_referencing("S") if in_cone else _proof_file_referencing()
+    engine._extract_subsets_pairs(proof_file)  # pylint: disable=protected-access
     return engine
 
 
@@ -60,3 +90,17 @@ def test_subsets_constraint_not_in_equality_pairs() -> None:
         "subsets constraints must NOT be in equality_pairs — "
         "replacing sampling from A with B when A ⊊ B changes distribution"
     )
+
+
+def test_decoy_scheme_out_of_cone_not_harvested() -> None:
+    """F-333: a scheme not referenced by the theorem (a decoy in the let:
+    block only) has NONE of its requirements harvested, so it cannot inject
+    an equality license into an unrelated game."""
+    req = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS,
+        frog_ast.Variable("KeySpace"),
+        frog_ast.BitStringType(frog_ast.Integer(128)),
+    )
+    engine = _make_engine_with_scheme(_make_scheme(req), in_cone=False)
+    assert len(engine.subsets_pairs) == 0
+    assert len(engine.equality_pairs) == 0

--- a/tests/unit/engine/test_modint_proof_engine.py
+++ b/tests/unit/engine/test_modint_proof_engine.py
@@ -215,6 +215,24 @@ class TestXorIdentityTypeGuard:
         # Unchanged — no BitStringLiteral(0) to remove
         assert result == method
 
+    def test_f296_leading_literal_does_not_drop_modint_operand(self) -> None:
+        """F-296: `0^n + m` with `m: ModInt<q>` must NOT drop the `0^n` literal.
+
+        XorIdentity gates on `_is_bitstring_add_chain`, which used to return on
+        the FIRST evidence term -- the leading `BitStringLiteral` `0^n` -- and
+        wrongly classified the chain as XOR, rewriting `0^n + m` to `m`. Closed
+        by the F-264 shared-helper fix: `_is_bitstring_add_chain` now scans all
+        terms and lets the ModInt operand override the leading literal, so the
+        chain is not treated as bitstring XOR and the pass declines."""
+        method = frog_parser.parse_method("""
+            ModInt<q> f(ModInt<q> m) {
+                return 0^n + m;
+            }
+        """)
+        tm = _type_map_with(m=_modint(_var("q")))
+        result = XorIdentityTransformer(tm).transform(method)
+        assert result == method, "leading literal must not drop a ModInt operand"
+
 
 # ---------------------------------------------------------------------------
 # ModIntSimplificationTransformer (Step 6.3)

--- a/tests/unit/engine/test_z3_residual_equivalence.py
+++ b/tests/unit/engine/test_z3_residual_equivalence.py
@@ -198,3 +198,159 @@ def test_nondeterministic_call_in_return_refused() -> None:
     result = _z3_residual_equivalence(game1, game2, let_types, namespace)
     assert not result.valid
     assert "non-deterministic" in (result.failure_detail or "")
+
+
+# ---------------------------------------------------------------------------
+# F-328/F-329: duplicate-statement walk desync (audit round 2, family 8)
+#
+# An earlier version of `_z3_residual_equivalence` enumerated both games'
+# returns (and ifs) through a single shared list with structural `==`
+# membership. A game containing two structurally identical returns had its
+# second occurrence deduped away; the lockstep walk desynced, broke out on
+# `None`, and fell through to `valid=True` with a genuinely differing pair
+# never Z3-checked. The walk now pairs statements positionally with
+# per-game identity-based enumeration, so every pair is checked.
+# ---------------------------------------------------------------------------
+
+
+def test_f328_duplicate_return_masks_differing_return_rejected() -> None:
+    # game1's Peek and Guess both `return k` (structurally identical);
+    # game2's Guess instead returns the constant. The two games are
+    # distinguishable with advantage 1 - 2^-8 (call Peek, then Guess,
+    # compare). The desync bug certified this pair; it must be rejected.
+    game1 = _parse_game(
+        """
+        Game G1() {
+            BitString<8> k;
+            BitString<8> Peek() {
+                return k;
+            }
+            BitString<8> Guess(BitString<8> x) {
+                return k;
+            }
+        }
+        """
+    )
+    game2 = _parse_game(
+        """
+        Game G2() {
+            BitString<8> k;
+            BitString<8> Peek() {
+                return k;
+            }
+            BitString<8> Guess(BitString<8> x) {
+                return 0^8;
+            }
+        }
+        """
+    )
+    result = _z3_residual_equivalence(
+        game1, game2, _empty_let_types(), _empty_namespace()
+    )
+    assert not result.valid
+    assert "return" in (result.failure_detail or "")
+
+
+def test_f329_duplicate_if_masks_differing_condition_rejected() -> None:
+    # game1's A and B share a structurally identical `if (x == k)`;
+    # game2's B guards on `x == c` instead. Distinguishable; the
+    # if-condition walk variant of the desync certified it.
+    game1 = _parse_game(
+        """
+        Game G1() {
+            BitString<8> k;
+            BitString<8> c;
+            Bool A(BitString<8> x) {
+                if (x == k) {
+                    return true;
+                }
+                return false;
+            }
+            Bool B(BitString<8> x) {
+                if (x == k) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """
+    )
+    game2 = _parse_game(
+        """
+        Game G2() {
+            BitString<8> k;
+            BitString<8> c;
+            Bool A(BitString<8> x) {
+                if (x == k) {
+                    return true;
+                }
+                return false;
+            }
+            Bool B(BitString<8> x) {
+                if (x == c) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        """
+    )
+    result = _z3_residual_equivalence(
+        game1, game2, _empty_let_types(), _empty_namespace()
+    )
+    assert not result.valid
+    assert "if-condition" in (result.failure_detail or "")
+
+
+def test_duplicate_identical_returns_still_pass() -> None:
+    # Positive control: duplicates on BOTH sides with no real difference
+    # must still be certified (the fix must not over-reject).
+    src = """
+        Game G() {
+            BitString<8> k;
+            BitString<8> Peek() {
+                return k;
+            }
+            BitString<8> Guess(BitString<8> x) {
+                return k;
+            }
+        }
+        """
+    result = _z3_residual_equivalence(
+        _parse_game(src), _parse_game(src), _empty_let_types(), _empty_namespace()
+    )
+    assert result.valid, result.failure_detail
+
+
+def test_duplicate_return_with_equivalent_difference_still_passes() -> None:
+    # Positive control: one game duplicates a return, and the differing
+    # pair is genuinely propositionally equivalent. The fixed walk must
+    # CHECK the pair (not skip it) and certify via Z3.
+    game1 = _parse_game(
+        """
+        Game G1() {
+            Bool P(Bool a, Bool b) {
+                return a && b;
+            }
+            Bool Q(Bool a, Bool b) {
+                return a && b;
+            }
+        }
+        """
+    )
+    game2 = _parse_game(
+        """
+        Game G2() {
+            Bool P(Bool a, Bool b) {
+                return a && b;
+            }
+            Bool Q(Bool a, Bool b) {
+                return b && a;
+            }
+        }
+        """
+    )
+    result = _z3_residual_equivalence(
+        game1, game2, _empty_let_types(), _empty_namespace()
+    )
+    assert result.valid, result.failure_detail

--- a/tests/unit/engine/test_z3_residual_equivalence.py
+++ b/tests/unit/engine/test_z3_residual_equivalence.py
@@ -354,3 +354,68 @@ def test_duplicate_return_with_equivalent_difference_still_passes() -> None:
         game1, game2, _empty_let_types(), _empty_namespace()
     )
     assert result.valid, result.failure_detail
+
+
+# ---------------------------------------------------------------------------
+# F-330/F-331: IN/SUBSETS membership atoms (audit round 2, family 8)
+#
+# The IN/SUBSETS branch of Z3FormulaVisitor asserted a non-None version map
+# (crashing the residual hatch, which supplies none -- F-330) and named its
+# atom from a per-visitor-instance counter, so two independently-built
+# formulas (one per game) collided `k in S` with `k2 in S` as the same atom
+# (F-331 cross-instance false accept). Membership tests are now interned
+# structurally, like the opaque-call fallback.
+# ---------------------------------------------------------------------------
+
+
+def test_f330_f331_membership_query_differs_rejected() -> None:
+    # Real.Query returns `k in S`, Fake.Query returns `k2 in S`. k and k2 are
+    # independent samples, so the games are distinguishable. Pre-fix: an
+    # AssertionError crash (F-330); a naive crash fix would false-accept via
+    # the counter-named atom collision (F-331). Must cleanly reject.
+    game1 = _parse_game(
+        """
+        Game Real() {
+            Set<BitString<8>> S;
+            BitString<8> k;
+            BitString<8> k2;
+            Void Initialize() { k <- BitString<8>; k2 <- BitString<8>; }
+            Bool Add(BitString<8> x) { S = S union {x}; return true; }
+            Bool Query() { return k in S; }
+        }
+        """
+    )
+    game2 = _parse_game(
+        """
+        Game Fake() {
+            Set<BitString<8>> S;
+            BitString<8> k;
+            BitString<8> k2;
+            Void Initialize() { k <- BitString<8>; k2 <- BitString<8>; }
+            Bool Add(BitString<8> x) { S = S union {x}; return true; }
+            Bool Query() { return k2 in S; }
+        }
+        """
+    )
+    result = _z3_residual_equivalence(
+        game1, game2, _empty_let_types(), _empty_namespace()
+    )
+    assert not result.valid
+    assert "return" in (result.failure_detail or "")
+
+
+def test_membership_identical_query_still_passes() -> None:
+    # Positive control: structurally identical membership tests must still
+    # intern to the same atom (no crash, no over-rejection).
+    src = """
+        Game G() {
+            Set<BitString<8>> S;
+            BitString<8> k;
+            Bool Add(BitString<8> x) { S = S union {x}; return true; }
+            Bool Query() { return k in S; }
+        }
+        """
+    result = _z3_residual_equivalence(
+        _parse_game(src), _parse_game(src), _empty_let_types(), _empty_namespace()
+    )
+    assert result.valid, result.failure_detail

--- a/tests/unit/parsing/test_ast_equality_hardening.py
+++ b/tests/unit/parsing/test_ast_equality_hardening.py
@@ -1,0 +1,131 @@
+"""AST-node equality hardening (audit round 2, family 8).
+
+F-335: `Game.__eq__` used a loose `isinstance` check, so a `Reduction`
+(a `Game` subclass) compared equal to a plain `Game` with the same body,
+and two `Reduction`s composing different security games compared equal
+because the inherited comparison ignored `to_use`/`play_against`.
+
+F-336: `ASTNode.__eq__` iterated only the left operand's `__dict__`,
+making equality partial and asymmetric on a malformed node (a degenerate
+left operand subset-compared equal; the reflected direction raised
+`AttributeError`).
+"""
+
+from proof_frog import frog_ast, frog_parser
+
+
+def _reduction(compose: str, against: str) -> frog_ast.Reduction:
+    return frog_parser.parse_reduction(
+        f"""
+        Reduction R() compose {compose} against {against}.Adversary {{
+            Int y;
+            Void Initialize() {{
+                y = 2;
+                return None;
+            }}
+            Int Run() {{
+                return y;
+            }}
+        }}
+        """
+    )
+
+
+def _plain_game() -> frog_ast.Game:
+    return frog_parser.parse_game(
+        """
+        Game R() {
+            Int y;
+            Void Initialize() {
+                y = 2;
+                return None;
+            }
+            Int Run() {
+                return y;
+            }
+        }
+        """
+    )
+
+
+# ---------------------------------------------------------------------------
+# F-335: Reduction equality
+# ---------------------------------------------------------------------------
+
+
+def test_reductions_composing_different_games_are_unequal() -> None:
+    r1 = _reduction("SecA()", "Thm()")
+    r2 = _reduction("SecB()", "Thm()")
+    # Identical bodies and parameters; only the composed game differs.
+    assert r1 != r2
+    assert r2 != r1  # symmetric
+
+
+def test_reductions_playing_against_different_games_are_unequal() -> None:
+    r1 = _reduction("Sec()", "ThmA()")
+    r2 = _reduction("Sec()", "ThmB()")
+    assert r1 != r2
+    assert r2 != r1
+
+
+def test_identical_reductions_are_equal() -> None:
+    # Positive control: same composition and body -> equal.
+    assert _reduction("Sec()", "Thm()") == _reduction("Sec()", "Thm()")
+
+
+def test_reduction_not_equal_to_plain_game_with_same_body() -> None:
+    reduction = _reduction("Sec()", "Thm()")
+    game = _plain_game()
+    # Same body/parameters, but a Reduction is not a plain Game.
+    assert reduction != game
+    assert game != reduction  # symmetric (F-335 also fixes the reverse)
+
+
+# ---------------------------------------------------------------------------
+# F-336: symmetric / total base equality on malformed nodes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_attribute_compares_unequal_both_directions() -> None:
+    # A degenerate node missing a semantic attribute must compare unequal in
+    # BOTH directions (fail-closed), never subset-equal and never raising.
+    complete = frog_parser.parse_game(
+        """
+        Game G() {
+            Int Run() {
+                Int x = 1;
+                return x;
+            }
+        }
+        """
+    ).methods[0].block.statements[0]
+    assert isinstance(complete, frog_ast.Sample) or hasattr(complete, "__dict__")
+
+    # Build a degenerate twin of the same class with one attribute removed.
+    import copy
+
+    degenerate = copy.deepcopy(complete)
+    some_attr = next(
+        a
+        for a in vars(degenerate)
+        if a not in {"line_num", "column_num", "origin"}
+    )
+    delattr(degenerate, some_attr)
+
+    assert complete != degenerate
+    assert degenerate != complete  # symmetric, no AttributeError
+
+
+def test_well_formed_same_class_nodes_still_compare_by_value() -> None:
+    # Positive control: the key-set guard does not disturb ordinary equality.
+    g1 = frog_parser.parse_game(
+        "Game G() { Int Run() { return 1; } }"
+    )
+    g2 = frog_parser.parse_game(
+        "Game G() { Int Run() { return 1; } }"
+    )
+    g3 = frog_parser.parse_game(
+        "Game G() { Int Run() { return 2; } }"
+    )
+    assert g1 == g2
+    assert g1 != g3

--- a/tests/unit/transforms/test_alpha_rename.py
+++ b/tests/unit/transforms/test_alpha_rename.py
@@ -98,3 +98,48 @@ def test_idempotent() -> None:
     once = _apply(src)
     twice = str(AlphaRename().apply(frog_parser.parse_game(once), _ctx()))
     assert once == twice
+
+
+def test_f237_underscore_prefixed_user_binder_is_renamed() -> None:
+    # A user local named `__x` must be renamed to a fresh `__aN__` name -- the
+    # old code skipped every `__`-prefixed binder, leaving the capture that
+    # AlphaRename exists to prevent (audit F-237/F-290/F-323). Only the
+    # engine's own `__aN__` names are exempt (for convergence).
+    out = _apply("""
+        Game G() {
+            Int __x;
+            Int O() {
+                Int __x = 5;
+                return __x;
+            }
+        }
+        """)
+    # The local `__x = 5` and its return are freshened; no `__x` binder/read
+    # survives in O to be captured.
+    assert "Int __a0__ = 5" in out
+    assert "return __a0__" in out
+
+
+def test_f238_f239_sampled_from_and_type_follow_shadowed_local() -> None:
+    # A local `n` shadows the field `n`; the local's own draw and type
+    # annotation reference `n`. After renaming the local to a fresh name, the
+    # exclusion set (already handled), the sampled_from domain type (F-238),
+    # and the `the_type` annotation (F-239) must ALL bind to the fresh name --
+    # not silently re-bind to the field `n`.
+    out = _apply("""
+        Game G(Int lambda) {
+            Int n;
+            Void Initialize() { n = 2; }
+            Bool O() {
+                Int n = 1;
+                BitString<n> x <- BitString<n> \\ {1^n};
+                return x == 0^n;
+            }
+        }
+        """)
+    # Grab O's body (after Initialize). The renamed local drives everything.
+    body = out.split("Bool O()", 1)[1]
+    # The local `n` is renamed; no bare `<n>` (field re-bind) remains in O.
+    assert "BitString<n>" not in body
+    # The type annotation, sampled_from, and exclusion all use the fresh name.
+    assert "BitString<__a" in body

--- a/tests/unit/transforms/test_boolean_absorption.py
+++ b/tests/unit/transforms/test_boolean_absorption.py
@@ -119,3 +119,30 @@ def test_three_conjunct_chain_with_redundant_middle() -> None:
     }
     """
     assert _apply(source) == frog_parser.parse_game(expected)
+
+
+def test_f245_absorption_preserves_short_circuit_guard_order() -> None:
+    """F-245: `&&` is left-to-right strict, so a guard must stay ahead of a
+    conjunct it protects. After absorption drops a conjunct, the survivors must
+    keep SOURCE order -- sorting by node_sort_key moved `M[x] == 0` (an
+    absent-key read) ahead of its `x in M` guard (`"EQUALS" < "IN"`), making the
+    read unconditional."""
+    source = """
+    Game G() {
+        Map<Int, Int> M;
+        Bool Check(Int x, Bool z) {
+            return (x in M) && (M[x] == 0) && ((M[x] == 0) || z);
+        }
+    }
+    """
+    # `(M[x] == 0)` absorbs `((M[x] == 0) || z)`; the guard `x in M` must remain
+    # the FIRST conjunct, before `M[x] == 0`.
+    expected = """
+    Game G() {
+        Map<Int, Int> M;
+        Bool Check(Int x, Bool z) {
+            return (x in M) && (M[x] == 0);
+        }
+    }
+    """
+    assert _apply(source) == frog_parser.parse_game(expected)

--- a/tests/unit/transforms/test_boolean_identity.py
+++ b/tests/unit/transforms/test_boolean_identity.py
@@ -167,3 +167,45 @@ def test_bitstring_concat_not_simplified() -> None:
     parsed = frog_parser.parse_method(method)
     result = BooleanIdentityTransformer().transform(parsed)
     assert result == parsed
+
+
+def test_f278_bitstring_concat_operand_not_simplified() -> None:
+    """F-278: `||` is overloaded (boolean OR vs BitString concatenation). An
+    ill-typed AST `bs || true` with `bs: BitString<1>` must NOT be collapsed to
+    the Boolean literal `true` (which would destroy the bitstring). With a type
+    map, BooleanIdentity skips the OR-identity when an operand is a known
+    BitString. (A well-typed boolean OR with a Bool operand still simplifies.)"""
+    from proof_frog.transforms.algebraic import BooleanIdentity
+    from proof_frog.transforms._base import PipelineContext
+    from proof_frog.visitors import NameTypeMap
+
+    ctx = PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            BitString<2> O(BitString<1> bs) {
+                return bs || true;
+            }
+        }
+        """
+    )
+    result = BooleanIdentity().apply(game, ctx)
+    assert result == game, "a BitString `||` operand must not trigger boolean-OR identity"
+
+    # Positive control: a genuine boolean OR still simplifies.
+    bool_game = frog_parser.parse_game(
+        """
+        Game G() {
+            Bool O(Bool x) {
+                return x || true;
+            }
+        }
+        """
+    )
+    bool_result = BooleanIdentity().apply(bool_game, ctx)
+    assert "true" in str(bool_result) and "x || true" not in str(bool_result)

--- a/tests/unit/transforms/test_branch_elimination.py
+++ b/tests/unit/transforms/test_branch_elimination.py
@@ -195,3 +195,38 @@ def test_branch_elimination(
     transformed_ast = BranchEliminiationTransformer().transform(game_ast)
     print("TRANSFORMED: ", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def test_f125_malformed_empty_conditions_splices_else() -> None:
+    """F-125: for an ``IfStatement([], [b1, b2])`` (no conditions -- malformed,
+    only directly constructible) the executing block is the else that
+    ``has_else_block()`` designates, i.e. ``blocks[-1]``. The pass previously
+    spliced ``blocks[0]``, running the wrong block and dropping the else."""
+    from proof_frog import frog_ast
+
+    def asn(name: str, num: int) -> frog_ast.Assignment:
+        return frog_ast.Assignment(None, frog_ast.Variable(name), frog_ast.Integer(num))
+
+    malformed = frog_ast.IfStatement(
+        [], [frog_ast.Block([asn("x", 1)]), frog_ast.Block([asn("y", 2)])]
+    )
+    block = frog_ast.Block([malformed, frog_ast.ReturnStatement(frog_ast.Integer(0))])
+    out = str(BranchEliminiationTransformer().transform(block))
+    assert "y" in out and "x" not in out  # else (blocks[-1]) executed, not blocks[0]
+
+
+def test_f125_if_false_else_still_splices_else() -> None:
+    """Control: the reachable ``if (false) { x } else { y }`` still eliminates to
+    the else (blocks[-1] == blocks[0] after paired deletion)."""
+    from proof_frog import frog_ast
+
+    def asn(name: str, num: int) -> frog_ast.Assignment:
+        return frog_ast.Assignment(None, frog_ast.Variable(name), frog_ast.Integer(num))
+
+    stmt = frog_ast.IfStatement(
+        [frog_ast.Boolean(False)],
+        [frog_ast.Block([asn("x", 1)]), frog_ast.Block([asn("y", 2)])],
+    )
+    block = frog_ast.Block([stmt, frog_ast.ReturnStatement(frog_ast.Integer(0))])
+    out = str(BranchEliminiationTransformer().transform(block))
+    assert "y" in out and "x" not in out

--- a/tests/unit/transforms/test_challenge_exclusion_rf.py
+++ b/tests/unit/transforms/test_challenge_exclusion_rf.py
@@ -479,3 +479,65 @@ def test_guard_var_reassigned_to_challenge_not_simplified() -> None:
     }
     """
     assert not _fired(source)
+
+
+def test_f015_joint_guard_single_component_input_declines() -> None:
+    """F-015: a joint tuple guard `[a,b] == [cf1,cf2]` excludes only the exact
+    tuple. A single-component RF input `H(a)` can still hit the challenge
+    (`a == cf1` with `b != cf2`), so the Initialize `H(cf1)` must NOT be
+    replaced with a uniform sample."""
+    source = """
+    Game Test() {
+        Function<BitString<8>, BitString<16>> H;
+        BitString<8> cf1;
+        BitString<8> cf2;
+        BitString<16> field;
+        BitString<16> Initialize() {
+            H <- Function<BitString<8>, BitString<16>>;
+            cf1 = 1;
+            cf2 = 2;
+            field = H(cf1);
+            return field;
+        }
+        BitString<16> Query(BitString<8> a, BitString<8> b) {
+            if ([a, b] == [cf1, cf2]) {
+                return 0;
+            }
+            return H(a);
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = ChallengeExclusionRFToUniformTransformer().transform(game)
+    # Not fired: the Initialize field still holds H(cf1), not a fresh sample.
+    assert "field = H(cf1)" in str(result)
+
+
+def test_f015_joint_guard_full_tuple_input_still_fires() -> None:
+    """Positive control: when the RF input references BOTH guarded components
+    (`H(a || b)`), the joint guard genuinely excludes it and the transform
+    fires."""
+    source = """
+    Game Test() {
+        Function<BitString<16>, BitString<16>> H;
+        BitString<8> cf1;
+        BitString<8> cf2;
+        BitString<16> field;
+        BitString<16> Initialize() {
+            H <- Function<BitString<16>, BitString<16>>;
+            cf1 = 1;
+            cf2 = 2;
+            field = H(cf1 || cf2);
+            return field;
+        }
+        BitString<16> Query(BitString<8> a, BitString<8> b) {
+            if ([a, b] == [cf1, cf2]) {
+                return 0;
+            }
+            return H(a || b);
+        }
+    }
+    """
+    game = frog_parser.parse_game(source)
+    result = ChallengeExclusionRFToUniformTransformer().transform(game)
+    assert "field <- BitString<16>" in str(result)  # fired

--- a/tests/unit/transforms/test_collapse_assignment.py
+++ b/tests/unit/transforms/test_collapse_assignment.py
@@ -126,3 +126,38 @@ def test_element_mutation_not_collapsed() -> None:
     assert (
         transformed_ast == expected_ast
     ), "Element mutation M[0]=42 should not collapse the declaration of M"
+
+
+def test_f146_sample_initial_not_collapsed() -> None:
+    """F-146: the first statement's value is what the collapse DELETES. A Sample
+    (`x <- S`) is a side-effecting draw -- sampling a possibly-empty domain is an
+    observable termination event -- so deleting it by folding a later
+    reassignment onto it changes observable behaviour. The sample must survive."""
+    method = frog_parser.parse_method(
+        """
+        Int f() {
+            Int x <- S;
+            x = 0;
+            return x;
+        }
+        """
+    )
+    result = CollapseAssignmentTransformer().transform(method)
+    # The `x <- S` draw must NOT be deleted (no collapse into `Int x = 0`).
+    assert result == method, "a Sample-initial draw must not be collapsed away"
+
+
+def test_f146_sample_call_initial_not_collapsed() -> None:
+    """F-146: a Sample whose `sampled_from` carries a call is likewise a
+    side-effecting draw and must not be collapsed away."""
+    method = frog_parser.parse_method(
+        """
+        Int f() {
+            Int x <- G.Sample();
+            x = 0;
+            return x;
+        }
+        """
+    )
+    result = CollapseAssignmentTransformer().transform(method)
+    assert result == method, "a Sample-call initial must not be collapsed away"

--- a/tests/unit/transforms/test_collapse_single_index_tuple.py
+++ b/tests/unit/transforms/test_collapse_single_index_tuple.py
@@ -159,3 +159,23 @@ def test_collapse_skips_variable_assigned_in_multiple_places() -> None:
         "a variable declared in both arms of an if must not be collapsed "
         f"(both declarations should stay product-typed):\n{transformed}"
     )
+
+
+def test_f313_prefix_access_not_collapsed() -> None:
+    """F-313: the collapse decision scans only the suffix (uses of THIS
+    declaration's ``v``), but the rewrite must not touch a ``v[i]`` in the
+    prefix, which refers to an outer/shadowed ``v`` (a different binding).
+    Here the parameter ``v`` is read as ``v[1]`` before a local ``[Int,Int] v``
+    shadows it; only the suffix ``v[1]`` may collapse to ``v``."""
+    method = frog_parser.parse_method("""
+        Int O([Int, Int] v, [Int, Int] w) {
+            Int a = v[1];
+            [Int, Int] v = w;
+            Int b = v[1];
+            return a + b;
+        }
+    """)
+    out = str(CollapseSingleIndexTupleTransformer().transform(method))
+    assert "Int a = v[1]" in out  # prefix (outer v) untouched
+    assert "Int v = w[1]" in out  # declaration collapsed to the single element
+    assert "Int b = v;" in out  # suffix access collapsed

--- a/tests/unit/transforms/test_concat_equality_decompose.py
+++ b/tests/unit/transforms/test_concat_equality_decompose.py
@@ -372,3 +372,63 @@ def test_slice_term_resolves_via_end_minus_start() -> None:
     }
     """
     assert _apply(source) == frog_parser.parse_game(expected)
+
+
+# --------------------------------------------------------------------------
+# Value-stability of resolved concat bindings (audit F-251 / F-252)
+# --------------------------------------------------------------------------
+
+
+def test_f251_nested_reassigned_binding_not_decomposed() -> None:
+    """A concat binding `v = a || b` reassigned inside an if-body is not
+    write-once; decomposing `v == w` against the stale RHS is unsound."""
+    game = _apply(
+        """
+        Game G() {
+            Bool O(BitString<1> a, BitString<1> b, BitString<1> c,
+                   BitString<1> d, BitString<2> w, Bool flip) {
+                BitString<2> v = a || b;
+                if (flip) {
+                    v = c || d;
+                }
+                return v == w;
+            }
+        }
+        """
+    )
+    assert "v == w" in str(game)  # not decomposed into w[0:1] == a && ...
+
+
+def test_f252_stale_rhs_free_var_not_decomposed() -> None:
+    """A concat binding `v = a || m1` whose free var `a` is later reassigned
+    must not be decomposed: the substituted `a || m1` would read the mutated
+    `a`, diverging from the frozen `v`."""
+    game = _apply(
+        """
+        Game G() {
+            Bool O(BitString<1> m0, BitString<1> m1, BitString<2> w) {
+                BitString<1> a = m0;
+                BitString<2> v = a || m1;
+                a = a + 1^1;
+                Bool z = a == m1;
+                return v == w && z;
+            }
+        }
+        """
+    )
+    assert "v == w" in str(game)  # not decomposed
+
+
+def test_f252_stable_rhs_free_var_still_decomposes() -> None:
+    """Positive control: `a` is never reassigned, so `v == w` decomposes."""
+    game = _apply(
+        """
+        Game G() {
+            Bool O(BitString<1> a, BitString<1> m1, BitString<2> w) {
+                BitString<2> v = a || m1;
+                return v == w;
+            }
+        }
+        """
+    )
+    assert "w[0 : 1] == a" in str(game)

--- a/tests/unit/transforms/test_counter_guarded_field_to_local.py
+++ b/tests/unit/transforms/test_counter_guarded_field_to_local.py
@@ -613,6 +613,34 @@ def test_counter_guarded_field_to_local(
         }""",
             id="counter_decremented_by_other_method",
         ),
+        # F-052: counter written a SECOND time in the target method via a
+        # <-uniq draw. The write-once monotonicity premise (the guarded branch
+        # fires at most once) is broken, but the old count-only-Assignment/Sample
+        # scan missed the UniqueSample write and counted exactly one increment.
+        # _count_assignments_recursive now counts UniqueSample too -> declines.
+        pytest.param(
+            """
+        Game Test() {
+            BitString<lambda> k;
+            Int count;
+            Set<Int> S;
+            Void Initialize() {
+                k <- BitString<lambda>;
+                count = 0;
+            }
+            BitString<lambda> Oracle(BitString<lambda> x) {
+                count = count + 1;
+                if (count == 1) {
+                    return k + x;
+                } else {
+                    BitString<lambda> r <- BitString<lambda>;
+                    return r + x;
+                }
+                count <-uniq[S] Int;
+            }
+        }""",
+            id="counter_resampled_via_uniq_in_target_method",
+        ),
     ],
 )
 def test_counter_guarded_rejects_unsound_cases(game: str) -> None:

--- a/tests/unit/transforms/test_counter_guarded_field_to_local.py
+++ b/tests/unit/transforms/test_counter_guarded_field_to_local.py
@@ -641,6 +641,35 @@ def test_counter_guarded_field_to_local(
         }""",
             id="counter_resampled_via_uniq_in_target_method",
         ),
+        # F-051: the field is drawn from a SET VARIABLE domain (k <- S), not a
+        # fixed type. Deep-copying that draw into the target oracle re-evaluates
+        # the domain under the oracle's scope, where S may be mutated between
+        # Initialize and the call. sampled_from is an Expression (a Variable),
+        # so the pass declines. (Reachable only via typechecker-rejected
+        # set-variable field samples; latent defense-in-depth.)
+        pytest.param(
+            """
+        Game Test() {
+            Set<BitString<lambda>> S;
+            BitString<lambda> k;
+            Int count;
+            Void Initialize() {
+                S = {};
+                k <- S;
+                count = 0;
+            }
+            BitString<lambda> Oracle(BitString<lambda> x) {
+                count = count + 1;
+                if (count == 1) {
+                    return k + x;
+                } else {
+                    BitString<lambda> r <- BitString<lambda>;
+                    return r + x;
+                }
+            }
+        }""",
+            id="field_drawn_from_set_variable_domain",
+        ),
     ],
 )
 def test_counter_guarded_rejects_unsound_cases(game: str) -> None:

--- a/tests/unit/transforms/test_cross_method_cse.py
+++ b/tests/unit/transforms/test_cross_method_cse.py
@@ -535,3 +535,54 @@ class TestCrossMethodFieldAliasAliasAware:
         result = CrossMethodFieldAliasTransformer(proof_namespace=ns).transform(game)
         assert result == game
 
+
+def test_f174_declines_when_initialize_has_early_return() -> None:
+    # Initialize has an early return before the field assignment, so `stored`
+    # is undefined on the skip trace. CrossMethodFieldAlias must NOT alias
+    # Oracle's `GG.evaluate(k)` to the field (which would read undefined
+    # state on that trace). See audit F-174.
+    game = frog_parser.parse_game("""
+        Game Foo(G GG, Bool skip) {
+            BitString<n> k;
+            BitString<n> stored;
+            Int Initialize() {
+                if (skip) { return 0; }
+                stored = GG.evaluate(k);
+                return 1;
+            }
+            BitString<n> Oracle() {
+                return GG.evaluate(k);
+            }
+        }
+        """)
+    ns = _make_det_namespace()
+    ns["GG"] = ns["G"]
+    result = CrossMethodFieldAliasTransformer(proof_namespace=ns).transform(game)
+    oracle = result.methods[1]
+    ret = oracle.block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    # Declined: Oracle still returns the call, not the field `stored`.
+    assert isinstance(ret.expression, frog_ast.FuncCall)
+
+
+def test_f174_still_aliases_without_early_return() -> None:
+    # Positive control: no early return in Initialize -> the alias fires.
+    game = frog_parser.parse_game("""
+        Game Foo(G GG) {
+            BitString<n> k;
+            BitString<n> stored;
+            Void Initialize() {
+                stored = GG.evaluate(k);
+            }
+            BitString<n> Oracle() {
+                return GG.evaluate(k);
+            }
+        }
+        """)
+    ns = _make_det_namespace()
+    ns["GG"] = ns["G"]
+    result = CrossMethodFieldAliasTransformer(proof_namespace=ns).transform(game)
+    ret = result.methods[1].block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    assert isinstance(ret.expression, frog_ast.Variable)
+    assert ret.expression.name == "stored"

--- a/tests/unit/transforms/test_dedup_deterministic.py
+++ b/tests/unit/transforms/test_dedup_deterministic.py
@@ -422,3 +422,43 @@ class TestDeduplicateDeterministicCalls:
             proof_namespace=_make_det_namespace()
         ).transform(method)
         assert result == expected
+
+    def test_f201_first_statement_writes_arg_not_deduped(self) -> None:
+        """F-201: when the FIRST occurrence's own statement writes an argument
+        variable (`k = G.evaluate(k);`), the write happens after that call is
+        evaluated and before the second call, so the two calls read different
+        values (`G(k0)` vs `G(G(k0))`) and must NOT be deduplicated. The
+        intermediate-region scan excluded the first statement, missing this."""
+        method = frog_parser.parse_method("""
+            Void f(BitString<n> k) {
+                k = G.evaluate(k);
+                return G.evaluate(k);
+            }
+            """)
+        expected = frog_parser.parse_method("""
+            Void f(BitString<n> k) {
+                k = G.evaluate(k);
+                return G.evaluate(k);
+            }
+            """)
+        result = DeduplicateDeterministicCallsTransformer(
+            proof_namespace=_make_det_namespace()
+        ).transform(method)
+        assert result == expected
+
+    def test_f201_first_statement_writes_nonarg_still_deduped(self) -> None:
+        """F-201 positive control: when the first occurrence's statement writes a
+        NON-argument variable (`x = G.evaluate(k);`), the argument `k` is stable
+        between the two calls, so the deduplication must still fire."""
+        method = frog_parser.parse_method("""
+            Void f(BitString<n> k) {
+                BitString<n> x = G.evaluate(k);
+                BitString<n> y = G.evaluate(k);
+                return [x, y];
+            }
+            """)
+        result = DeduplicateDeterministicCallsTransformer(
+            proof_namespace=_make_det_namespace()
+        ).transform(method)
+        # The second G.evaluate(k) is replaced by a reference to the first result.
+        assert str(result) != str(method), "stable-arg dedup should still fire"

--- a/tests/unit/transforms/test_else_unwrap.py
+++ b/tests/unit/transforms/test_else_unwrap.py
@@ -168,3 +168,50 @@ def test_else_unwrap(
     print("EXPECTED", expected_ast)
     print("TRANSFORMED", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def test_f123_malformed_multiblock_if_not_unwrapped() -> None:
+    """F-123: ElseUnwrap indexed blocks[1] as the else guarded only by
+    has_else_block(), which accepts any block surplus. On a malformed
+    IfStatement([C], [B0, B1, B2]) it spliced B1 and silently dropped B2. A
+    well-formed single-else if has exactly len(conditions)+1 blocks; the pass
+    must now decline the malformed shape, leaving B2 intact."""
+    from proof_frog import frog_ast
+
+    cond = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, frog_ast.Variable("a"), frog_ast.Integer(1)
+    )
+    then_block = frog_ast.Block([frog_ast.ReturnStatement(frog_ast.Integer(1))])
+    b1 = frog_ast.Block(
+        [frog_ast.Assignment(None, frog_ast.Variable("x"), frog_ast.Integer(2))]
+    )
+    b2 = frog_ast.Block(
+        [frog_ast.Assignment(None, frog_ast.Variable("y"), frog_ast.Integer(3))]
+    )
+    malformed = frog_ast.IfStatement([cond], [then_block, b1, b2])
+    block = frog_ast.Block(
+        [malformed, frog_ast.ReturnStatement(frog_ast.Integer(9))]
+    )
+    out = ElseUnwrapTransformer().transform(block)
+    assert out == block  # declined -- nothing spliced, B2 not dropped
+    assert "y" in str(out)  # B2's write survives
+
+
+def test_f123_wellformed_if_else_still_unwraps() -> None:
+    """Control for F-123: a proper 2-block if-else still unwraps."""
+    from proof_frog import frog_ast
+
+    cond = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, frog_ast.Variable("a"), frog_ast.Integer(1)
+    )
+    wf = frog_ast.IfStatement(
+        [cond],
+        [
+            frog_ast.Block([frog_ast.ReturnStatement(frog_ast.Integer(1))]),
+            frog_ast.Block(
+                [frog_ast.Assignment(None, frog_ast.Variable("x"), frog_ast.Integer(2))]
+            ),
+        ],
+    )
+    block = frog_ast.Block([wf, frog_ast.ReturnStatement(frog_ast.Integer(9))])
+    assert ElseUnwrapTransformer().transform(block) != block  # unwrapped

--- a/tests/unit/transforms/test_expand_tuples.py
+++ b/tests/unit/transforms/test_expand_tuples.py
@@ -445,3 +445,40 @@ def test_f322_whole_var_unique_sample_declines() -> None:
         ]
     )
     assert visitors.AllConstantFieldAccesses("v").visit(block) is False
+
+
+def test_f324_declines_when_local_escapes_block() -> None:
+    """F-324: a block-local product declaration whose variable is also read in
+    an enclosing block (an out-of-scope AST the typechecker rejects) must not be
+    expanded -- splitting it here would leave the outer ``v[k]`` access dangling.
+    (Compare the control below, which expands when every use is in-block.)"""
+    method = frog_parser.parse_method("""
+        Int Oracle(Bool c) {
+            Int acc = 0;
+            if (c) {
+                [Int, Int] v = [1, 2];
+                acc = acc + v[0];
+            }
+            return v[1];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[1, 2]" in out  # tuple left intact
+    assert "v@1" not in out  # no dangling component reference
+
+
+def test_f324_control_expands_when_all_uses_in_block() -> None:
+    """Control for F-324: with every use inside the declaring block the local
+    still expands."""
+    method = frog_parser.parse_method("""
+        Int Oracle(Bool c) {
+            Int acc = 0;
+            if (c) {
+                [Int, Int] v = [1, 2];
+                acc = acc + v[0] + v[1];
+            }
+            return acc;
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[1, 2]" not in out  # expanded into components

--- a/tests/unit/transforms/test_expand_tuples.py
+++ b/tests/unit/transforms/test_expand_tuples.py
@@ -390,3 +390,58 @@ def test_expand_three_element_product_tuples(
 
     transformed_ast = ExpandTupleTransformer().transform(game_ast)
     assert expected_ast == transformed_ast
+
+
+def _bs(n: int) -> frog_ast.BitStringType:
+    return frog_ast.BitStringType(frog_ast.Integer(n))
+
+
+def test_f322_all_constant_declines_whole_var_product_sample() -> None:
+    """F-322: a whole-variable product-type sample ``v <- [T0, T1]`` must make
+    the AllConstantFieldAccesses gate decline -- ExpandTuple cannot split an
+    atomic aggregate draw into per-component draws. (Built as an AST because the
+    typechecker rejects product-type sample domains at the surface.)"""
+    prod = frog_ast.ProductType([_bs(4), _bs(4)])
+    block = frog_ast.Block(
+        [
+            frog_ast.Sample(prod, frog_ast.Variable("v"), prod),
+            frog_ast.ReturnStatement(
+                frog_ast.ArrayAccess(frog_ast.Variable("v"), frog_ast.Integer(0))
+            ),
+        ]
+    )
+    assert visitors.AllConstantFieldAccesses("v").visit(block) is False
+
+
+def test_f322_element_sample_still_splittable() -> None:
+    """Control: an element sample at a constant index ``v[0] <- T`` keeps its
+    ArrayAccess lvalue and does NOT block expansion."""
+    block = frog_ast.Block(
+        [
+            frog_ast.Sample(
+                _bs(4),
+                frog_ast.ArrayAccess(frog_ast.Variable("v"), frog_ast.Integer(0)),
+                _bs(4),
+            ),
+            frog_ast.ReturnStatement(
+                frog_ast.ArrayAccess(frog_ast.Variable("v"), frog_ast.Integer(1))
+            ),
+        ]
+    )
+    assert visitors.AllConstantFieldAccesses("v").visit(block) is True
+
+
+def test_f322_whole_var_unique_sample_declines() -> None:
+    """A whole-variable ``v <-uniq[S] [T0, T1]`` is equally unsplittable."""
+    prod = frog_ast.ProductType([_bs(4), _bs(4)])
+    block = frog_ast.Block(
+        [
+            frog_ast.UniqueSample(
+                prod, frog_ast.Variable("v"), frog_ast.Variable("S"), prod, "uniq"
+            ),
+            frog_ast.ReturnStatement(
+                frog_ast.ArrayAccess(frog_ast.Variable("v"), frog_ast.Integer(0))
+            ),
+        ]
+    )
+    assert visitors.AllConstantFieldAccesses("v").visit(block) is False

--- a/tests/unit/transforms/test_exponent_modulus_gate.py
+++ b/tests/unit/transforms/test_exponent_modulus_gate.py
@@ -1,0 +1,145 @@
+"""Regression tests: group-exponent folding respects the modulus/order.
+
+Folding group exponents (`g^a * g^b -> g^(a+b)`, `g^a / g^b -> g^(a-b)`,
+`(g^e1)^e2 -> g^(e1*e2)`) reduces the combined exponent modulo the exponents'
+ModInt modulus M. That matches the group law only when `g^M == identity`,
+i.e. the group order divides M. The provable case is M == the base group's
+order. These tests pin:
+
+  - decline when M is a foreign/too-small modulus (F-272, F-273, F-283);
+  - decline two different ModInt moduli (F-274, ill-typed ADD);
+  - still fold when M is the group order, and when exponents are Int.
+"""
+
+from proof_frog import frog_ast, frog_parser
+from proof_frog.visitors import build_game_type_map, NameTypeMap
+from proof_frog.transforms.algebraic import (
+    GroupElemExponentCombinationTransformer,
+    GroupElemSimplificationTransformer,
+)
+
+
+def _method(game: frog_ast.Game, name: str) -> frog_ast.Method:
+    for m in game.methods:
+        if m.signature.name == name:
+            return m
+    raise KeyError(name)
+
+
+def _combine(method_src: str) -> tuple[frog_ast.Game, frog_ast.Game]:
+    game = frog_parser.parse_game("Game G(Group G) {\n" + method_src + "\n}")
+    out = (
+        GroupElemExponentCombinationTransformer(build_game_type_map(game))
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    return game, out
+
+
+def _fired(game: frog_ast.Game, out: frog_ast.Game) -> bool:
+    return _method(out, "f") != _method(game, "f")
+
+
+# ---- F-272: g^a * g^b, exponents ModInt<2>, group order != 2 -> decline ----
+
+
+def test_f272_mul_declines_foreign_small_modulus() -> None:
+    game, out = _combine(
+        """
+        GroupElem<G> f(GroupElem<G> h, ModInt<2> a, ModInt<2> b) {
+            return h ^ a * h ^ b;
+        }
+        """
+    )
+    assert not _fired(game, out)
+
+
+# ---- F-273: g^a / g^b, same foreign modulus -> decline ----
+
+
+def test_f273_div_declines_foreign_small_modulus() -> None:
+    game, out = _combine(
+        """
+        GroupElem<G> f(GroupElem<G> h, ModInt<2> a, ModInt<2> b) {
+            return h ^ a / h ^ b;
+        }
+        """
+    )
+    assert not _fired(game, out)
+
+
+# ---- F-274: g^a * g^b with two DIFFERENT ModInt moduli -> decline ----
+
+
+def test_f274_mul_declines_mismatched_moduli() -> None:
+    game, out = _combine(
+        """
+        GroupElem<G> f(GroupElem<G> h, ModInt<4> a, ModInt<6> b) {
+            return h ^ a * h ^ b;
+        }
+        """
+    )
+    assert not _fired(game, out)
+
+
+# ---- Positive: modulus IS the group order -> folds ----
+
+
+def test_mul_fires_when_modulus_is_group_order() -> None:
+    game, out = _combine(
+        """
+        GroupElem<G> f(GroupElem<G> h, ModInt<G.order> a, ModInt<G.order> b) {
+            return h ^ a * h ^ b;
+        }
+        """
+    )
+    assert _fired(game, out)
+
+
+# ---- Positive: Int exponents fold (exact integer arithmetic) ----
+
+
+def test_mul_fires_on_int_exponents() -> None:
+    game, out = _combine(
+        """
+        GroupElem<G> f(GroupElem<G> h, Int a, Int b) {
+            return h ^ a * h ^ b;
+        }
+        """
+    )
+    assert _fired(game, out)
+
+
+# ---- F-283: power-of-power (g^e1)^e2 with foreign modulus -> decline ----
+
+
+def _powfold(method_src: str) -> tuple[frog_ast.Game, frog_ast.Game]:
+    game = frog_parser.parse_game("Game G(Group G) {\n" + method_src + "\n}")
+    out = (
+        GroupElemSimplificationTransformer(build_game_type_map(game))
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    return game, out
+
+
+def test_f283_powerfold_declines_foreign_modulus() -> None:
+    game, out = _powfold(
+        """
+        GroupElem<G> f(GroupElem<G> h, ModInt<3> a, ModInt<3> b) {
+            return (h ^ a) ^ b;
+        }
+        """
+    )
+    assert not _fired(game, out)
+
+
+def test_powerfold_fires_when_modulus_is_group_order() -> None:
+    game, out = _powfold(
+        """
+        GroupElem<G> f(GroupElem<G> h, ModInt<G.order> a, ModInt<G.order> b) {
+            return (h ^ a) ^ b;
+        }
+        """
+    )
+    assert _fired(game, out)

--- a/tests/unit/transforms/test_extract_slice_bound_purity.py
+++ b/tests/unit/transforms/test_extract_slice_bound_purity.py
@@ -1,0 +1,62 @@
+"""Regression test: ExtractRepeatedTupleAccess slice-bound purity (F-235).
+
+A slice `v[A:B]` whose bounds contain a non-deterministic call
+(`v[P.Cut():P.Cut()+n]`) must NOT be deduplicated with a structurally-equal
+sibling: each occurrence draws fresh, so merging them into one shared local
+correlates independent i.i.d. draws (ruling 7.A.6).
+
+Calls in slice bounds are not source-parseable, so the shape is built by
+substituting `P.Cut()` for a placeholder variable, mirroring the audit's
+pass-level harness.
+"""
+
+from proof_frog import frog_ast, frog_parser
+from proof_frog.visitors import SubstitutionTransformer
+from proof_frog.transforms.inlining import ExtractRepeatedTupleAccessTransformer
+
+
+def _cut_ns():
+    prim = frog_parser.parse_primitive_file("Primitive Cutter() { Int Cut(); }")
+    return {"P": prim}
+
+
+def _sub_cut_for_c(game: frog_ast.Game) -> frog_ast.Game:
+    call = frog_ast.FuncCall(frog_ast.FieldAccess(frog_ast.Variable("P"), "Cut"), [])
+    ast_map = frog_ast.ASTMap[frog_ast.ASTNode](identity=False)
+    ast_map.set(frog_ast.Variable("c"), call)
+    return SubstitutionTransformer(ast_map).transform(game)
+
+
+def test_f235_declines_dedup_of_nondet_slice_bounds() -> None:
+    # `v[c:c+n]` twice, with `c` -> P.Cut() (non-deterministic).
+    game = frog_parser.parse_game("""
+        Game G(Cutter P, Int n) {
+            [BitString<n>, BitString<n>] O(BitString<n> v, Int c) {
+                BitString<n> x = v[c : c + n];
+                BitString<n> y = v[c : c + n];
+                return [x, y];
+            }
+        }
+        """)
+    game = _sub_cut_for_c(game)
+    out = str(
+        ExtractRepeatedTupleAccessTransformer(proof_namespace=_cut_ns()).transform(game)
+    )
+    # The two slices must remain separate (each keeps its own P.Cut() draws).
+    assert "__cse_slice" not in out
+    assert out.count("v[P.Cut() : P.Cut() + n]") == 2
+
+
+def test_f235_still_dedups_deterministic_slice_bounds() -> None:
+    # Plain deterministic bounds -> the repeated slice IS extracted.
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            [BitString<n>, BitString<n>] O(BitString<n> v) {
+                BitString<n> x = v[0 : n];
+                BitString<n> y = v[0 : n];
+                return [x, y];
+            }
+        }
+        """)
+    out = str(ExtractRepeatedTupleAccessTransformer().transform(game))
+    assert "__cse_slice" in out

--- a/tests/unit/transforms/test_extract_slice_bound_purity.py
+++ b/tests/unit/transforms/test_extract_slice_bound_purity.py
@@ -60,3 +60,61 @@ def test_f235_still_dedups_deterministic_slice_bounds() -> None:
         """)
     out = str(ExtractRepeatedTupleAccessTransformer().transform(game))
     assert "__cse_slice" in out
+
+
+def test_f231_declines_merge_across_bound_reassignment() -> None:
+    """F-231: two structurally-equal `v[t:t+n]` slices separated by `t = n`
+    span DIFFERENT ranges (t changed), so they must not be merged into one
+    shared local. The reassignment guard now covers the bound variables, not
+    just the base."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int n) {
+            Bool O(BitString<n + n + n> v, Int t) {
+                BitString<n> x = v[t : t + n];
+                t = n;
+                BitString<n> y = v[t : t + n];
+                return x == y;
+            }
+        }
+        """
+    )
+    out = str(ExtractRepeatedTupleAccessTransformer().transform(game))
+    assert "__cse_slice" not in out  # not merged
+
+
+def test_f234_declines_merge_across_forbinder_bound() -> None:
+    """F-234: two `v[j-n:j]` slices in sibling `for` loops share a bound
+    variable `j` that is a per-loop binder; they must not be hoisted/merged
+    across the binders (the shared reassigns_or_rebinds detects for-binders)."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int n) {
+            BitString<n> O(BitString<n + n + n> v) {
+                BitString<n> acc = 0^n;
+                for (Int j = n to n + n) { acc = v[j - n : j]; }
+                for (Int j = n to n + n) { acc = v[j - n : j]; }
+                return acc;
+            }
+        }
+        """
+    )
+    out = str(ExtractRepeatedTupleAccessTransformer().transform(game))
+    assert "__cse_slice" not in out  # not merged across the for-binders
+
+
+def test_f231_stable_bounds_still_merge() -> None:
+    """Positive control: constant bounds with no reassignment still merge."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int n) {
+            Bool O(BitString<n + n + n> v) {
+                BitString<n> x = v[0 : n];
+                BitString<n> y = v[0 : n];
+                return x == y;
+            }
+        }
+        """
+    )
+    out = str(ExtractRepeatedTupleAccessTransformer().transform(game))
+    assert "__cse_slice" in out  # merged

--- a/tests/unit/transforms/test_forward_expression_alias.py
+++ b/tests/unit/transforms/test_forward_expression_alias.py
@@ -297,3 +297,40 @@ def test_forward_expression_alias_field(
 
     transformed_ast = ForwardExpressionAliasTransformer().transform(game_ast)
     assert expected_ast == transformed_ast
+
+
+def test_f184_self_referential_field_assign_not_aliased() -> None:
+    """F-184: `ctr = ctr + 1` -- the assigned field `ctr` is a free variable of
+    its own RHS, so `ctr == ctr + 1` does NOT hold afterward; a later
+    `ctr + 1` must not be aliased to `ctr`."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int lambda) {
+            Int ctr = 0;
+            Int Oracle() {
+                ctr = ctr + 1;
+                return ctr + 1;
+            }
+        }
+        """
+    )
+    out = str(ForwardExpressionAliasTransformer().transform(game))
+    assert "return ctr + 1" in out  # not aliased to `return ctr`
+
+
+def test_f184_non_self_referential_field_assign_still_aliases() -> None:
+    """Positive control: a field defined from an expression that does NOT
+    reference the field still aliases a later identical occurrence."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int a, Int b) {
+            Int s;
+            Int Oracle() {
+                s = a * b;
+                return (a * b) + s;
+            }
+        }
+        """
+    )
+    out = str(ForwardExpressionAliasTransformer().transform(game))
+    assert "a * b" not in out.split("return")[1]  # the return's a*b became s

--- a/tests/unit/transforms/test_forward_expression_alias.py
+++ b/tests/unit/transforms/test_forward_expression_alias.py
@@ -334,3 +334,24 @@ def test_f184_non_self_referential_field_assign_still_aliases() -> None:
     )
     out = str(ForwardExpressionAliasTransformer().transform(game))
     assert "a * b" not in out.split("return")[1]  # the return's a*b became s
+
+
+def test_f187_field_self_copy_dropped_no_recursion() -> None:
+    """F-187: a field self-copy `F = F;` is a no-op that drove Path P into
+    unbounded recursion ("maximum recursion depth exceeded"). It is now dropped
+    (trivially sound -- F is unchanged) and the pass terminates."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int lambda) {
+            Int F;
+            Int Oracle(Int a) {
+                F = a;
+                F = F;
+                return F;
+            }
+        }
+        """
+    )
+    out = str(ForwardExpressionAliasTransformer().transform(game))
+    assert "F = F" not in out  # the no-op self-copy is gone
+    assert "F = a" in out and "return F" in out

--- a/tests/unit/transforms/test_forward_expression_alias.py
+++ b/tests/unit/transforms/test_forward_expression_alias.py
@@ -355,3 +355,28 @@ def test_f187_field_self_copy_dropped_no_recursion() -> None:
     out = str(ForwardExpressionAliasTransformer().transform(game))
     assert "F = F" not in out  # the no-op self-copy is gone
     assert "F = a" in out and "return F" in out
+
+
+def test_f188_declines_when_loop_binder_captures_field() -> None:
+    """F-188: a field assignment ``f = local`` propagates ``local -> f`` into
+    subsequent code. It must decline when a following ``for`` binder rebinds the
+    field name ``f`` and the loop body reads ``local`` -- retargeting that read
+    to ``f`` would capture the binder. (Compare test id ``binder j`` below,
+    which has no collision and DOES fire.)"""
+    game = frog_parser.parse_game("""
+        Game G() {
+            Int f;
+            Void Initialize() { f = 0; }
+            Int O(Int seed) {
+                Int local = seed;
+                f = local;
+                Int acc = 0;
+                for (Int f = 0 to 3) {
+                    acc = acc + local;
+                }
+                return acc;
+            }
+        }
+        """)
+    # Unchanged: the loop-binder rebind of `f` blocks retargeting `local -> f`.
+    assert ForwardExpressionAliasTransformer().transform(game) == game

--- a/tests/unit/transforms/test_groupelem_simplification.py
+++ b/tests/unit/transforms/test_groupelem_simplification.py
@@ -220,3 +220,36 @@ def test_groupelem_identity_rules(method: str, expected: str) -> None:
     transformed = GroupElemSimplificationTransformer(tm).transform(method_ast)
 
     assert transformed == expected_ast
+
+
+def test_f285_non_group_identity_field_not_cancelled() -> None:
+    """F-285/F-286: `x * E.identity` where `E` is NOT a Group (e.g. a scheme
+    instance whose `identity` is a plain `Int` field) must not be cancelled --
+    the multiplicative-identity rule required a type/group check, not a bare
+    name-match on `.identity`."""
+    method = frog_parser.parse_method(
+        """
+        Int f(Int x) {
+            return x * E.identity;
+        }
+        """
+    )
+    # `E` is typed as a non-group (Int stands in for a scheme instance); `G`
+    # remains a genuine Group so the positive path is unaffected.
+    tm = {"E": frog_ast.IntType(), "x": frog_ast.IntType(), "G": frog_ast.GroupType()}
+    out = GroupElemSimplificationTransformer(tm).transform(method)
+    assert "x * E.identity" in str(out)  # not cancelled to x
+
+
+def test_f285_genuine_group_identity_still_cancelled() -> None:
+    """Positive control: `x * G.identity` with `G` typed Group still cancels."""
+    method = frog_parser.parse_method(
+        """
+        GroupElem<G> f(GroupElem<G> x) {
+            return x * G.identity;
+        }
+        """
+    )
+    tm = {"G": frog_ast.GroupType(), "x": frog_ast.GroupElemType(frog_ast.Variable("G"))}
+    out = GroupElemSimplificationTransformer(tm).transform(method)
+    assert "G.identity" not in str(out)  # cancelled -> return x

--- a/tests/unit/transforms/test_hoist_determ_call_alias.py
+++ b/tests/unit/transforms/test_hoist_determ_call_alias.py
@@ -1,0 +1,76 @@
+"""Regression test for HoistDeterministicCallToInitialize's alias builder (F-170).
+
+When Initialize ends `return F(x)`, the pass expands local single-assignment
+aliases so `F(x)` with `x = k` earlier matches a hoisted `F(k)`. The alias
+scan counted only top-level `Assignment` nodes, so a re-binding of `x` nested
+in an if/for or via a Sample was missed -- making a coin-dependent `x` look
+like a stable alias of `k`. It now requires the COMPLETE recursive write count
+of the alias name to be exactly 1.
+"""
+
+from proof_frog import frog_ast, frog_parser
+from proof_frog.transforms.inlining import HoistDeterministicCallToInitialize
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx() -> PipelineContext:
+    plt = NameTypeMap()
+    n = frog_ast.BitStringType(frog_ast.Variable("n"))
+    plt.set("F", frog_ast.FunctionType(n, n))
+    return PipelineContext(
+        variables={},
+        proof_let_types=plt,
+        proof_namespace={"F": None},
+        subsets_pairs=[],
+    )
+
+
+def _apply(src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(HoistDeterministicCallToInitialize().apply(game, _ctx()))
+
+
+def test_f170_declines_coin_dependent_alias() -> None:
+    # x is re-bound in the if-branch, so `return F(x)` is coin-dependent and
+    # must NOT be expanded to `F(k)`. The pass may still hoist O's F(k) into a
+    # field, but Initialize's terminal `return F(x)` must be PRESERVED.
+    out = _apply(
+        """
+        Game G(Int n) {
+            BitString<n> k;
+            Function<BitString<n>, BitString<n>> F;
+            BitString<n> Initialize() {
+                k <- BitString<n>;
+                BitString<n> k2 <- BitString<n>;
+                BitString<1> b <- BitString<1>;
+                BitString<n> x = k;
+                if (b == 1^1) { x = k2; }
+                return F(x);
+            }
+            BitString<n> O() { return F(k); }
+        }
+        """
+    )
+    assert "F(x)" in out  # coin-dependent return preserved, not collapsed
+
+
+def test_f170_still_expands_stable_alias() -> None:
+    # x is assigned exactly once (`x = k`), so `return F(x)` IS `F(k)`: the
+    # alias expands and the return collapses to the hoisted field. Positive
+    # control -- the coin-dependent `F(x)` form must be gone.
+    out = _apply(
+        """
+        Game G(Int n) {
+            BitString<n> k;
+            Function<BitString<n>, BitString<n>> F;
+            BitString<n> Initialize() {
+                k <- BitString<n>;
+                BitString<n> x = k;
+                return F(x);
+            }
+            BitString<n> O() { return F(k); }
+        }
+        """
+    )
+    assert "F(x)" not in out

--- a/tests/unit/transforms/test_hoist_deterministic_call_to_initialize.py
+++ b/tests/unit/transforms/test_hoist_deterministic_call_to_initialize.py
@@ -67,9 +67,7 @@ class TestHoistDeterministicCallToInitialize:
 
         # A new field of type BitString<n> must be added.
         assert len(result.fields) == len(game.fields) + 1
-        new_field_name = next(
-            f.name for f in result.fields if f.name not in {"seed"}
-        )
+        new_field_name = next(f.name for f in result.fields if f.name not in {"seed"})
 
         # Initialize should end with: <new_field> = GG.evaluate(seed);
         init = result.methods[0]
@@ -86,6 +84,42 @@ class TestHoistDeterministicCallToInitialize:
             assert isinstance(ret, frog_ast.ReturnStatement)
             assert isinstance(ret.expression, frog_ast.Variable)
             assert ret.expression.name == new_field_name
+
+    def test_nested_element_write_to_arg_field_blocks_hoist(self) -> None:
+        """F-172: a nested element write (`seed[0][1] = ...`) to the field
+        used as the deterministic call's argument must block the hoist.
+
+        `_fields_assigned_in_block` previously matched only a depth-1
+        ArrayAccess l-value, so a nested write was invisible and the pass
+        cached a stale snapshot in Initialize while an oracle kept mutating
+        the field. Peeling the full l-value via `lvalue_base_name` makes the
+        mutation visible, so the pass declines.
+        """
+        game = frog_parser.parse_game("""
+            Game Foo(G GG) {
+                Array<Array<BitString<n>, 2>, 2> seed;
+                Void Initialize() {
+                    seed <- Array<Array<BitString<n>, 2>, 2>;
+                }
+                BitString<n> Get1() {
+                    return GG.evaluate(seed);
+                }
+                BitString<n> Get2() {
+                    return GG.evaluate(seed);
+                }
+                BitString<n> Mutate() {
+                    seed[0][1] = 0^n;
+                    return 0^n;
+                }
+            }
+            """)
+        ns = _make_det_namespace()
+        ns["GG"] = ns["G"]
+        result = HoistDeterministicCallToInitializeTransformer(
+            proof_namespace=ns
+        ).transform(game)
+        # No cached field is added: the mutated argument makes hoisting unsound.
+        assert len(result.fields) == len(game.fields)
 
     def test_initialize_with_return_not_hoisted(self) -> None:
         """If Initialize contains any ReturnStatement, hoisting would be unsound.
@@ -113,9 +147,7 @@ class TestHoistDeterministicCallToInitialize:
         init = game.methods[0]
         assert init.signature.name == "Initialize"
         injected_return = frog_ast.ReturnStatement(frog_ast.Integer(0))
-        init.block = frog_ast.Block(
-            [injected_return, *list(init.block.statements)]
-        )
+        init.block = frog_ast.Block([injected_return, *list(init.block.statements)])
 
         ns = _make_det_namespace()
         ns["GG"] = ns["G"]
@@ -312,9 +344,7 @@ class TestHoistFunctionDRCalls:
 
         # Expect one new field of type BitString<16> (the range type of RF)
         assert len(result.fields) == len(game.fields) + 1
-        new_field = next(
-            f for f in result.fields if f.name not in {"seed", "RF"}
-        )
+        new_field = next(f for f in result.fields if f.name not in {"seed", "RF"})
         assert isinstance(new_field.type, frog_ast.BitStringType)
         # Oracles should read the new field, not call RF directly
         for oracle in result.methods[1:]:
@@ -668,9 +698,7 @@ class TestNestedDeterministicStableArgs:
         early_return_block = frog_ast.Block(
             [frog_ast.ReturnStatement(frog_ast.Integer(0))]
         )
-        if_stmt = frog_ast.IfStatement(
-            [frog_ast.Boolean(True)], [early_return_block]
-        )
+        if_stmt = frog_ast.IfStatement([frog_ast.Boolean(True)], [early_return_block])
         init.block = frog_ast.Block([if_stmt, *list(init.block.statements)])
         ns = _make_det_namespace()
         ns["GG"] = ns["G"]
@@ -711,9 +739,7 @@ class TestNestedDeterministicStableArgs:
             proof_namespace=ns
         ).transform(game)
         assert len(result.fields) == len(game.fields) + 1
-        new_field_name = next(
-            f.name for f in result.fields if f.name not in {"seed"}
-        )
+        new_field_name = next(f.name for f in result.fields if f.name not in {"seed"})
         init = result.methods[0]
         stmts = list(init.block.statements)
         ret = stmts[-1]
@@ -786,9 +812,7 @@ class TestNestedDeterministicStableArgs:
             proof_namespace=ns
         ).transform(game)
         assert len(result.fields) == len(game.fields) + 1
-        new_field_name = next(
-            f.name for f in result.fields if f.name not in {"pair"}
-        )
+        new_field_name = next(f.name for f in result.fields if f.name not in {"pair"})
         init = result.methods[0]
         stmts = list(init.block.statements)
         # The hoisted assignment should be the last statement (no terminal

--- a/tests/unit/transforms/test_hoist_duplicate_branch.py
+++ b/tests/unit/transforms/test_hoist_duplicate_branch.py
@@ -107,3 +107,32 @@ def test_non_return_position_unchanged() -> None:
         """
     result = _apply(src, _det_namespace())
     assert result == frog_parser.parse_method(src)
+
+
+def test_f211_mints_fresh_name_over_preexisting_hoist_local() -> None:
+    """F-211(a): when a local named `__hoist_0__` already exists (e.g. minted
+    by an earlier fixed-point iteration and preserved downstream), the pass
+    must mint a FRESH name for the new group rather than emitting a second,
+    differently-valued `__hoist_0__` declaration (a capture-unsafe clobber)."""
+    method = _apply(
+        """
+        BitString<n> O(Bool b, Bool c, BitString<n> x, BitString<n> y) {
+            BitString<n> __hoist_0__ = G.evaluate(x);
+            if (b) { return G.evaluate(y); }
+            if (c) { return G.evaluate(y); }
+            return __hoist_0__;
+        }
+        """,
+        _det_namespace(),
+    )
+    decls = [
+        s
+        for s in method.block.statements
+        if isinstance(s, frog_ast.Assignment)
+        and isinstance(s.var, frog_ast.Variable)
+        and s.var.name == "__hoist_0__"
+    ]
+    # The pre-existing `__hoist_0__` is preserved exactly once; the new group
+    # is named `__hoist_1__`, so its value is not confused with `G.evaluate(x)`.
+    assert len(decls) == 1
+    assert "__hoist_1__" in str(method)

--- a/tests/unit/transforms/test_if_condition_alias.py
+++ b/tests/unit/transforms/test_if_condition_alias.py
@@ -1,7 +1,8 @@
 import pytest
 from proof_frog import frog_ast, frog_parser
 from proof_frog.transforms.control_flow import IfConditionAliasSubstitutionTransformer
-from proof_frog.visitors import SearchVisitor
+from proof_frog.transforms._base import has_nondeterministic_call
+from proof_frog.visitors import SearchVisitor, NameTypeMap
 
 
 def _transform_game(source: str) -> str:
@@ -615,3 +616,53 @@ def test_phase1_inline_still_fires_for_initialize_only_fields() -> None:
     game = frog_parser.parse_game(source)
     result = IfConditionAliasSubstitutionTransformer().transform(game)
     assert result != game, "Initialize-only field alias should still inline"
+
+
+def test_f077_resampled_rf_field_not_substituted_even_with_name_collision() -> None:
+    """F-077: a game field `Hcoll` of Function type that is RE-SAMPLED in an
+    oracle (`Rekey(){ Hcoll <- Function<...> }`) is an adaptive random function;
+    a field `A = Hcoll(B)` defined in Initialize is a stale snapshot once Rekey
+    re-samples, so substituting `return A -> return Hcoll(y)` is unsound.
+
+    The original prosecution route relied on `has_nondeterministic_call`
+    misclassifying `Hcoll` as deterministic when a proof-let `Function Hcoll`
+    shares the name (the _base.py name-only lookup blind spot). This test injects
+    exactly that collision (so `has_nondeterministic_call` returns False) and
+    confirms the pass STILL declines -- the F-075 structural guard subsumes it:
+    the re-sample makes `assign_counts[Hcoll] == 2`, so the "referenced fields
+    must be single-assignment in Initialize" precondition fails regardless. An
+    RF that passes the guards is sampled exactly once in Initialize, hence
+    stable, so no variant slips through."""
+    ftype = frog_ast.FunctionType(
+        frog_ast.IntType(),
+        frog_ast.BitStringType(frog_ast.Variable("n")),
+    )
+    let_types = NameTypeMap()
+    let_types.set("Hcoll", ftype)
+    # Sanity: the collision genuinely defeats has_nondeterministic_call.
+    call = frog_parser.parse_expression("Hcoll(B)")
+    assert has_nondeterministic_call(call, {}, let_types) is False
+
+    game = frog_parser.parse_game(
+        """
+        Game Real(Int n) {
+            Function<Int, BitString<n>> Hcoll;
+            BitString<n> A;
+            Int B;
+            Void Initialize() {
+                B = 1;
+                Hcoll <- Function<Int, BitString<n>>;
+                A = Hcoll(B);
+            }
+            Void Rekey() { Hcoll <- Function<Int, BitString<n>>; }
+            BitString<n> Test(Int y) {
+                if (y == B) { return A; }
+                return A;
+            }
+        }
+        """
+    )
+    result = IfConditionAliasSubstitutionTransformer(
+        proof_namespace={}, proof_let_types=let_types
+    ).transform(game)
+    assert result == game, "re-sampled RF field must not be substituted"

--- a/tests/unit/transforms/test_if_condition_alias.py
+++ b/tests/unit/transforms/test_if_condition_alias.py
@@ -666,3 +666,30 @@ def test_f077_resampled_rf_field_not_substituted_even_with_name_collision() -> N
         proof_namespace={}, proof_let_types=let_types
     ).transform(game)
     assert result == game, "re-sampled RF field must not be substituted"
+
+
+def test_f078_array_element_write_between_guard_and_use_declines() -> None:
+    """F-078: the array element-write spelling `if (x == F[0]) { F[0] = 99;
+    return F[0]; }` must not substitute `return F[0]` via the `x == F[0]` guard
+    alias -- the element write `F[0] = 99` changes F[0], so the aliased value is
+    stale. Closed by the F-075 complete `reassigns_or_rebinds` scan, which sees
+    the element write. (The Array spelling is typechecker-latent; the Map
+    spelling of the same hole is covered by the F-075 A3/A5 fixes.)"""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Array<Int, 2> F;
+            Int O(Int x) {
+                if (x == F[0]) {
+                    F[0] = 99;
+                    return F[0];
+                }
+                return 0;
+            }
+        }
+        """
+    )
+    result = IfConditionAliasSubstitutionTransformer(
+        proof_namespace={}, proof_let_types=NameTypeMap()
+    ).transform(game)
+    assert result == game, "an element write must stop the guard-alias substitution"

--- a/tests/unit/transforms/test_if_false_return_to_conjunction.py
+++ b/tests/unit/transforms/test_if_false_return_to_conjunction.py
@@ -281,3 +281,32 @@ def test_fires_when_intervening_decl_does_not_touch_guard_vars() -> None:
     game = frog_parser.parse_game(source)
     result = IfFalseReturnToConjunction().apply(game, _ctx())
     assert result != game  # fired
+
+
+def test_f117_return_none_not_absorbed() -> None:
+    """F-117: the trailing-return guard used a Python ``is None`` test, which
+    does not catch a FrogLang ``None`` literal. A well-typed ``Bool?`` oracle
+    returning ``None`` was absorbed into the type-invalid ``!P && None``. It must
+    now decline."""
+    source = """
+    Game G() {
+        Bool? O(Bool p) {
+            if (p) { return false; }
+            return None;
+        }
+    }
+    """
+    assert _apply(source) == frog_parser.parse_game(source)  # unchanged
+
+
+def test_f117_boolean_trailing_still_absorbed() -> None:
+    """Control for F-117: a genuine boolean trailing return still absorbs."""
+    source = """
+    Game G() {
+        Bool O(Bool p, Bool q) {
+            if (p) { return false; }
+            return q;
+        }
+    }
+    """
+    assert _apply(source) != frog_parser.parse_game(source)  # absorbed

--- a/tests/unit/transforms/test_if_split_branch_assignment.py
+++ b/tests/unit/transforms/test_if_split_branch_assignment.py
@@ -204,3 +204,47 @@ def test_if_split_branch_assignment(
     print("EXPECTED", expected_ast)
     print("TRANSFORMED", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def test_f160_declines_when_branch_value_free_var_reassigned() -> None:
+    """F-160: `x = y` in a branch, then `y = y + 1` in the tail before `x` is
+    read. Substituting the branch value `y` into the tail would read the
+    mutated `y`, not the branch-time value -- so the split must decline."""
+    method = frog_parser.parse_method(
+        """
+        Int Oracle(Bool c) {
+            Int y = 5;
+            Int x;
+            if (c) {
+                x = y;
+            } else {
+                x = 0;
+            }
+            y = y + 1;
+            return x * 100 + y;
+        }
+        """
+    )
+    out = str(IfSplitBranchAssignmentTransformer().transform(method))
+    assert "x = y" in out  # not split/substituted
+
+
+def test_f160_still_splits_when_free_var_stable() -> None:
+    """Positive control: no reassignment of the branch value's free var in the
+    tail -> the split still fires."""
+    method = frog_parser.parse_method(
+        """
+        Int Oracle(Bool c) {
+            Int y = 5;
+            Int x;
+            if (c) {
+                x = y;
+            } else {
+                x = 0;
+            }
+            return x * 100 + y;
+        }
+        """
+    )
+    out = str(IfSplitBranchAssignmentTransformer().transform(method))
+    assert "x = y" not in out  # split: x substituted by its branch value

--- a/tests/unit/transforms/test_if_split_branch_assignment.py
+++ b/tests/unit/transforms/test_if_split_branch_assignment.py
@@ -155,6 +155,34 @@ from proof_frog.transforms.inlining import IfSplitBranchAssignmentTransformer
             }
             """,
         ),
+        # F-161: an element write to the branch variable (`x[0] = 5`, an
+        # ArrayAccess l-value) is a reassignment and must block the fold --
+        # otherwise the write would be moved into each branch with `x`
+        # substituted by its branch value, mutating that branch value.
+        (
+            """
+            Int f(Bool cond, Array<Int, 2> a, Array<Int, 2> b) {
+                if (cond) {
+                    Array<Int, 2> x = a;
+                } else {
+                    Array<Int, 2> x = b;
+                }
+                x[0] = 5;
+                return x[1];
+            }
+            """,
+            """
+            Int f(Bool cond, Array<Int, 2> a, Array<Int, 2> b) {
+                if (cond) {
+                    Array<Int, 2> x = a;
+                } else {
+                    Array<Int, 2> x = b;
+                }
+                x[0] = 5;
+                return x[1];
+            }
+            """,
+        ),
     ],
     ids=[
         "basic_typed",
@@ -163,6 +191,7 @@ from proof_frog.transforms.inlining import IfSplitBranchAssignmentTransformer
         "no_op_different_vars",
         "no_op_no_subsequent",
         "removes_preceding_declaration",
+        "no_op_element_write_to_var",
     ],
 )
 def test_if_split_branch_assignment(

--- a/tests/unit/transforms/test_if_to_boolean_assignment.py
+++ b/tests/unit/transforms/test_if_to_boolean_assignment.py
@@ -179,3 +179,63 @@ def test_both_decls_with_later_reference_declines() -> None:
         nm.transform_name == "If To Boolean Assignment" and "capture" in nm.reason
         for nm in ctx.near_misses
     )
+
+
+def test_f085_noncanonical_boolean_payloads_compared_by_truth_value() -> None:
+    """F-085: the differing-literal guard compares branch bools by TRUTH VALUE,
+    not raw Python payload. A non-canonical ``Boolean(2)`` (truthy) vs
+    ``Boolean(True)`` both mean ``true``; the pass must NOT merge them into
+    ``x = c`` (a probability-changing rewrite). Only a future transform could
+    produce such a payload; the parser always builds genuine bools."""
+    from proof_frog.transforms.control_flow import IfToBooleanAssignmentTransformer
+
+    cond = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, frog_ast.Variable("a"), frog_ast.Integer(1)
+    )
+    stmt = frog_ast.IfStatement(
+        [cond],
+        [
+            frog_ast.Block(
+                [frog_ast.Assignment(None, frog_ast.Variable("x"), frog_ast.Boolean(2))]
+            ),
+            frog_ast.Block(
+                [
+                    frog_ast.Assignment(
+                        None, frog_ast.Variable("x"), frog_ast.Boolean(True)
+                    )
+                ]
+            ),
+        ],
+    )
+    block = frog_ast.Block([stmt, frog_ast.ReturnStatement(frog_ast.Variable("x"))])
+    assert IfToBooleanAssignmentTransformer().transform(block) == block  # declined
+
+
+def test_f085_genuine_true_false_still_merges() -> None:
+    """Control for F-085: a genuine true/false pair still collapses to x = c."""
+    from proof_frog.transforms.control_flow import IfToBooleanAssignmentTransformer
+
+    cond = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EQUALS, frog_ast.Variable("a"), frog_ast.Integer(1)
+    )
+    stmt = frog_ast.IfStatement(
+        [cond],
+        [
+            frog_ast.Block(
+                [
+                    frog_ast.Assignment(
+                        None, frog_ast.Variable("x"), frog_ast.Boolean(True)
+                    )
+                ]
+            ),
+            frog_ast.Block(
+                [
+                    frog_ast.Assignment(
+                        None, frog_ast.Variable("x"), frog_ast.Boolean(False)
+                    )
+                ]
+            ),
+        ],
+    )
+    block = frog_ast.Block([stmt, frog_ast.ReturnStatement(frog_ast.Variable("x"))])
+    assert IfToBooleanAssignmentTransformer().transform(block) != block  # merged

--- a/tests/unit/transforms/test_injective_equality_group_exp.py
+++ b/tests/unit/transforms/test_injective_equality_group_exp.py
@@ -289,3 +289,68 @@ def test_different_exponents_does_not_fire() -> None:
     """
     got = _apply(source, _ctx([_prime_req()]))
     assert got == frog_parser.parse_game(source), str(got)
+
+
+def test_f249_method_param_not_resolved_as_group_elem() -> None:
+    """F-249: `_expr_is_group_elem_on_game` must NOT type a bare variable by a
+    method PARAMETER -- a param is local to its method, and scanning every
+    method would launder a `GroupElem<G1>` param in one method onto a
+    same-named `GroupElem<G2>` operand in another (applying G1's prime-order
+    certificate to a composite-order G2 and rewriting `x^k == y^k -> x == y`)."""
+    from proof_frog.transforms._wrappers import _expr_is_group_elem_on_game
+
+    game = frog_parser.parse_game(
+        """
+        Game G(Group G1, Group G2) {
+            GroupElem<G1> Probe(GroupElem<G1> x) {
+                return x;
+            }
+            Bool Test(GroupElem<G2> x) {
+                return x == x;
+            }
+        }
+        """
+    )
+    # `x` is only a method parameter (GroupElem<G1> in Probe, GroupElem<G2> in
+    # Test) -- not a game field/parameter -- so it must not resolve.
+    assert _expr_is_group_elem_on_game(frog_ast.Variable("x"), game) is None
+
+
+def test_f249_game_field_still_resolved_as_group_elem() -> None:
+    """Positive control: a game FIELD typed GroupElem<G> (truly global) still
+    resolves to its group."""
+    from proof_frog.transforms._wrappers import _expr_is_group_elem_on_game
+
+    game = frog_parser.parse_game(
+        """
+        Game G(Group G1) {
+            GroupElem<G1> fld;
+            Bool Test() {
+                return fld == fld;
+            }
+        }
+        """
+    )
+    assert _expr_is_group_elem_on_game(frog_ast.Variable("fld"), game) is not None
+
+
+def test_f249_agreeing_method_params_resolve() -> None:
+    """Narrowed control: when every method that declares a same-named GroupElem
+    parameter agrees on the SAME group, the type is unambiguous and resolves
+    (so legitimate method-param group operands still work, e.g. HashedElGamal)."""
+    from proof_frog.transforms._wrappers import _expr_is_group_elem_on_game
+
+    game = frog_parser.parse_game(
+        """
+        Game G(Group G1) {
+            GroupElem<G1> A(GroupElem<G1> x) {
+                return x;
+            }
+            Bool B(GroupElem<G1> x) {
+                return x == x;
+            }
+        }
+        """
+    )
+    # `x` is a GroupElem<G1> parameter in BOTH methods -> unambiguous -> resolves.
+    assert _expr_is_group_elem_on_game(frog_ast.Variable("x"), game) is not None

--- a/tests/unit/transforms/test_injective_equality_simplify.py
+++ b/tests/unit/transforms/test_injective_equality_simplify.py
@@ -294,3 +294,91 @@ def test_single_arg_call_rewrites() -> None:
     """
     result, _ = _apply(source, _ns(ns_src))
     assert result == frog_parser.parse_game(expected)
+
+
+# --------------------------------------------------------------------------
+# Value-stability of resolved bindings (audit F-247 / F-248)
+# --------------------------------------------------------------------------
+
+NS_INJ_ENC = """
+Primitive T(Int n) {
+    deterministic injective BitString<n> Enc1(BitString<n> x);
+}
+"""
+
+
+def test_f247_nested_write_binding_not_resolved() -> None:
+    """A local binding `w = T.Enc1(x)` whose arg `x` is reassigned inside an
+    if-body is NOT write-once; resolving `w == T.Enc1(x)` to `x == x` would be
+    unsound (the nested write is invisible to a top-level-only scan)."""
+    source = """
+    Game G(Int n) {
+        Bool Test(Bool c) {
+            BitString<n> x = 0^n;
+            BitString<n> w = T.Enc1(x);
+            if (c) {
+                x = 1^n;
+            }
+            return w == T.Enc1(x);
+        }
+    }
+    """
+    result, _ = _apply(source, _ns(NS_INJ_ENC))
+    assert "w == T.Enc1(x)" in str(result)  # not collapsed to x == x
+
+
+def test_f247_stable_arg_binding_still_resolves() -> None:
+    """Positive control: no reassignment of `x`, so `w == T.Enc1(x)` resolves
+    and the injective rewrite fires."""
+    source = """
+    Game G(Int n) {
+        Bool Test(BitString<n> x) {
+            BitString<n> w = T.Enc1(x);
+            return w == T.Enc1(x);
+        }
+    }
+    """
+    result, _ = _apply(source, _ns(NS_INJ_ENC))
+    assert "x == x" in str(result)
+
+
+def test_f248_mutated_field_rhs_not_resolved() -> None:
+    """A field `F = T.Enc1(t)` frozen at Init must not be resolved to its RHS
+    at a site where the free field `t` has since been mutated -- that would
+    collapse `F == T.Enc1(t)` to `t == t` though F holds the stale value."""
+    source = """
+    Game G(Int n) {
+        BitString<n> t;
+        BitString<n> F;
+        Void Initialize() {
+            t = 0^n;
+            F = T.Enc1(t);
+        }
+        Bool Test() {
+            t = 1^n;
+            return F == T.Enc1(t);
+        }
+    }
+    """
+    result, _ = _apply(source, _ns(NS_INJ_ENC))
+    assert "F == T.Enc1(t)" in str(result)  # not collapsed to t == t
+
+
+def test_f248_immutable_field_rhs_still_resolves() -> None:
+    """Positive control: `t` is never mutated after Init, so F resolves to its
+    RHS and the injective comparison collapses."""
+    source = """
+    Game G(Int n) {
+        BitString<n> t;
+        BitString<n> F;
+        Void Initialize() {
+            t = 0^n;
+            F = T.Enc1(t);
+        }
+        Bool Test() {
+            return F == T.Enc1(t);
+        }
+    }
+    """
+    result, _ = _apply(source, _ns(NS_INJ_ENC))
+    assert "t == t" in str(result)

--- a/tests/unit/transforms/test_inline_single_use_field.py
+++ b/tests/unit/transforms/test_inline_single_use_field.py
@@ -594,3 +594,35 @@ def test_cross_method_inline_declines_on_element_mutated_free_var() -> None:
     """
     # A must NOT be inlined to B: the game is unchanged.
     _transform_and_compare(source, source)
+
+
+def test_f219_field_used_in_another_field_type_not_inlined() -> None:
+    """F-219: a field used only inside another field's declared TYPE (`q` in
+    `Array<Int, q>`) is a type parameter -- genuine array-size state -- not a
+    value use. The whole-game use scan counts it, but replacement rewrites only
+    method bodies, so inlining would delete `q`'s definition and declaration
+    while leaving a dangling `Array<Int, q>`. The pass must decline (the field
+    survives unchanged)."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int q;
+            Array<Int, q> arr;
+            Void Initialize() {
+                q = 8;
+            }
+            Int Count() {
+                Int c = 0;
+                for (Int i in arr) {
+                    c = c + 1;
+                }
+                return c;
+            }
+        }
+        """
+    )
+    result = InlineSingleUseFieldTransformer().transform(game)
+    out = str(result)
+    assert "Int q;" in out, "field q's declaration must survive"
+    assert "q = 8" in out, "field q's defining assignment must survive"
+    assert "Array<Int, q>" in out, "the array type must not be left dangling"

--- a/tests/unit/transforms/test_inline_single_use_field_cross_method.py
+++ b/tests/unit/transforms/test_inline_single_use_field_cross_method.py
@@ -1,0 +1,48 @@
+"""Regression test: cross-method field inlining requires the def in Initialize.
+
+InlineSingleUseField substitutes a single-assignment field's definition into
+its uses. When the use is in a DIFFERENT method, that is sound only if the
+definition runs before any oracle can observe the field -- i.e. it is in
+Initialize. A definition in an oracle can be observed uninitialized if the
+adversary calls the using-oracle first (audit F-216).
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import InlineSingleUseFieldTransformer
+
+
+def _after(src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(InlineSingleUseFieldTransformer().transform(game))
+
+
+def test_f216_declines_cross_method_when_def_in_oracle() -> None:
+    # `b = 5` in Store, `return b` in Get. A Get-before-Store call reads an
+    # uninitialized b, so `return b` must NOT be inlined to `return 5`.
+    after = _after(
+        """
+        Game G() {
+            Int b;
+            Void Initialize() { }
+            Int Store() { b = 5; return 0; }
+            Int Get() { return b; }
+        }
+        """
+    )
+    assert "b = 5" in after  # field survives; not inlined
+
+
+def test_f216_inlines_cross_method_when_def_in_initialize() -> None:
+    # `b = 5` in Initialize (runs before any oracle) -> inlining `return b`
+    # to `return 5` is sound. Positive control.
+    after = _after(
+        """
+        Game G() {
+            Int b;
+            Void Initialize() { b = 5; }
+            Int Get() { return b; }
+        }
+        """
+    )
+    assert "return 5" in after
+    assert "b = 5" not in after

--- a/tests/unit/transforms/test_inline_single_use_field_interference.py
+++ b/tests/unit/transforms/test_inline_single_use_field_interference.py
@@ -71,3 +71,29 @@ def test_f214_still_inlines_without_interference() -> None:
     )
     assert "Int A;" not in after
     assert "return 5;" in after
+
+
+def test_f215_declines_write_inside_compound_last_use_statement() -> None:
+    # A = ctr; if (c) { ctr = 100; return A; } -- the free var `ctr` is written
+    # INSIDE the compound last-use statement, before the use of A within it. The
+    # step-5 scan slice `[def+1 : last_use]` excluded that statement, so the
+    # write escaped and inlining A -> ctr would read the post-write value (100).
+    # The field must survive (no inline).
+    after = _after(
+        """
+        Game G() {
+            Int ctr;
+            Int A;
+            Int O(Bool c) {
+                ctr = 0;
+                A = ctr;
+                if (c) {
+                    ctr = 100;
+                    return A;
+                }
+                return 0;
+            }
+        }
+        """
+    )
+    assert "Int A;" in after, "field must not inline past a write in its last-use statement"

--- a/tests/unit/transforms/test_inline_single_use_field_interference.py
+++ b/tests/unit/transforms/test_inline_single_use_field_interference.py
@@ -1,0 +1,73 @@
+"""Regression tests for InlineSingleUseField's step-5 interference scan (F-214).
+
+Inlining a single-use field across an intermediate window is unsound if that
+window mutates the field. The private scan matched only a bare `name = ...`
+lvalue, so a nested element write (`M[0]=1`) or a `<-uniq[S]` insertion that
+grows `S` slipped through and the field was inlined past its own mutation
+(reading a stale value). The scan now routes through the complete shared
+`reassigns_or_rebinds` helper.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import InlineSingleUseFieldTransformer
+
+
+def _after(src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(InlineSingleUseFieldTransformer().transform(game))
+
+
+def test_f214_declines_inline_past_element_write() -> None:
+    # A = |M|; M[0] = 1; return A  -- inlining A past the element write would
+    # read the post-write |M|. The field must survive (no inline).
+    after = _after(
+        """
+        Game G() {
+            Map<Int, Int> M;
+            Int A;
+            Int O() {
+                A = |M|;
+                M[0] = 1;
+                return A;
+            }
+        }
+        """
+    )
+    assert "Int A;" in after
+
+
+def test_f214_declines_inline_past_uniq_growth() -> None:
+    # A = |S|; x <-uniq[S] BitString<n>; return A -- the uniq draw grows S,
+    # so inlining A past it reads the post-growth |S|. Field must survive.
+    after = _after(
+        """
+        Game G(Int n) {
+            Set<BitString<n>> S;
+            Int A;
+            Int O() {
+                A = |S|;
+                BitString<n> x <-uniq[S] BitString<n>;
+                return A;
+            }
+        }
+        """
+    )
+    assert "Int A;" in after
+
+
+def test_f214_still_inlines_without_interference() -> None:
+    # A = 5; return A -- no interference, the field is single-use and inlined
+    # away (positive control: the guard is not over-declining).
+    after = _after(
+        """
+        Game G() {
+            Int A;
+            Int O() {
+                A = 5;
+                return A;
+            }
+        }
+        """
+    )
+    assert "Int A;" not in after
+    assert "return 5;" in after

--- a/tests/unit/transforms/test_inline_single_use_field_uniq.py
+++ b/tests/unit/transforms/test_inline_single_use_field_uniq.py
@@ -1,0 +1,59 @@
+"""Regression test: InlineSingleUseField counts `<-uniq[S]` insertion (F-212/213).
+
+A `<-uniq[S]` draw implicitly inserts the drawn value into the exclusion set
+`S`, so a set field used as a uniq domain is mutated on every draw. The
+single-use-field check counted only lvalue writes, so it treated such a set as
+single-assignment and either eliminated it -- rewriting `<-uniq[S]` to
+`<-uniq[{}]` and destroying distinctness (F-212) -- or inlined a stale snapshot
+of it across methods (F-213).
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import InlineSingleUseFieldTransformer
+
+
+def _after(src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(InlineSingleUseFieldTransformer().transform(game))
+
+
+def test_f212_uniq_exclusion_set_not_eliminated() -> None:
+    # S is assigned once (`S = {}`) and used as a uniq exclusion set. The draw
+    # grows S, so S is NOT single-assignment and must not be inlined to `{}`.
+    after = _after(
+        """
+        Game G(Int n) {
+            Set<BitString<n>> S;
+            Void Initialize() { S = {}; }
+            BitString<n> Draw() {
+                BitString<n> x <-uniq[S] BitString<n>;
+                return x;
+            }
+        }
+        """
+    )
+    # S survives; the draw still excludes S (not rewritten to `<-uniq[{}]`).
+    assert "Set<BitString<n>> S" in after
+    assert "<-uniq[{}]" not in after
+    assert "<-uniq[S]" in after
+
+
+def test_f213_uniq_set_snapshot_not_inlined_cross_method() -> None:
+    # A = S in Initialize, then S grows via a uniq draw in another oracle.
+    # Inlining A's snapshot of S cross-method would read a stale (empty) S.
+    after = _after(
+        """
+        Game G(Int n) {
+            Set<BitString<n>> S;
+            Set<BitString<n>> A;
+            Void Initialize() { S = {}; A = S; }
+            BitString<n> Draw() {
+                BitString<n> x <-uniq[S] BitString<n>;
+                return x;
+            }
+            Int Count() { return |A|; }
+        }
+        """
+    )
+    # A is not eliminated (its snapshot is not a stable single value).
+    assert "A = S" in after

--- a/tests/unit/transforms/test_inline_single_use_field_view.py
+++ b/tests/unit/transforms/test_inline_single_use_field_view.py
@@ -1,0 +1,56 @@
+"""Regression test: InlineSingleUseField must see view-carried reads (F-218).
+
+A field RHS like `0 in M.keys` reads the map `M` only through a `.keys`
+FieldAccess. The old free-var scan (VariableCollectionVisitor) skipped
+variables under a FieldAccess, so the read-set was EMPTY and both stability
+gates became vacuous -- letting the field inline cross-method into an oracle
+even though another oracle mutates `M`, so the inlined `0 in M.keys` reads the
+live view instead of the Initialize-time snapshot. The FieldAccess-complete
+`referenced_variable_names` now contributes `M`, so the stability gate declines.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import InlineSingleUseFieldTransformer
+
+
+def test_f218_view_carried_read_blocks_cross_method_inline() -> None:
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Map<Int, Int> M;
+            Bool A;
+            Void Initialize() { A = 0 in M.keys; }
+            Void Put() { M[0] = 1; }
+            Bool Get() { return A; }
+        }
+        """
+    )
+    out = str(InlineSingleUseFieldTransformer().transform(game))
+    # A must NOT be inlined into Get(): `M` is mutated in Put(), so the field's
+    # Initialize-time value is not stable.
+    assert "A = 0 in M.keys" in out
+    assert "return A" in out
+
+
+def test_f218_plain_stable_field_read_still_inlines() -> None:
+    """Positive control: a field whose RHS reads a plain, stably-assigned field
+    still inlines cross-method -- the FieldAccess-complete read-set does not
+    over-decline ordinary (non-view) reads."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int x;
+            Int A;
+            Void Initialize() {
+                x = 3;
+                A = x + 1;
+            }
+            Int Get() { return A; }
+        }
+        """
+    )
+    out = str(InlineSingleUseFieldTransformer().transform(game))
+    # A is inlined into Get() (its value flows through), so the field and its
+    # `return A` are gone -- ordinary reads are not over-declined.
+    assert "return A" not in out
+    assert "Int A" not in out

--- a/tests/unit/transforms/test_inlining_capture.py
+++ b/tests/unit/transforms/test_inlining_capture.py
@@ -1,0 +1,251 @@
+"""Regression tests: inlining passes must not capture a free variable.
+
+Name-based inlining is unsound when a `for` binder (or same-named local) at the
+substitution site shadows a free variable of the inlined expression: after
+inlining, that free variable reads the binder instead of its outer binding.
+AlphaRename leaves loop binders in place, so the capture survives
+canonicalization. (Audit RC4: F-150 and siblings.)
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import InlineSingleUseVariable
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _apply(src: str) -> str:
+    return str(InlineSingleUseVariable().apply(frog_parser.parse_game(src), _ctx()))
+
+
+def test_f150_loop_binder_capture_declined() -> None:
+    """`v = i + 1` (field i) must not inline into a `for (Int i = ...)` body:
+    the binder `i` would capture the field reference."""
+    out = _apply(
+        """
+        Game G(Int n) {
+            Int i;
+            Int Probe() {
+                Int total = 0;
+                Int v = i + 1;
+                for (Int i = 0 to 2) {
+                    total = total + v;
+                }
+                return total;
+            }
+        }
+        """
+    )
+    assert "Int v = i + 1" in out  # not inlined into the loop body
+
+
+def test_f150_no_capture_still_inlines() -> None:
+    """Positive control: a differently-named binder does not capture, so the
+    single-use variable still inlines."""
+    out = _apply(
+        """
+        Game G(Int n) {
+            Int i;
+            Int Probe() {
+                Int total = 0;
+                Int v = i + 1;
+                for (Int j = 0 to 2) {
+                    total = total + v;
+                }
+                return total;
+            }
+        }
+        """
+    )
+    assert "Int v = i + 1" not in out  # inlined
+    assert "total + (i + 1)" in out
+
+
+# ---------------------------------------------------------------------------
+# Shadow-aware movers (RC4: F-169/F-173/F-178/F-190/F-210/F-228)
+# ---------------------------------------------------------------------------
+
+from proof_frog.transforms.inlining import (  # noqa: E402
+    HoistDeterministicCallToInitialize,
+    HoistDuplicateBranchCall,
+    CrossMethodFieldAlias,
+    SplitOpaqueTupleField,
+    HoistGroupExpToInitialize,
+    InlineSingleUseField,
+    _method_bound_names,
+    _name_shadowed_in_method,
+)
+
+
+def _det_ns():
+    prim = frog_parser.parse_primitive_file(
+        """
+        Primitive P() {
+            deterministic Int f(Int x);
+        }
+        """
+    )
+    return {"E": prim}
+
+
+def _apply_pass(pass_obj, src, ns=None):
+    game = frog_parser.parse_game(src)
+    ctx = PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace=ns or {},
+        subsets_pairs=[],
+    )
+    return str(pass_obj.apply(game, ctx))
+
+
+def test_method_bound_names_only_new_bindings() -> None:
+    """Params, typed locals, and for-binders bind; a plain field write does
+    not (it mutates the field in scope)."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int n) {
+            Int fld;
+            Int O(Int p) {
+                fld = 3;
+                Int loc = 4;
+                for (Int i = 0 to 2) { fld = fld + i; }
+                return fld;
+            }
+        }
+        """
+    )
+    bound = _method_bound_names(game.methods[0])
+    assert "p" in bound and "loc" in bound and "i" in bound
+    assert "fld" not in bound  # plain field write is not a new binding
+    assert not _name_shadowed_in_method(game.methods[0], "fld")
+
+
+def test_f173_stable_arg_shadowed_by_param_not_hoisted() -> None:
+    """HoistDeterministicCallToInitialize must not treat `E.f(k)` as stable
+    when `k` is a method parameter shadowing the field `k`."""
+    out = _apply_pass(
+        HoistDeterministicCallToInitialize(),
+        """
+        Game G() {
+            Int k;
+            Void Initialize() { k = 1; }
+            Int Chal(Int k) { return E.f(k); }
+        }
+        """,
+        _det_ns(),
+    )
+    assert "_hoisted" not in out  # the shadowed-arg call is not hoisted
+
+
+def test_f178_forbinder_shadow_blocks_alias() -> None:
+    """CrossMethodFieldAlias must not splice `Variable(stored)` into a method
+    whose `for` binder is named `stored`."""
+    out = _apply_pass(
+        CrossMethodFieldAlias(),
+        """
+        Game G() {
+            Int stored;
+            Void Initialize() { stored = E.f(0); }
+            Int Oracle() {
+                Int acc = 0;
+                for (Int stored = 0 to 2) { acc = acc + E.f(0); }
+                return acc;
+            }
+        }
+        """,
+        _det_ns(),
+    )
+    # The oracle's E.f(0) is inside a `for (Int stored ...)`, so it is not
+    # replaced by the field `stored`.
+    assert "acc = acc + E.f(0)" in out
+
+
+def test_f190_param_shadow_blocks_tuple_split() -> None:
+    """SplitOpaqueTupleField must decline when a method parameter shadows the
+    tuple field name."""
+    out = _apply_pass(
+        SplitOpaqueTupleField(),
+        """
+        Game G() {
+            [Int, Int] pair;
+            Void Initialize() { pair = E.pair(); }
+            Int Echo([Int, Int] pair) { return pair[0]; }
+            Int Use() { return pair[1]; }
+        }
+        """,
+        {
+            "E": frog_parser.parse_primitive_file(
+                "Primitive P() { deterministic [Int, Int] pair(); }"
+            )
+        },
+    )
+    # `pair` is shadowed by Echo's parameter, so the field is not split.
+    assert "__split" not in out and "pair_0" not in out
+
+
+def test_f210_loop_binder_arg_not_hoisted_but_field_arg_is() -> None:
+    """HoistDuplicateBranchCall must not hoist a call whose argument is a loop
+    binder, but must still hoist one whose arg is a field."""
+    declined = _apply_pass(
+        HoistDuplicateBranchCall(),
+        """
+        Game G() {
+            Int O(Bool b) {
+                Int acc = 0;
+                for (Int i = 0 to 2) {
+                    if (b) { acc = acc + E.f(i); }
+                    else { acc = acc + E.f(i); }
+                }
+                return acc;
+            }
+        }
+        """,
+        _det_ns(),
+    )
+    assert "__hoist" not in declined  # loop-binder arg: not hoisted
+
+
+def test_f228_param_shadow_blocks_group_exp_hoist() -> None:
+    """HoistGroupExpToInitialize must not freeze `h ^ e` when `e` is a method
+    parameter shadowing the field `e`."""
+    out = _apply_pass(
+        HoistGroupExpToInitialize(),
+        """
+        Game G(Group Grp) {
+            GroupElem<Grp> h;
+            Int e;
+            Void Initialize() { e = 1; h = Grp.generator; }
+            GroupElem<Grp> Chal(Int e) { return h ^ e; }
+        }
+        """,
+    )
+    assert "_hge" not in out  # shadowed exponent not hoisted
+
+
+def test_f228_route2_field_not_inlined_into_shadowed_param() -> None:
+    """InlineSingleUseField must not inline field `e` into `Chal`'s `h ^ e`
+    where `e` is the shadowing parameter (F-228 route 2)."""
+    out = _apply_pass(
+        InlineSingleUseField(),
+        """
+        Game G(Group Grp) {
+            GroupElem<Grp> h;
+            Int e;
+            Void Initialize() { e = 1; h = Grp.generator; }
+            GroupElem<Grp> Chal(Int e) { return h ^ e; }
+        }
+        """,
+    )
+    # The field `h` may inline (Grp.generator), but the exponent must stay the
+    # parameter `e` -- the field `e`'s value (1) must NOT be substituted in.
+    assert "^ e" in out
+    assert "^ 1" not in out

--- a/tests/unit/transforms/test_inlining_control_flow_barrier.py
+++ b/tests/unit/transforms/test_inlining_control_flow_barrier.py
@@ -1,0 +1,85 @@
+"""Regression tests: field-write relocation must respect control-flow exits.
+
+Both passes relocate a field write earlier in a method. If an early `return`
+sits between the new and old positions, the field would be written on a trace
+where the original never wrote it -- observable by another oracle.
+
+  - F-197 RedundantFieldCopy: `v <- ...; if (b) { return w; } f = v;` must not
+    become `f <- ...; if (b) { return w; }` (writes f on the b-path).
+  - F-165 HoistFieldPureAlias: `g = A[0]+1; if (b) { return 0; } f = A[0];`
+    must not hoist `f = A[0]` above the early return.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import RedundantFieldCopy, HoistFieldPureAlias
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _fires(pass_obj, src: str) -> bool:
+    game = frog_parser.parse_game(src)
+    return str(pass_obj.apply(game, _ctx())) != str(game)
+
+
+def test_f197_redundant_field_copy_declines_across_early_return() -> None:
+    assert not _fires(
+        RedundantFieldCopy(),
+        """
+        Game G(Int n) {
+            BitString<n> f;
+            Set<BitString<n>> S;
+            BitString<n> Store(Bool b, BitString<n> w) {
+                BitString<n> v <-uniq[S] BitString<n>;
+                if (b) { S = S union w; return w; }
+                f = v;
+                return w;
+            }
+        }
+        """,
+    )
+
+
+def test_f197_redundant_field_copy_still_fires_without_early_return() -> None:
+    # No early return -> the redundant copy is eliminated.
+    assert _fires(
+        RedundantFieldCopy(),
+        """
+        Game G(Int n) {
+            BitString<n> f;
+            BitString<n> Store(BitString<n> w) {
+                BitString<n> v = w;
+                f = v;
+                return w;
+            }
+        }
+        """,
+    )
+
+
+def test_f165_hoist_field_pure_alias_declines_across_early_return() -> None:
+    assert not _fires(
+        HoistFieldPureAlias(),
+        """
+        Game G() {
+            Map<Int, Int> A;
+            Int f;
+            Int g;
+            Int O1(Bool b) {
+                g = A[0] + 1;
+                if (b) { return 0; }
+                f = A[0];
+                return g;
+            }
+            Int O2() { return f; }
+        }
+        """,
+    )

--- a/tests/unit/transforms/test_inlining_field_and_use_scan.py
+++ b/tests/unit/transforms/test_inlining_field_and_use_scan.py
@@ -1,0 +1,110 @@
+"""Regression tests for three family-4 inlining interference gaps.
+
+- F-144 CollapseAssignment: two field stores must not collapse across an
+  intervening control-flow exit (the first store is live on the early-return
+  path, observable by a later oracle). Locals stay collapsible.
+- F-159 IfSplitBranchAssignment: dropping each branch's trailing `x = A` store
+  is unsound when `x` is a field (persists across calls); the pass fires only
+  for locals.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import (
+    CollapseAssignment,
+    IfSplitBranchAssignment,
+)
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _run(pass_obj, src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(pass_obj.apply(game, _ctx()))
+
+
+# ---- F-144 CollapseAssignment ----
+
+
+def test_f144_field_stores_not_collapsed_across_return() -> None:
+    out = _run(
+        CollapseAssignment(),
+        """
+        Game G() {
+            Int f;
+            Int Store(Bool b) {
+                f = 0;
+                if (b) { return 1; }
+                f = 1;
+                return f;
+            }
+            Int Get() { return f; }
+        }
+        """,
+    )
+    # Both field stores survive: `f = 0` is NOT deleted.
+    assert "f = 0" in out
+
+
+def test_f144_local_stores_still_collapse() -> None:
+    out = _run(
+        CollapseAssignment(),
+        """
+        Game G() {
+            Int O() {
+                Int v = 0;
+                v = 1;
+                return v;
+            }
+        }
+        """,
+    )
+    # `Int v = 0` collapses into `Int v = 1`.
+    assert "v = 0" not in out
+    assert "v = 1" in out
+
+
+# ---- F-159 IfSplitBranchAssignment ----
+
+
+def test_f159_field_branch_assignment_not_dropped() -> None:
+    out = _run(
+        IfSplitBranchAssignment(),
+        """
+        Game G() {
+            Int x;
+            Int Store(Bool c) {
+                if (c) { x = 1; } else { x = 2; }
+                return x;
+            }
+            Int Get() { return x; }
+        }
+        """,
+    )
+    # The field stores are retained (pass declines): `x = 1` / `x = 2` survive.
+    assert "x = 1" in out and "x = 2" in out
+
+
+def test_f159_local_branch_assignment_still_splits() -> None:
+    out = _run(
+        IfSplitBranchAssignment(),
+        """
+        Game G() {
+            Int Store(Bool c) {
+                Int x;
+                if (c) { x = 1; } else { x = 2; }
+                return x;
+            }
+        }
+        """,
+    )
+    # Local x: the pass fires, substituting the value into the moved return.
+    assert "return 1" in out and "return 2" in out

--- a/tests/unit/transforms/test_inlining_nested_arg_purity.py
+++ b/tests/unit/transforms/test_inlining_nested_arg_purity.py
@@ -1,0 +1,52 @@
+"""Regression tests: purity gates see through nested call arguments.
+
+A "deterministic" outer call whose ARGUMENT contains a non-deterministic
+(abstract-primitive) call is itself non-deterministic (i.i.d. per ruling
+7.A.6). Passes that inline such a call by treating the outer call as pure
+correlate independent draws. This pins the nested-argument gate for
+InlineMultiUsePureExpression (F-194). (F-202, the analogous fix in the shared
+`_DeterministicCallCollector`, is deferred -- it broke two CFRG proofs.)
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import (
+    InlineMultiUsePureExpressionTransformer,
+)
+
+
+def _multiuse(method_src: str, function_var_names=None) -> str:
+    game = frog_parser.parse_game("Game G() {\n" + method_src + "\n}")
+    return str(
+        InlineMultiUsePureExpressionTransformer(function_var_names).transform(game)
+    )
+
+
+def test_f194_declines_function_let_call_with_nondet_argument() -> None:
+    # H is a deterministic Function-let, but its argument P.Sample(0^n) is an
+    # abstract-primitive draw. Inlining `v = H(P.Sample(0^n))` into two uses
+    # would duplicate the draw -> declined (v survives).
+    out = _multiuse(
+        """
+        Bool O() {
+            Bool v = H(P.Sample());
+            return v == v;
+        }
+        """,
+        function_var_names={"H"},
+    )
+    assert "Bool v = H(P.Sample())" in out
+
+
+def test_f194_still_inlines_function_let_call_with_pure_argument() -> None:
+    # H(k) with a plain variable argument is deterministic -> inlined at both
+    # uses (the declaration is removed).
+    out = _multiuse(
+        """
+        Bool O(Int k) {
+            Bool v = H(k);
+            return v == v;
+        }
+        """,
+        function_var_names={"H"},
+    )
+    assert "Bool v = H(k)" not in out

--- a/tests/unit/transforms/test_inlining_undefined_read_gate.py
+++ b/tests/unit/transforms/test_inlining_undefined_read_gate.py
@@ -1,0 +1,95 @@
+"""Regression tests: don't relocate a call whose argument is an undefined read.
+
+Reading an absent map key `M[k]` is an observable undefined-read abort. A pass
+that hoists or deduplicates such a call to a position with broader reachability
+changes the set of traces on which the abort occurs.
+
+  - F-206 HoistDuplicateBranchCall: `F.eval(M[c])` in two branch returns must
+    not hoist before the branches (would force the read on the fall-through).
+  - F-200 DeduplicateDeterministicCalls: `F.eval(M[x])` in an else-if condition
+    must not hoist to a pre-if local (would read M[x] on the `!(x in M)` path).
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import (
+    HoistDuplicateBranchCallTransformer,
+    DeduplicateDeterministicCallsTransformer,
+)
+
+
+def _det_ns():
+    prim = frog_parser.parse_primitive_file(
+        """
+        Primitive P() {
+            deterministic Int eval(Int x);
+        }
+        """
+    )
+    return {"F": prim}
+
+
+def _hoist(src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(HoistDuplicateBranchCallTransformer(_det_ns()).transform(game))
+
+
+def _dedup(src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(
+        DeduplicateDeterministicCallsTransformer(proof_namespace=_det_ns()).transform(
+            game
+        )
+    )
+
+
+# ---- F-206 HoistDuplicateBranchCall ----
+
+
+def test_f206_declines_hoist_of_map_read_call() -> None:
+    out = _hoist(
+        """
+        Game G(P F) {
+            Map<Int, Int> M;
+            Int O(Bool b1, Bool b2, Int c) {
+                if (b1) { return F.eval(M[c]); }
+                if (b2) { return F.eval(M[c]); }
+                return 0;
+            }
+        }
+        """
+    )
+    assert "__hoist" not in out  # not hoisted
+
+
+def test_f206_still_hoists_plain_arg_call() -> None:
+    out = _hoist(
+        """
+        Game G(P F) {
+            Int O(Bool b1, Bool b2, Int c) {
+                if (b1) { return F.eval(c); }
+                if (b2) { return F.eval(c); }
+                return 0;
+            }
+        }
+        """
+    )
+    assert "__hoist" in out  # plain arg: hoisted
+
+
+# ---- F-200 DeduplicateDeterministicCalls ----
+
+
+def test_f200_declines_dedup_of_elseif_map_read() -> None:
+    out = _dedup(
+        """
+        Game G(P F) {
+            Map<Int, Int> M;
+            Int O(Int x, Int y, Int z) {
+                if (!(x in M)) { return z; }
+                else if (F.eval(M[x]) == y) { return y; }
+                return F.eval(M[x]);
+            }
+        }
+        """
+    )
+    assert "__determ" not in out  # not deduped

--- a/tests/unit/transforms/test_lazy_map_pair_to_sampled_function.py
+++ b/tests/unit/transforms/test_lazy_map_pair_to_sampled_function.py
@@ -397,3 +397,34 @@ def test_declines_map_field_initializer() -> None:
         }
         """,
     )
+
+
+def test_f010_fresh_field_name_avoids_parameter_capture() -> None:
+    """F-010: the injected field name must be fresh w.r.t. EVERY name in the
+    game, not just field names. A collision with a method parameter would let
+    that parameter lexically capture the injected field (a reference to the field
+    inside the method resolving to the parameter). `_fresh_field_name` must
+    therefore avoid a parameter named `F`."""
+    from proof_frog.transforms.random_functions import _fresh_field_name
+
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int M;
+            Int Oracle(Int F) { return F; }
+        }
+        """
+    )
+    name = _fresh_field_name(game, "F")
+    assert name != "F", "injected name must not collide with a parameter named F"
+
+    # No collision anywhere -> the base name is used unchanged.
+    clean = frog_parser.parse_game(
+        """
+        Game G() {
+            Int M;
+            Int Oracle(Int x) { return x; }
+        }
+        """
+    )
+    assert _fresh_field_name(clean, "F") == "F"

--- a/tests/unit/transforms/test_lazy_map_scan.py
+++ b/tests/unit/transforms/test_lazy_map_scan.py
@@ -729,3 +729,20 @@ def test_body_contains_unrelated_array_access_preserved() -> None:
         }
     """
     _apply_and_expect(game_src, expected_src)
+
+
+def test_f143_bare_references_whitelist_limited_to_indices_0_and_1() -> None:
+    """F-143: `_bare_references` must whitelist a `var[k]` access only for the
+    indices that `_TupleAccessSubstitution` actually rewrites (0 and 1). A
+    higher literal index like `var[2]` is never substituted, so allowing it
+    through the "bare reference" check would let it survive the rewrite as a
+    dangling reference to the deleted loop binder. `var[2]` must therefore count
+    as a bare reference (so the pass declines), while `var[0]`/`var[1]` do not."""
+    from proof_frog.transforms.map_iteration import _bare_references
+
+    assert _bare_references(frog_parser.parse_expression("e[0] + e[1]"), "e") is False
+    assert _bare_references(frog_parser.parse_expression("e[0]"), "e") is False
+    assert _bare_references(frog_parser.parse_expression("e[1]"), "e") is False
+    # An out-of-range index is not substituted -> counts as a bare reference.
+    assert _bare_references(frog_parser.parse_expression("e[2]"), "e") is True
+    assert _bare_references(frog_parser.parse_expression("e[0] + e[2]"), "e") is True

--- a/tests/unit/transforms/test_loop_multiplicity.py
+++ b/tests/unit/transforms/test_loop_multiplicity.py
@@ -1,0 +1,101 @@
+"""Regression tests: don't inline a non-deterministic value into a loop body.
+
+A single SYNTACTIC use inside a loop is DYNAMICALLY evaluated once per
+iteration. Inlining a non-deterministic expression into such a use multiplies
+its draw (one sample becomes q i.i.d. samples). Findings F-148
+(InlineSingleUseVariable), F-162 (IfSplitBranchAssignment), F-156
+(InlineLocalTupleLiteral). With an empty proof namespace every FuncCall is
+treated non-deterministic.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import (
+    InlineSingleUseVariable,
+    IfSplitBranchAssignment,
+    InlineLocalTupleLiteral,
+)
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _apply(pass_obj, src: str) -> str:
+    game = frog_parser.parse_game(src)
+    return str(pass_obj.apply(game, _ctx()))
+
+
+def test_f148_single_use_var_not_inlined_into_loop() -> None:
+    out = _apply(
+        InlineSingleUseVariable(),
+        """
+        Game G(Enc E, Int n) {
+            Bool Probe(BitString<n> m) {
+                Map<Int, BitString<n>> L;
+                BitString<n> c = E.Enc(m);
+                for (Int i = 0 to 2) { L[i] = c; }
+                return L[0] == L[1];
+            }
+        }
+        """,
+    )
+    assert "BitString<n> c = E.Enc(m)" in out  # not inlined into the loop
+
+
+def test_f148_single_use_var_still_inlined_without_loop() -> None:
+    out = _apply(
+        InlineSingleUseVariable(),
+        """
+        Game G(Enc E, Int n) {
+            BitString<n> Probe(BitString<n> m) {
+                BitString<n> c = E.Enc(m);
+                return c;
+            }
+        }
+        """,
+    )
+    assert "c = E.Enc(m)" not in out  # inlined (single use, no loop)
+    assert "return E.Enc(m)" in out
+
+
+def test_f162_branch_value_not_split_into_loop() -> None:
+    out = _apply(
+        IfSplitBranchAssignment(),
+        """
+        Game G(P p, Int n) {
+            Bool Oracle(Bool c) {
+                BitString<n> x;
+                Map<Int, BitString<n>> M;
+                if (c) { x = p.f(0); } else { x = p.f(1); }
+                for (Int i = 0 to 2) { M[i] = x; }
+                return M[0] == M[1];
+            }
+        }
+        """,
+    )
+    # The branch assignments survive (not moved into the loop as fresh calls).
+    assert "x = p.f(0)" in out and "x = p.f(1)" in out
+
+
+def test_f156_tuple_element_not_inlined_into_loop() -> None:
+    out = _apply(
+        InlineLocalTupleLiteral(),
+        """
+        Game G(Gen P, Int n) {
+            Bool O() {
+                [BitString<n>, Int] v = [P.Sample(), 0];
+                BitString<n> acc = 0^n;
+                for (Int i = 0 to 2) { acc = acc + v[0]; }
+                return acc == 0^n;
+            }
+        }
+        """,
+    )
+    assert "[P.Sample(), 0]" in out  # tuple not inlined into the loop

--- a/tests/unit/transforms/test_loop_multiplicity.py
+++ b/tests/unit/transforms/test_loop_multiplicity.py
@@ -99,3 +99,42 @@ def test_f156_tuple_element_not_inlined_into_loop() -> None:
         """,
     )
     assert "[P.Sample(), 0]" in out  # tuple not inlined into the loop
+
+
+def test_f158_tuple_element_free_var_not_captured_by_loop_binder() -> None:
+    """F-158: a tuple element's free variable ``w`` rebound by a following
+    ``for`` binder must block inlining ``v[0] -> w`` into the loop body --
+    otherwise the substitution captures the binder. Closed by the shared
+    ``_stmt_mutates_var`` now treating for-binders as rebinds (F-183/F-188)."""
+    out = _apply(
+        InlineLocalTupleLiteral(),
+        """
+        Game G() {
+            Int O(Int w) {
+                Int acc = 0;
+                [Int, Int] v = [w, 0];
+                for (Int w = 0 to 2) { acc = acc + v[0]; }
+                return acc;
+            }
+        }
+        """,
+    )
+    assert "[w, 0]" in out  # tuple literal not inlined across the binder
+
+
+def test_f158_control_inlines_without_binder_collision() -> None:
+    """Control for F-158: with a non-colliding binder the inline fires."""
+    out = _apply(
+        InlineLocalTupleLiteral(),
+        """
+        Game G() {
+            Int O(Int w) {
+                Int acc = 0;
+                [Int, Int] v = [w, 0];
+                for (Int j = 0 to 2) { acc = acc + v[0]; }
+                return acc;
+            }
+        }
+        """,
+    )
+    assert "[w, 0]" not in out  # v[0] inlined to w

--- a/tests/unit/transforms/test_method_scoped_type_map.py
+++ b/tests/unit/transforms/test_method_scoped_type_map.py
@@ -1,0 +1,210 @@
+"""Regression tests for per-method type-map scoping.
+
+The flat game-wide ``build_game_type_map`` was last-write-wins and scope-blind:
+a parameter or local named ``x`` in one method silently overwrote a same-named
+binding of a *different* type in a sibling method. Type-directed algebraic
+transforms then read a sibling method's type for a bare name, laundering a
+wrong type onto an operand and performing an unsound rewrite (audit
+F-256/F-261/F-263/F-270/F-308) -- or corrupting a true equivalence
+(F-255/F-269/F-287).
+
+``build_method_type_map`` + ``MethodScopedTypeMapMixin`` scope the map to a
+single method (fields + only that method's params/locals). These tests pin the
+attack shapes (poisoning must NOT fire) alongside positive controls (the
+transform still fires where legitimately sound).
+"""
+
+from proof_frog import frog_ast, frog_parser
+from proof_frog.visitors import (
+    build_game_type_map,
+    build_method_type_map,
+    NameTypeMap,
+)
+from proof_frog.transforms.algebraic import (
+    XorCancellationTransformer,
+    TupleEqualityDecomposeTransformer,
+    GroupElemCancellationTransformer,
+)
+from proof_frog.transforms._base import PipelineContext
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _method(game: frog_ast.Game, name: str) -> frog_ast.Method:
+    for m in game.methods:
+        if m.signature.name == name:
+            return m
+    raise KeyError(name)
+
+
+# ---------------------------------------------------------------------------
+# build_method_type_map itself
+# ---------------------------------------------------------------------------
+
+
+def test_build_method_type_map_scopes_params_to_method() -> None:
+    game = frog_parser.parse_game("""
+        Game G(Int q, Int n) {
+            ModInt<q> f(ModInt<q> x, ModInt<q> m) { return x + m; }
+            BitString<n> g(BitString<n> x) { return x; }
+        }
+        """)
+    f_map = build_method_type_map(game, _method(game, "f"))
+    g_map = build_method_type_map(game, _method(game, "g"))
+    # ``x`` resolves to each method's OWN parameter type, not the sibling's.
+    assert isinstance(f_map.get("x"), frog_ast.ModIntType)
+    assert isinstance(g_map.get("x"), frog_ast.BitStringType)
+    # The flat map, by contrast, is last-write-wins: g's BitString x clobbers
+    # f's ModInt x (this is the defect the scoped map removes).
+    flat = build_game_type_map(game)
+    assert isinstance(flat.get("x"), frog_ast.BitStringType)
+
+
+def test_build_method_type_map_local_shadows_field() -> None:
+    game = frog_parser.parse_game("""
+        Game G(Int n) {
+            BitString<n> x;
+            Bool f() { ModInt<n> x = 0; return x == 0; }
+        }
+        """)
+    f_map = build_method_type_map(game, _method(game, "f"))
+    # The method-local ``x`` (ModInt) shadows the field ``x`` (BitString).
+    assert isinstance(f_map.get("x"), frog_ast.ModIntType)
+
+
+# ---------------------------------------------------------------------------
+# F-261 / F-263 -- XorCancellation must not cancel a ModInt chain because a
+# sibling method has a BitString parameter of the same name.
+# ---------------------------------------------------------------------------
+
+_XOR_POISON = """
+    Game G(Int q, Int n) {
+        ModInt<q> f(ModInt<q> x, ModInt<q> m) { return x + x + m; }
+        BitString<n> g(BitString<n> x) { return x; }
+    }
+"""
+
+_XOR_POSITIVE = """
+    Game G(Int n) {
+        BitString<n> f(BitString<n> x, BitString<n> m) { return x + x + m; }
+        BitString<n> g(BitString<n> x) { return x; }
+    }
+"""
+
+
+def test_f261_xor_cancellation_not_cross_method_poisoned() -> None:
+    game = frog_parser.parse_game(_XOR_POISON)
+    out = (
+        XorCancellationTransformer(build_game_type_map(game), _ctx())
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    # f's ModInt chain x + x + m must survive: NOT cancelled to m.
+    assert _method(out, "f") == _method(game, "f")
+
+
+def test_f261_xor_cancellation_still_fires_on_genuine_bitstring() -> None:
+    game = frog_parser.parse_game(_XOR_POSITIVE)
+    out = (
+        XorCancellationTransformer(build_game_type_map(game), _ctx())
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    # f's genuine BitString chain x + x + m DOES cancel to m.
+    body = _method(out, "f").block.statements
+    assert len(body) == 1
+    ret = body[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    assert ret.expression == frog_ast.Variable("m")
+
+
+def test_f263_xor_all_cancel_zero_uses_own_method_width() -> None:
+    # f returns x + x on a BitString<n> x; a sibling g has a BitString<n + n>
+    # parameter also named x. The flat map minted a wrong-width 0^(n + n);
+    # per-method scoping mints 0^n (this method's width).
+    game = frog_parser.parse_game(
+        """
+        Game G(Int n) {
+            BitString<n> f(BitString<n> x) { return x + x; }
+            BitString<n + n> g(BitString<n + n> x) { return x; }
+        }
+        """
+    )
+    out = (
+        XorCancellationTransformer(build_game_type_map(game), _ctx())
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    ret = _method(out, "f").block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    zero = ret.expression
+    assert isinstance(zero, frog_ast.BitStringLiteral)
+    # width is n, not n + n
+    assert zero.length == frog_ast.Variable("n")
+
+
+# ---------------------------------------------------------------------------
+# F-256 -- TupleEqualityDecompose must use this method's tuple arity, not a
+# sibling method's smaller-arity same-named parameter.
+# ---------------------------------------------------------------------------
+
+
+def test_f256_tuple_decompose_uses_own_method_arity() -> None:
+    game = frog_parser.parse_game("""
+        Game G() {
+            Bool O1([Int, Int, Int] x, [Int, Int, Int] y) { return x != y; }
+            Bool O2([Int, Int] x, [Int, Int] y) { return x != y; }
+        }
+        """)
+    out = (
+        TupleEqualityDecomposeTransformer(_ctx(), build_game_type_map(game))
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    # O1 decomposes into THREE component comparisons (its own arity), not two.
+    ret = _method(out, "O1").block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    # Count the leaf ArrayAccess disequalities in the OR chain.
+    leaves: list[frog_ast.Expression] = []
+    stack = [ret.expression]
+    while stack:
+        e = stack.pop()
+        if (
+            isinstance(e, frog_ast.BinaryOperation)
+            and e.operator == frog_ast.BinaryOperators.OR
+        ):
+            stack.append(e.left_expression)
+            stack.append(e.right_expression)
+        else:
+            leaves.append(e)
+    assert len(leaves) == 3
+
+
+# ---------------------------------------------------------------------------
+# F-270 -- GroupElemCancellation must not cancel an Int chain (m / x) * x
+# because a sibling method's same-named params are GroupElem.
+# ---------------------------------------------------------------------------
+
+
+def test_f270_groupelem_cancellation_not_cross_method_poisoned() -> None:
+    game = frog_parser.parse_game("""
+        Game G(Group H) {
+            Int Compute(Int m, Int x) { return (m / x) * x; }
+            GroupElem<H> ZOracle(GroupElem<H> m, GroupElem<H> x) { return m; }
+        }
+        """)
+    out = (
+        GroupElemCancellationTransformer(build_game_type_map(game))
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    # Compute's Int chain (m / x) * x must survive: NOT cancelled to m
+    # (truncating Int division makes the cancellation unsound).
+    assert _method(out, "Compute") == _method(game, "Compute")

--- a/tests/unit/transforms/test_near_misses.py
+++ b/tests/unit/transforms/test_near_misses.py
@@ -2196,6 +2196,31 @@ def test_sink_uniform_no_near_miss_when_clean() -> None:
     assert not any(nm.transform_name == "Sink Uniform Sample" for nm in ctx.near_misses)
 
 
+def test_sink_uniform_near_miss_on_scope_escape() -> None:
+    """F-042: SinkUniformSample reports a near-miss when the sample variable is
+    referenced outside the block it would be sunk within (out-of-scope AST)."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            Bool O(Bool a, Bool b) {
+                if (a) {
+                    ModInt<2> x <- ModInt<2>;
+                    if (b) { ModInt<2> y = x; }
+                }
+                return x == 0;
+            }
+        }
+        """)
+    ctx = _make_ctx()
+    result = SinkUniformSample().apply(game, ctx)
+    assert result == game  # declined
+    assert any(
+        nm.transform_name == "Sink Uniform Sample"
+        and nm.variable == "x"
+        and "out of scope" in nm.reason
+        for nm in ctx.near_misses
+    )
+
+
 def test_merge_uniform_near_miss_on_domain_write() -> None:
     """RC5: MergeUniformSamples reports a near-miss when ``n`` is written
     between the two ``BitString<n>`` samples it would merge."""

--- a/tests/unit/transforms/test_normalize_commutative.py
+++ b/tests/unit/transforms/test_normalize_commutative.py
@@ -151,7 +151,11 @@ from proof_frog.transforms.algebraic import NormalizeCommutativeChainsTransforme
             }
             """,
         ),
-        # Structural ordering for equality: FuncCall sorts after Variable
+        # F-260: a `==` containing a NON-deterministic call is left in place.
+        # With the empty namespace here `f(a)` is a non-deterministic call, so
+        # swapping it (to canonicalize FuncCall-after-Variable) is declined --
+        # reordering could change side-effect order. (A deterministic call still
+        # swaps; see test_f260_deterministic_call_still_reorders.)
         (
             """
             Bool f(Int a, Int b) {
@@ -160,7 +164,7 @@ from proof_frog.transforms.algebraic import NormalizeCommutativeChainsTransforme
             """,
             """
             Bool f(Int a, Int b) {
-                return a == f(a);
+                return f(a) == a;
             }
             """,
         ),
@@ -175,3 +179,73 @@ def test_normalize_commutative_chains(method: str, expected: str) -> None:
     print("EXPECTED:", expected_ast)
     print("TRANSFORMED:", transformed)
     assert expected_ast == transformed
+
+
+def _det_namespace():
+    prim = frog_parser.parse_primitive_file(
+        """
+        Primitive P(Int n) {
+            deterministic Int det(Int x);
+        }
+        """
+    )
+    return {"F": prim}
+
+
+def test_f260_two_stateful_calls_not_reordered() -> None:
+    """F-260: two non-deterministic calls in a `+` chain must NOT be reordered --
+    swapping `challenger.Inc() + challenger.Get()` changes which side effect
+    fires first, so two distinguishable expressions would collapse to one."""
+    method = frog_parser.parse_method(
+        """
+        Int f(Int a) {
+            return challenger.Inc() + challenger.Get();
+        }
+        """
+    )
+    result = NormalizeCommutativeChainsTransformer().transform(method)
+    assert result == method, "chain with stateful calls must keep source order"
+
+
+def test_f260_pure_chain_still_reorders() -> None:
+    """F-260 positive control: a chain with no calls is reordered as before."""
+    method = frog_parser.parse_method(
+        """
+        Int f(Int a, Int b, Int c) {
+            return c + a + b;
+        }
+        """
+    )
+    expected = frog_parser.parse_method(
+        """
+        Int f(Int a, Int b, Int c) {
+            return a + b + c;
+        }
+        """
+    )
+    result = NormalizeCommutativeChainsTransformer().transform(method)
+    assert result == expected
+
+
+def test_f260_deterministic_call_still_reorders() -> None:
+    """F-260: a DETERMINISTIC call has no side effect, so the structural swap
+    (FuncCall sorts after Variable) still fires -- only non-deterministic calls
+    block the reorder."""
+    method = frog_parser.parse_method(
+        """
+        Bool f(Int a) {
+            return F.det(a) == a;
+        }
+        """
+    )
+    expected = frog_parser.parse_method(
+        """
+        Bool f(Int a) {
+            return a == F.det(a);
+        }
+        """
+    )
+    result = NormalizeCommutativeChainsTransformer(
+        proof_namespace=_det_namespace()
+    ).transform(method)
+    assert result == expected

--- a/tests/unit/transforms/test_normalize_product_literal.py
+++ b/tests/unit/transforms/test_normalize_product_literal.py
@@ -289,3 +289,40 @@ def test_transformer_no_change_returns_same_block() -> None:
     """)
     out = NormalizeProductLiteralTransformer(_ctx()).transform(game)
     assert out == game
+
+
+def test_f316_decline_path_does_not_graft_tuple_into_product_type() -> None:
+    """F-316: when a ProductType is NOT a literal (a genuine space -- here it
+    has a SetType member), the rewriter must leave it untouched. Previously the
+    decline path called ``_transform_children``, which recursed into
+    ``node.types`` and converted a nested literal member into a ``Tuple``,
+    grafting a ``Tuple`` into ``ProductType.types`` (a corrupt mixed node)."""
+    from proof_frog.transforms.tuples import _ProductLiteralValueRewriter
+
+    nested_literal = frog_ast.ProductType(
+        [frog_ast.Variable("a"), frog_ast.Variable("b")]
+    )
+    outer = frog_ast.ProductType(
+        [frog_ast.SetType(frog_ast.BitStringType(frog_ast.Integer(8))), nested_literal]
+    )
+    ctx = _ctx()
+    out = _ProductLiteralValueRewriter(ctx).transform(outer)
+    # The space is returned unchanged...
+    assert out is outer
+    # ...and no Tuple was grafted into its type members.
+    assert not any(isinstance(t, frog_ast.Tuple) for t in out.types)
+    # A decline near-miss is still reported.
+    assert any(
+        nm.transform_name == "Normalize Product-Literal Tuples"
+        for nm in ctx.near_misses
+    )
+
+
+def test_f316_genuine_literal_still_converts() -> None:
+    """Control for F-316: a genuine tuple literal (all members expressions) is
+    still rewritten into a ``Tuple``."""
+    from proof_frog.transforms.tuples import _ProductLiteralValueRewriter
+
+    lit = frog_ast.ProductType([frog_ast.Variable("x"), frog_ast.Variable("y")])
+    out = _ProductLiteralValueRewriter(_ctx()).transform(lit)
+    assert isinstance(out, frog_ast.Tuple)

--- a/tests/unit/transforms/test_parameter_standardizing.py
+++ b/tests/unit/transforms/test_parameter_standardizing.py
@@ -122,3 +122,46 @@ def test_no_params_is_noop() -> None:
     )
     out = _ParameterStandardizer().rename_game(game)
     assert out == game
+
+
+def test_f306_declines_when_target_name_collides_with_loop_binder() -> None:
+    """F-306: the canonical target names arg1..argN must be fresh w.r.t. body
+    binders. A loop binder named `arg1` (which AlphaRename does not rename) would
+    capture a parameter renamed to `arg1`, so the parameter reference inside the
+    loop would resolve to the binder. The pass must decline the rename (leaving
+    the parameter name intact) rather than produce a capturing rename."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int O(Int c) {
+                Int r = 0;
+                for (Int arg1 in {1, 2}) {
+                    r = r + c;
+                }
+                return r;
+            }
+        }
+        """
+    )
+    result = _ParameterStandardizer().rename_game(game)
+    out = str(result)
+    # The parameter must NOT have been renamed to `arg1` (which the loop binder
+    # would capture); it stays `c`.
+    assert "Int O(Int c)" in out, "collision with a loop binder must decline the rename"
+    assert "r = r + c" in out, "the parameter reference must not be captured"
+
+
+def test_f306_standardizes_when_no_collision() -> None:
+    """F-306 positive control: with no colliding body binder, the parameter is
+    still standardized to arg1."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int O(Int c) { return c + 1; }
+        }
+        """
+    )
+    result = _ParameterStandardizer().rename_game(game)
+    out = str(result)
+    assert "Int O(Int arg1)" in out
+    assert "return arg1 + 1" in out

--- a/tests/unit/transforms/test_parameter_standardizing.py
+++ b/tests/unit/transforms/test_parameter_standardizing.py
@@ -165,3 +165,24 @@ def test_f306_standardizes_when_no_collision() -> None:
     out = str(result)
     assert "Int O(Int arg1)" in out
     assert "return arg1 + 1" in out
+
+
+def test_f307_declines_when_target_name_collides_with_field() -> None:
+    """F-307 (sibling of F-306): the canonical target names arg1..argN must also
+    be fresh w.r.t. game FIELDS. A field named `arg1` fuses with a parameter
+    renamed to `arg1` -- a field read `return c + arg1` would become
+    `return arg1 + arg1` (the field read captured by the parameter). The pass
+    must decline the rename, leaving the parameter name intact."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int arg1;
+            Void Initialize() { arg1 = 5; }
+            Int O(Int c) { return c + arg1; }
+        }
+        """
+    )
+    result = _ParameterStandardizer().rename_game(game)
+    out = str(result)
+    assert "Int O(Int c)" in out, "collision with a field must decline the rename"
+    assert "return c + arg1" in out, "the field read must not fuse with the parameter"

--- a/tests/unit/transforms/test_purity_gate_duplicated_operands.py
+++ b/tests/unit/transforms/test_purity_gate_duplicated_operands.py
@@ -1,0 +1,154 @@
+"""Regression tests: purity gates on duplicated / deleted operands.
+
+Per ruling 7.A.6, each invocation of an abstract-primitive (unannotated) call
+is an independent i.i.d. draw. Passes that duplicate an operand (deep-copy it
+into several positions) or delete one of two structurally-equal operands must
+therefore decline when the operand carries a non-deterministic call -- else
+they collapse independent draws or multiply one draw into several. Each test
+pins the decline for a non-deterministic operand alongside a deterministic
+positive (the transform still fires).
+
+Findings: F-242, F-243 (BooleanAbsorption dedup), F-254 (ConcatEqualityDecompose
+`other`), F-257 (TupleEqualityDecompose `project`).
+"""
+
+from proof_frog import frog_ast, frog_parser
+from proof_frog.visitors import build_game_type_map, NameTypeMap
+from proof_frog.transforms.algebraic import (
+    BooleanAbsorptionTransformer,
+    ConcatEqualityDecomposeTransformer,
+    TupleEqualityDecomposeTransformer,
+)
+from proof_frog.transforms._base import PipelineContext
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _expr(src: str) -> frog_ast.Expression:
+    return frog_parser.parse_expression(src)
+
+
+# ---------------------------------------------------------------------------
+# F-242 / F-243 -- BooleanAbsorption duplicate-conjunct dedup
+# ---------------------------------------------------------------------------
+
+
+def test_f242_dedup_declines_nondeterministic_duplicate_conjuncts() -> None:
+    # flip() && flip(): two structurally-equal conjuncts, but each flip() is
+    # an independent draw -- dedup to flip() is unsound.
+    expr = _expr("flip() && flip()")
+    out = BooleanAbsorptionTransformer(_ctx()).transform(expr)
+    assert out == expr  # unchanged
+
+
+def test_f243_dedup_declines_nondet_multiset_collision() -> None:
+    # (flip() || flip() || b) && (flip() || b || b): mutually-"subset"
+    # disjunct sets {flip(), b} but each flip() is an independent draw.
+    expr = _expr("(flip() || flip() || b) && (flip() || b || b)")
+    out = BooleanAbsorptionTransformer(_ctx()).transform(expr)
+    assert out == expr  # unchanged
+
+
+def test_f242_dedup_still_fires_on_deterministic_duplicate() -> None:
+    # a && a: deterministic variable, dedup to a is sound.
+    expr = _expr("a && a")
+    out = BooleanAbsorptionTransformer(_ctx()).transform(expr)
+    assert out == frog_ast.Variable("a")
+
+
+# ---------------------------------------------------------------------------
+# F-254 -- ConcatEqualityDecompose slices `other` once per concat term
+# ---------------------------------------------------------------------------
+
+
+def _concat_decompose(method_src: str) -> frog_ast.Method:
+    game = frog_parser.parse_game("Game G(Int n) {\n" + method_src + "\n}")
+    out = (
+        ConcatEqualityDecomposeTransformer(_ctx(), build_game_type_map(game))
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    for m in out.methods:
+        return m
+    raise AssertionError
+
+
+def test_f254_concat_decompose_declines_nondeterministic_other() -> None:
+    # gen() == a || b: `other` = gen() would be sliced twice -> two draws.
+    method = _concat_decompose("""
+        Bool f(BitString<n> a, BitString<n> b) {
+            return gen() == (a || b);
+        }
+        """)
+    ret = method.block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    # Unchanged: still a single top-level equality, not a slice conjunction.
+    assert isinstance(ret.expression, frog_ast.BinaryOperation)
+    assert ret.expression.operator == frog_ast.BinaryOperators.EQUALS
+
+
+def test_f254_concat_decompose_still_fires_on_deterministic_other() -> None:
+    # c == a || b with c a plain variable: decomposes into slice comparisons.
+    method = _concat_decompose("""
+        Bool f(BitString<n> c, BitString<n> a, BitString<n> b) {
+            return c == (a || b);
+        }
+        """)
+    ret = method.block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    # Fired: top-level AND of per-slice equalities.
+    assert isinstance(ret.expression, frog_ast.BinaryOperation)
+    assert ret.expression.operator == frog_ast.BinaryOperators.AND
+
+
+# ---------------------------------------------------------------------------
+# F-257 -- TupleEqualityDecompose projects a non-Tuple operand per component
+# ---------------------------------------------------------------------------
+
+
+def _tuple_decompose(method_src: str) -> frog_ast.Method:
+    game = frog_parser.parse_game("Game G() {\n" + method_src + "\n}")
+    out = (
+        TupleEqualityDecomposeTransformer(_ctx(), build_game_type_map(game))
+        .scope_to_game(game, None)
+        .transform(game)
+    )
+    for m in out.methods:
+        return m
+    raise AssertionError
+
+
+def test_f257_tuple_decompose_declines_nondeterministic_operand() -> None:
+    # Coin() != t where Coin() returns a 2-tuple: projecting Coin()[0],
+    # Coin()[1] would call Coin() twice -> two independent draws.
+    method = _tuple_decompose("""
+        Bool f([Int, Int] t) {
+            return Coin() != t;
+        }
+        """)
+    ret = method.block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    # Unchanged: still a single top-level NOTEQUALS, not an OR of projections.
+    assert isinstance(ret.expression, frog_ast.BinaryOperation)
+    assert ret.expression.operator == frog_ast.BinaryOperators.NOTEQUALS
+
+
+def test_f257_tuple_decompose_still_fires_on_variable_operand() -> None:
+    # s != t, both tuple-typed variables: decomposes (variable reads are
+    # deterministic, so per-component projection is sound).
+    method = _tuple_decompose("""
+        Bool f([Int, Int] s, [Int, Int] t) {
+            return s != t;
+        }
+        """)
+    ret = method.block.statements[0]
+    assert isinstance(ret, frog_ast.ReturnStatement)
+    assert isinstance(ret.expression, frog_ast.BinaryOperation)
+    assert ret.expression.operator == frog_ast.BinaryOperators.OR

--- a/tests/unit/transforms/test_redundant_copies.py
+++ b/tests/unit/transforms/test_redundant_copies.py
@@ -152,6 +152,40 @@ from proof_frog.transforms.inlining import RedundantCopyTransformer
             }
             """,
         ),
+        # F-179 positive: an array copy with no mutation still folds.
+        (
+            """
+            Int f(Array<Int, 2> w) {
+                Array<Int, 2> v = w;
+                return v[0];
+            }
+            """,
+            """
+            Int f(Array<Int, 2> w) {
+                return w[0];
+            }
+            """,
+        ),
+        # F-179 decline: an element write to the original (`w[0] = 2`, an
+        # ArrayAccess l-value) after the copy `v = w` must block the
+        # substitution -- otherwise `return v[0]` would read post-mutation
+        # state. The scan now peels the l-value via `lvalue_base_name`.
+        (
+            """
+            Int f(Array<Int, 2> w) {
+                Array<Int, 2> v = w;
+                w[0] = 2;
+                return v[0];
+            }
+            """,
+            """
+            Int f(Array<Int, 2> w) {
+                Array<Int, 2> v = w;
+                w[0] = 2;
+                return v[0];
+            }
+            """,
+        ),
     ],
 )
 def test_redundant_copies(

--- a/tests/unit/transforms/test_redundant_copies.py
+++ b/tests/unit/transforms/test_redundant_copies.py
@@ -231,3 +231,21 @@ def test_f181_plain_copy_still_eliminated() -> None:
     )
     out = str(RedundantCopyTransformer().transform(method))
     assert "Int b = a" not in out  # the copy is removed (b -> a)
+
+
+def test_f183_declines_when_loop_binder_captures_copy_source() -> None:
+    """F-183: a copy ``v = w`` must not be eliminated when a following ``for``
+    binder rebinds the copy source ``w`` and the loop body uses ``v`` --
+    substituting ``v -> w`` there would capture the binder's ``w``."""
+    method = frog_parser.parse_method("""
+        Int O(Int w) {
+            Int acc = 0;
+            Int v = w;
+            for (Int w = 0 to 3) {
+                acc = acc + v;
+            }
+            return acc;
+        }
+        """)
+    # Unchanged: the loop-binder rebind of `w` blocks the substitution.
+    assert RedundantCopyTransformer().transform(method) == method

--- a/tests/unit/transforms/test_redundant_copies.py
+++ b/tests/unit/transforms/test_redundant_copies.py
@@ -199,3 +199,35 @@ def test_redundant_copies(
     print("EXPECTED", expected_ast)
     print("TRANSFORMED", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def test_f181_sample_from_variable_not_a_copy() -> None:
+    """F-181: `v <- w` samples a uniform element from the set `w` (a genuine
+    draw, ruling 7.A.8), NOT a copy of `w`. RedundantCopy must not delete the
+    draw and substitute the whole set."""
+    method = frog_parser.parse_method(
+        """
+        Int f() {
+            Set<Int> w = {0, 1};
+            Int v <- w;
+            return v;
+        }
+        """
+    )
+    out = str(RedundantCopyTransformer().transform(method))
+    assert "Int v <- w" in out  # the draw is preserved, not deleted
+
+
+def test_f181_plain_copy_still_eliminated() -> None:
+    """Positive control: a plain typed alias `Int b = a;` is still eliminated."""
+    method = frog_parser.parse_method(
+        """
+        Int f() {
+            Int a = 1;
+            Int b = a;
+            return b;
+        }
+        """
+    )
+    out = str(RedundantCopyTransformer().transform(method))
+    assert "Int b = a" not in out  # the copy is removed (b -> a)

--- a/tests/unit/transforms/test_redundant_field_copy.py
+++ b/tests/unit/transforms/test_redundant_field_copy.py
@@ -233,3 +233,25 @@ def test_redundant_field_copy(
 
     transformed_ast = RedundantFieldCopyTransformer().transform(game_ast)
     assert transformed_ast == expected_ast
+
+
+def test_f198_redeclaration_after_copy_declines() -> None:
+    """F-198: `v <- ...; f = v; v = v + v;` -- the field copy `f = v` must not
+    be eliminated. The redeclaration `v = v + v` comes AFTER the copy, so
+    `decl_index >= index`; the pass (via the F-199 ordering guard, plus the
+    use-scan) declines rather than substituting a differently-valued write."""
+    game = frog_parser.parse_game(
+        """
+        Game Real(Int n) {
+            BitString<n> f;
+            Void Initialize() {
+                BitString<n> v <- BitString<n>;
+                f = v;
+                BitString<n> v = v + v;
+            }
+            BitString<n> Get() { return f; }
+        }
+        """
+    )
+    out = str(RedundantFieldCopyTransformer().transform(game))
+    assert "f = v" in out  # copy preserved (not unsoundly eliminated)

--- a/tests/unit/transforms/test_refactor_group_elem_field_exp.py
+++ b/tests/unit/transforms/test_refactor_group_elem_field_exp.py
@@ -1,0 +1,130 @@
+"""Regression tests for RefactorGroupElemFieldExp Initialize-safety guards.
+
+The pass rewrites `Field1 = g^(a*b)` to `Field2 ^ b` when a peer
+`Field2 = g^a` exists. Three ways that is unsound, now guarded:
+
+  - F-221: the shared factor must have the SAME value at both field
+    positions. If a free variable of the factor is reassigned between them,
+    the two occurrences are independent draws (stale exponent).
+  - F-224: if Initialize can return early, moving Field2 changes which traces
+    define it (turning a guarded/undefined read into a defined one).
+  - F-225: moving Field2's assignment up past an intervening READ of Field2
+    changes that read's value.
+
+Each `DECLINED` case is paired with the P0 positive control (the pass still
+fires on the sound shape).
+"""
+
+import copy
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import RefactorGroupElemFieldExp
+from proof_frog.transforms._base import PipelineContext
+from proof_frog.visitors import NameTypeMap
+
+
+def _ctx() -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+
+
+def _fires(game_src: str) -> bool:
+    game = frog_parser.parse_game(game_src)
+    after = RefactorGroupElemFieldExp().apply(copy.deepcopy(game), _ctx())
+    return str(after) != str(game)
+
+
+def test_p0_positive_fires() -> None:
+    # Clean shape: B = g^x; A = g^(x*3) with x unchanged -> A = B^3.
+    assert _fires(
+        """
+        Game Pos(Group G) {
+            GroupElem<G> B;
+            GroupElem<G> A;
+            Void Initialize() {
+                Int x = 2;
+                B = G.generator ^ x;
+                A = G.generator ^ (x * 3);
+            }
+        }
+        """
+    )
+
+
+def test_f221_stale_exponent_no_move_declines() -> None:
+    # x reassigned between B and A -> B's x and A's x are different draws.
+    assert not _fires(
+        """
+        Game Stale(Group G) {
+            GroupElem<G> B;
+            GroupElem<G> A;
+            Void Initialize() {
+                Int x = 1;
+                B = G.generator ^ x;
+                x = 3;
+                A = G.generator ^ (x * 2);
+            }
+        }
+        """
+    )
+
+
+def test_f221_stale_exponent_move_declines() -> None:
+    # A before B, x re-sampled between -> moving B up would conflate draws.
+    assert not _fires(
+        """
+        Game StaleMove(Group G) {
+            GroupElem<G> A;
+            GroupElem<G> B;
+            Void Initialize() {
+                Int x = 1;
+                A = G.generator ^ (x * x);
+                x = 3;
+                B = G.generator ^ x;
+            }
+        }
+        """
+    )
+
+
+def test_f224_early_return_in_init_declines() -> None:
+    # Moving B above `if (p) { return true; }` changes which traces define B.
+    assert not _fires(
+        """
+        Game EarlyRet(Group G) {
+            GroupElem<G> A;
+            GroupElem<G> B;
+            Bool Initialize(Bool p) {
+                Int x = 2;
+                A = G.generator ^ (x * 3);
+                if (p) { return true; }
+                B = G.generator ^ x;
+                return false;
+            }
+        }
+        """
+    )
+
+
+def test_f225_read_before_write_move_declines() -> None:
+    # `C = B` reads an unassigned B before B is defined; hoisting B above it
+    # turns an observable undefined read into a defined value.
+    assert not _fires(
+        """
+        Game ReadBeforeWrite(Group G) {
+            GroupElem<G> A;
+            GroupElem<G> B;
+            GroupElem<G> C;
+            Void Initialize() {
+                Int x = 2;
+                A = G.generator ^ (x * 3);
+                C = B;
+                B = G.generator ^ x;
+            }
+        }
+        """
+    )

--- a/tests/unit/transforms/test_refactor_group_elem_field_exp.py
+++ b/tests/unit/transforms/test_refactor_group_elem_field_exp.py
@@ -128,3 +128,37 @@ def test_f225_read_before_write_move_declines() -> None:
         }
         """
     )
+
+
+def test_f222_cross_group_generators_decline() -> None:
+    """F-222: `A = G.generator^(x*y)` must not be refactored as `B^y` when
+    `B = H.generator^x` is in a DIFFERENT group -- that crosses groups and is
+    ill-typed (`GroupElem<G>` field set to `(GroupElem<H>)^y`)."""
+    assert not _fires(
+        """
+        Game Cross(Group G, Group H, Int x, Int y) {
+            GroupElem<H> B;
+            GroupElem<G> A;
+            Void Initialize() {
+                B = H.generator ^ x;
+                A = G.generator ^ (x * y);
+            }
+        }
+        """
+    )
+
+
+def test_f222_same_group_generators_still_fire() -> None:
+    """Positive control: same group -> the refactor still fires."""
+    assert _fires(
+        """
+        Game Same(Group G, Int x, Int y) {
+            GroupElem<G> B;
+            GroupElem<G> A;
+            Void Initialize() {
+                B = G.generator ^ x;
+                A = G.generator ^ (x * y);
+            }
+        }
+        """
+    )

--- a/tests/unit/transforms/test_remove_unnecessary_field.py
+++ b/tests/unit/transforms/test_remove_unnecessary_field.py
@@ -188,3 +188,45 @@ def test_unnecessary_field_visitor(
     transformed_ast = dependencies.remove_unnecessary_fields(game_ast)
     print("transformed AST", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def test_f319_field_read_only_in_index_position_is_kept() -> None:
+    """F-319: a field `F` read only in the index of a write to another (kept)
+    field, `M[F] = v`, is necessary -- dropping it while `M[F] = v` survives
+    emits a game with a dangling reference to the undeclared `F`. The game-wide
+    fixpoint must keep `F` (and its setter) so the output stays well-formed."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Map<Int, Int> M;
+            Int F;
+            Void Initialize() { F = 0; }
+            Void Store(Int v) { M[F] = v; }
+            Map<Int, Int> Get() { return M; }
+        }
+        """
+    )
+    result = dependencies.remove_unnecessary_fields(game)
+    out = str(result)
+    assert "Int F;" in out, "the index field F must be kept (no dangling reference)"
+    assert "F = 0" in out, "F's setter must be kept"
+    assert "M[F]" in out, "the kept write M[F]=v must still reference a declared F"
+
+
+def test_f319_genuinely_unnecessary_field_still_removed() -> None:
+    """F-319 positive control: a field that is neither returned nor read in a
+    kept write's index is still removed (the fixpoint does not over-keep)."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int U;
+            Int M;
+            Void Initialize() { U = 5; M = 3; }
+            Int Get() { return M; }
+        }
+        """
+    )
+    result = dependencies.remove_unnecessary_fields(game)
+    out = str(result)
+    assert "Int U;" not in out, "a genuinely unnecessary field must still be removed"
+    assert "Int M;" in out, "a necessary field must be kept"

--- a/tests/unit/transforms/test_remove_unnecessary_field.py
+++ b/tests/unit/transforms/test_remove_unnecessary_field.py
@@ -230,3 +230,30 @@ def test_f319_genuinely_unnecessary_field_still_removed() -> None:
     out = str(result)
     assert "Int U;" not in out, "a genuinely unnecessary field must still be removed"
     assert "Int M;" in out, "a necessary field must be kept"
+
+
+def test_f320_loop_carried_write_not_deleted() -> None:
+    """F-320: a loop-carried write whose reviving read is EARLIER in the body
+    text but executes in a LATER iteration (via the back-edge) must not be
+    deleted. For `for (...) { y = y + x; x = x + 1; }` a single reverse pass
+    marks `x = x + 1` dead before `y = y + x` makes `x` necessary; the liveness
+    fixpoint revives it, so the loop-carried increment survives."""
+    method = frog_parser.parse_method(
+        """
+        Int Sum(Int n) {
+            Int x = 0;
+            Int y = 0;
+            for (Int i = 0 to n) {
+                y = y + x;
+                x = x + 1;
+            }
+            return y;
+        }
+        """
+    )
+    result = dependencies.remove_unnecessary_statements(
+        [], method.block, outer_names=set()
+    )
+    out = str(result)
+    assert "x = x + 1" in out, "the loop-carried increment must not be deleted"
+    assert "y = y + x" in out

--- a/tests/unit/transforms/test_simplify_return.py
+++ b/tests/unit/transforms/test_simplify_return.py
@@ -291,3 +291,40 @@ def test_simplify_return_soundness_still_fires(game: str, expected: str) -> None
         frog_parser.parse_game(game)
     )
     assert frog_parser.parse_game(expected) == transformed
+
+
+def test_f127_reduction_field_write_preserved() -> None:
+    """F-127: SimplifyReturn's field-write protection reads self.fields, which
+    was populated only by transform_game. A Reduction (a Game subclass, but
+    dispatched via transform_reduction) left it empty, so `f = 7; return f;` in
+    a reduction oracle was collapsed to `return 7;`, dropping the observable
+    field write. transform_reduction now populates the fields."""
+    reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Int f;
+            Void Initialize() { f = 0; }
+            Int Oracle() {
+                f = 7;
+                return f;
+            }
+        }
+    """)
+    out = SimplifyReturnTransformer().transform(reduction)
+    assert isinstance(out, type(reduction))  # still a Reduction
+    assert "f = 7" in str(out)  # field write not deleted
+
+
+def test_f127_reduction_local_still_inlined() -> None:
+    """Control for F-127: a genuine typed local in a reduction oracle is still
+    inlined into the trailing return."""
+    reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Void Initialize() { }
+            Int Oracle() {
+                Int v = 5;
+                return v;
+            }
+        }
+    """)
+    out = str(SimplifyReturnTransformer().transform(reduction))
+    assert "return 5" in out and "Int v = 5" not in out

--- a/tests/unit/transforms/test_single_call_field_to_local.py
+++ b/tests/unit/transforms/test_single_call_field_to_local.py
@@ -443,3 +443,28 @@ def test_field_to_local_fires_when_domain_not_mutated() -> None:
         }
         """)
     assert _single_call_field_to_local(game) == expected
+
+
+def test_f058_is_written_detects_element_and_uniq_writes() -> None:
+    """F-058: the field-write guard `_is_written_in_recursive` must peel the full
+    l-value (so `M[k] = v`, `M[k][j] = v`, `obj.f = v` count as writes to the
+    base) and recognize `UniqueSample` writes. The previous bare-Variable +
+    Assignment/Sample check missed both, so a field mutated only via an element
+    write or a `<-uniq` draw looked unwritten."""
+    from proof_frog.transforms.sampling import _is_written_in_recursive
+
+    element = frog_parser.parse_method("Void f() { M[0] = 5; }")
+    assert _is_written_in_recursive(element.block, "M") is True
+
+    nested = frog_parser.parse_method("Void f() { M[0][1] = 5; }")
+    assert _is_written_in_recursive(nested.block, "M") is True
+
+    uniq = frog_parser.parse_method("Void f() { x <-uniq[S] BitString<4>; }")
+    assert _is_written_in_recursive(uniq.block, "x") is True
+
+    field = frog_parser.parse_method("Void f() { X.g = 5; }")
+    assert _is_written_in_recursive(field.block, "X") is True
+
+    # Unrelated write must not match.
+    other = frog_parser.parse_method("Void f() { y = 5; }")
+    assert _is_written_in_recursive(other.block, "M") is False

--- a/tests/unit/transforms/test_sink_uniform_sample.py
+++ b/tests/unit/transforms/test_sink_uniform_sample.py
@@ -268,3 +268,48 @@ def test_sink_fires_when_if_branch_writes_unrelated_name() -> None:
         }
         """)
     assert SinkUniformSampleTransformer().transform(method) == expected
+
+
+def test_f042_declines_when_variable_escapes_block() -> None:
+    """F-042 scope guard: a block-local sample whose name is referenced outside
+    its block with no governing outer declaration (an out-of-scope AST the
+    typechecker would reject) must NOT be sunk -- sinking would leave the
+    outside use reading a variable defined on only one path."""
+    method = frog_parser.parse_method("""
+        Bool O(Bool a, Bool b) {
+            if (a) {
+                ModInt<2> x <- ModInt<2>;
+                if (b) {
+                    ModInt<2> y = x;
+                }
+            }
+            return x == 0;
+        }
+        """)
+    # Unchanged: the guard declines because `x` escapes the `if (a)` block.
+    assert SinkUniformSampleTransformer().transform(method) == method
+
+
+def test_f042_still_fires_with_legitimate_shadowing() -> None:
+    """F-042 guard precision: a *separate* outer declaration of the same name
+    (legitimate block-scoped shadowing) governs the outside references, so the
+    inner sink must still fire -- the guard only blocks true escapes."""
+    method = frog_parser.parse_method("""
+        ModInt<2> O(Bool a, Bool c) {
+            if (a) {
+                ModInt<2> x <- ModInt<2>;
+                if (c) {
+                    ModInt<2> y = x;
+                }
+            }
+            if (c) {
+                ModInt<2> x <- ModInt<2>;
+                return x;
+            }
+            return 0;
+        }
+        """)
+    transformed = SinkUniformSampleTransformer().transform(method)
+    # The first block's `x` is sunk into its `if (c)` sub-branch; the sibling
+    # `x` (a distinct declaration) is untouched.
+    assert transformed != method

--- a/tests/unit/transforms/test_slice_of_inline_concat.py
+++ b/tests/unit/transforms/test_slice_of_inline_concat.py
@@ -227,3 +227,36 @@ def test_slice_of_inline_concat_declines_on_stale_length(game: str) -> None:
     game_ast = frog_parser.parse_game(game)
     transformed = SliceOfInlineConcatTransformer().transform_game(game_ast)
     assert transformed == game_ast, "pass must decline when the operand length is shadowed"
+
+
+def test_f030_side_effecting_dropped_operand_not_dropped() -> None:
+    """F-030: `(a || b)[0 : |a|] -> a` drops `b`. Evaluating a concatenation
+    evaluates both operands, so dropping one that contains a non-deterministic
+    call would erase that call's observable effect. The rewrite must decline
+    when the DROPPED operand is impure."""
+    from proof_frog import frog_parser
+    from proof_frog.transforms.sampling import SliceOfInlineConcatTransformer
+    from proof_frog.transforms._base import PipelineContext
+    from proof_frog.visitors import NameTypeMap
+
+    prim = frog_parser.parse_primitive_file(
+        "Primitive P(Int n) { BitString<n> g(); }"  # g is non-deterministic
+    )
+    ctx = PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={"F": prim},
+        subsets_pairs=[],
+    )
+    method = frog_parser.parse_method(
+        "BitString<n> O() { BitString<n> a <- BitString<n>; return (a || F.g())[0 : n]; }"
+    )
+    result = SliceOfInlineConcatTransformer(NameTypeMap(), ctx).transform(method)
+    assert "F.g()" in str(result), "an impure dropped operand must not be dropped"
+
+    # Positive control: two pure operands still simplify (drop is sound).
+    pure = frog_parser.parse_method(
+        "BitString<n> O() { BitString<n> a <- BitString<n>; BitString<n> b <- BitString<n>; return (a || b)[0 : n]; }"
+    )
+    pure_out = SliceOfInlineConcatTransformer(NameTypeMap(), ctx).transform(pure)
+    assert "return a;" in str(pure_out), "pure concat slice should still simplify to a"

--- a/tests/unit/transforms/test_slice_simplification.py
+++ b/tests/unit/transforms/test_slice_simplification.py
@@ -200,3 +200,43 @@ def test_unrelated_unique_sample_does_not_block_splice() -> None:
         frog_parser.parse_method(method)
     )
     assert "a2 = a;" in str(transformed), str(transformed)
+
+
+def test_f065_duplicate_concat_operand_maps_positionally() -> None:
+    """F-065: for `z = a || a || b`, a slice must map to the operand physically
+    occupying its byte range. The de-duplicating VariableCollectionVisitor
+    collapsed the operands to [a, b], so the positional offsets rewrote
+    `z[lambda : 2*lambda]` (the SECOND copy of `a`) to `b` -- a false
+    equivalence when |a| == |b|. Preserving order + duplicates maps
+    `z[lambda:2*lambda]` to `a` and `z[2*lambda:3*lambda]` to `b`."""
+    second_a = frog_parser.parse_game(
+        """
+        Game G() {
+            BitString<lambda> Query() {
+                BitString<lambda> a <- BitString<lambda>;
+                BitString<lambda> b <- BitString<lambda>;
+                BitString<lambda + lambda + lambda> z = a || a || b;
+                return z[lambda : 2 * lambda];
+            }
+        }
+        """
+    )
+    out = SimplifySpliceTransformer({"lambda": Symbol("lambda")}).transform(second_a)
+    body = str(out)
+    assert "return a;" in body, "z[lambda:2*lambda] must map to the second `a`"
+    assert "return b;" not in body, "z[lambda:2*lambda] must NOT map to `b`"
+
+    third_b = frog_parser.parse_game(
+        """
+        Game G() {
+            BitString<lambda> Query() {
+                BitString<lambda> a <- BitString<lambda>;
+                BitString<lambda> b <- BitString<lambda>;
+                BitString<lambda + lambda + lambda> z = a || a || b;
+                return z[2 * lambda : 3 * lambda];
+            }
+        }
+        """
+    )
+    out_b = SimplifySpliceTransformer({"lambda": Symbol("lambda")}).transform(third_b)
+    assert "return b;" in str(out_b), "z[2*lambda:3*lambda] must map to `b`"

--- a/tests/unit/transforms/test_split_opaque_tuple_field.py
+++ b/tests/unit/transforms/test_split_opaque_tuple_field.py
@@ -217,3 +217,31 @@ class TestSplitOpaqueTupleField:
         )
         result = SplitOpaqueTupleFieldTransformer().transform(game)
         assert result == game
+
+
+def test_f193_out_of_range_constant_index_no_crash() -> None:
+    """F-193: an out-of-range constant tuple index `pair[5]` on a 2-tuple field
+    (typechecker-shielded from source, but AST-reachable) must not crash the
+    pass at `component_types[k]` (IndexError). It declines instead."""
+    from proof_frog import frog_parser
+    from proof_frog.transforms.inlining import SplitOpaqueTupleField
+    from proof_frog.transforms._base import PipelineContext
+    from proof_frog.visitors import NameTypeMap
+
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            [Int, Int] pair;
+            Void Initialize() { pair = D.make(); }
+            Int Use() { return pair[5]; }
+        }
+        """
+    )
+    ctx = PipelineContext(
+        variables={},
+        proof_let_types=NameTypeMap(),
+        proof_namespace={},
+        subsets_pairs=[],
+    )
+    out = SplitOpaqueTupleField().apply(game, ctx)  # must not raise IndexError
+    assert "pair[5]" in str(out)  # declined (out-of-range index)

--- a/tests/unit/transforms/test_split_uniform_samples.py
+++ b/tests/unit/transforms/test_split_uniform_samples.py
@@ -406,3 +406,36 @@ def test_f032_constant_bounds_still_split() -> None:
     parsed = frog_parser.parse_method(method)
     transformed = SplitUniformSampleTransformer({}).transform(parsed)
     assert transformed != parsed, "constant-bound split should still fire"
+
+
+def test_f036_out_of_bounds_slice_declines() -> None:
+    """F-036: `z[4:8]` on a BitString<4> reads outside the sampled range -- an
+    undefined out-of-bounds read, NOT an independent uniform sub-sample. The
+    split must decline (else it fabricates a fresh uniform for undefined bits)."""
+    method = """
+        BitString<4> f() {
+            BitString<4> z <- BitString<4>;
+            return z[4 : 8];
+        }
+        """
+    transformed = SplitUniformSampleTransformer({}).transform(
+        frog_parser.parse_method(method)
+    )
+    assert "z[4 : 8]" in str(transformed)  # not split
+
+
+def test_f036_in_bounds_constant_slices_still_split() -> None:
+    """Positive control: fully in-bounds constant slices of a BitString<8> still
+    split into independent uniform pieces."""
+    method = """
+        Void f() {
+            BitString<8> z <- BitString<8>;
+            BitString<4> a = z[0 : 4];
+            BitString<4> b = z[4 : 8];
+        }
+        """
+    transformed = SplitUniformSampleTransformer({}).transform(
+        frog_parser.parse_method(method)
+    )
+    text = str(transformed)
+    assert "z[0 : 4]" not in text and "z[4 : 8]" not in text  # split

--- a/tests/unit/transforms/test_split_uniform_samples.py
+++ b/tests/unit/transforms/test_split_uniform_samples.py
@@ -439,3 +439,53 @@ def test_f036_in_bounds_constant_slices_still_split() -> None:
     )
     text = str(transformed)
     assert "z[0 : 4]" not in text and "z[4 : 8]" not in text  # split
+
+
+def test_f033_signed_offset_slices_not_split() -> None:
+    """F-033: slices `z[0:n]` and `z[n+c : n+c+n]` of a `BitString<n+n+c>` are
+    disjoint only when `c >= 0` (or `c <= -2n`). The offset `c` appears only
+    inside a compound length, so its sign is unconstrained -- at `c = -n` (legal:
+    the sampled length `n+n+c = n` is nonnegative) both slices are `z[0:n]`, the
+    same bits. The pass must NOT assume `c` positive and split them into
+    independent samples (it previously did, via blanket positivity)."""
+    game = frog_parser.parse_game(
+        """
+        Game Real(Int n, Int c) {
+            Bool Query() {
+                BitString<n + n + c> z <- BitString<n + n + c>;
+                BitString<n> a = z[0 : n];
+                BitString<n> b = z[n + c : n + c + n];
+                return a == b;
+            }
+        }
+        """
+    )
+    result = SplitUniformSampleTransformer(
+        {"n": Symbol("n"), "c": Symbol("c")}
+    ).transform(game)
+    assert result == game, "slices with a signed-offset gap must not be split"
+
+
+def test_f033_standalone_length_gap_still_split() -> None:
+    """F-033 positive control: when the gap between slices is a STANDALONE
+    BitString length symbol (`m` from a `BitString<m>` pad), well-formedness
+    forces `m >= 0`, so the slices are genuinely disjoint and the split must
+    still fire -- the fix restricts positivity to standalone length symbols, it
+    does not blanket-decline symbolic gaps."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Int n, Int m) {
+            BitString<n + m + n> Query() {
+                BitString<n + m + n> z <- BitString<n + m + n>;
+                BitString<n> a = z[0 : n];
+                BitString<m> pad = z[n : n + m];
+                BitString<n> b = z[n + m : n + m + n];
+                return a || pad || b;
+            }
+        }
+        """
+    )
+    result = SplitUniformSampleTransformer(
+        {"n": Symbol("n"), "m": Symbol("m")}
+    ).transform(game)
+    assert result != game, "slices gapped by a standalone length must still split"

--- a/tests/unit/transforms/test_stmt_mutates_var.py
+++ b/tests/unit/transforms/test_stmt_mutates_var.py
@@ -49,3 +49,16 @@ def test_set_minus_form_does_not_grow_its_set() -> None:
 
 def test_plain_read_not_a_write() -> None:
     assert not _stmt_mutates_var(_stmt("Int y = M[0];"), "M")
+
+
+def test_numeric_for_binder_detected() -> None:
+    # F-183/F-188: a `for (Int i = ...)` binder rebinds `i`, shadowing it in
+    # the loop body -- an interference scan must treat it as a write.
+    assert _stmt_mutates_var(_stmt("for (Int i = 0 to 3) { }"), "i")
+    assert not _stmt_mutates_var(_stmt("for (Int i = 0 to 3) { }"), "j")
+
+
+def test_generic_for_binder_detected() -> None:
+    # F-183/F-188: a `for (T e in S)` binder rebinds `e`.
+    assert _stmt_mutates_var(_stmt("for (Int e in S) { }"), "e")
+    assert not _stmt_mutates_var(_stmt("for (Int e in S) { }"), "S_unrelated")

--- a/tests/unit/transforms/test_stmt_mutates_var.py
+++ b/tests/unit/transforms/test_stmt_mutates_var.py
@@ -1,0 +1,51 @@
+"""Unit tests for the shared inlining write-detector `_stmt_mutates_var`.
+
+It is the single source of truth for "does this statement mutate variable X"
+across the inlining passes' interference / stability scans. It must see both
+blind spots the private scanners historically missed:
+
+  - element/slice/field writes (`M[k]=v`, `X.f=v`) -- audit A.1;
+  - `<-uniq[S]` implicit insertion growing the exclusion set S -- audit A.2
+    (F-154/167/175/180/186/208), while the `\\`-set-minus form does NOT grow
+    its set.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import _stmt_mutates_var
+
+
+def _stmt(src: str):
+    # Parse a one-statement method and return its single statement.
+    method = frog_parser.parse_method("Void f() { " + src + " }")
+    return method.block.statements[0]
+
+
+def test_direct_assignment_detected() -> None:
+    assert _stmt_mutates_var(_stmt("M = N;"), "M")
+
+
+def test_element_write_detected() -> None:
+    assert _stmt_mutates_var(_stmt("M[0] = 1;"), "M")
+
+
+def test_field_write_detected() -> None:
+    assert _stmt_mutates_var(_stmt("X.f = 1;"), "X")
+
+
+def test_uniq_draw_grows_exclusion_set() -> None:
+    # `x <-uniq[S] BitString<n>` implicitly inserts into S -> writes S.
+    stmt = _stmt("BitString<n> x <-uniq[S] BitString<n>;")
+    assert _stmt_mutates_var(stmt, "S")
+    # It does NOT write an unrelated name.
+    assert not _stmt_mutates_var(stmt, "T")
+
+
+def test_set_minus_form_does_not_grow_its_set() -> None:
+    # `x <- BitString<n> \ E` samples from the complement but does NOT insert
+    # into E, so E is not mutated.
+    stmt = _stmt("BitString<n> x <- BitString<n> \\ E;")
+    assert not _stmt_mutates_var(stmt, "E")
+
+
+def test_plain_read_not_a_write() -> None:
+    assert not _stmt_mutates_var(_stmt("Int y = M[0];"), "M")

--- a/tests/unit/transforms/test_tuple_equality_decompose.py
+++ b/tests/unit/transforms/test_tuple_equality_decompose.py
@@ -82,3 +82,36 @@ def test_non_tuple_neq_does_not_fire() -> None:
     }
     """
     assert _apply(source) == frog_parser.parse_game(source)
+
+
+def test_f258_optional_operand_not_decomposed() -> None:
+    """F-258: `[1,2] != m` where `m : [Int,Int]?` (could hold None) must NOT be
+    decomposed. The old one-sided arity read projected `m[i]` -> `None[i]`, an
+    undefined read that corrupted an everywhere-defined game (`[1,2] != None`
+    is just `true`) into an always-aborting one -> a valid hop wrongly rejected.
+    Both operands must be products of equal arity."""
+    source = """
+    Game A() {
+        [Int, Int]? m;
+        Bool O() {
+            m = None;
+            return [1, 2] != m;
+        }
+    }
+    """
+    # Unchanged: the non-equal / optional operand declines the decomposition
+    # (no `m[0]` / `m[1]` projection is manufactured).
+    assert _apply(source) == frog_parser.parse_game(source)
+
+
+def test_f258_both_products_still_decompose() -> None:
+    """Positive control: two products of equal arity still decompose."""
+    source = """
+    Game A() {
+        Bool O(Int a, Int b, Int c, Int d) {
+            return [a, b] != [c, d];
+        }
+    }
+    """
+    out = str(_apply(source))
+    assert "a != c" in out and "b != d" in out  # decomposed via OR

--- a/tests/unit/transforms/test_uniform_groupelem_simplification.py
+++ b/tests/unit/transforms/test_uniform_groupelem_simplification.py
@@ -41,3 +41,39 @@ def test_f279_still_fires_single_use_no_loop() -> None:
     out = UniformGroupElemSimplificationTransformer().transform(method)
     assert "u * m" not in str(out)
     assert "return u" in str(out)
+
+
+def test_f282_group_mismatch_not_absorbed() -> None:
+    """F-282: `u <- GroupElem<H>` is uniform over H, but `u * gen` is carried out
+    in the declared group `Grp`. When the sampled group differs from the carrier
+    (`GroupElem<Grp> u <- GroupElem<H>`), `u * gen` lands in the coset `gen*H`, a
+    different support, so absorbing `u * gen` to `u` is unsound and must decline."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Group Grp, Group H, GroupElem<Grp> gen) {
+            GroupElem<Grp> O() {
+                GroupElem<Grp> u <- GroupElem<H>;
+                return u * gen;
+            }
+        }
+        """
+    )
+    result = UniformGroupElemSimplificationTransformer().transform(game)
+    assert result == game, "group-mismatch uniform must not be absorbed"
+
+
+def test_f282_matching_group_still_absorbed() -> None:
+    """F-282 positive control: when the sampled and carrier groups match, the
+    absorption still fires (uniform times anything is uniform over the group)."""
+    game = frog_parser.parse_game(
+        """
+        Game G(Group Grp, GroupElem<Grp> gen) {
+            GroupElem<Grp> O() {
+                GroupElem<Grp> u <- GroupElem<Grp>;
+                return u * gen;
+            }
+        }
+        """
+    )
+    result = UniformGroupElemSimplificationTransformer().transform(game)
+    assert result != game, "matching-group uniform should still be absorbed"

--- a/tests/unit/transforms/test_uniform_groupelem_simplification.py
+++ b/tests/unit/transforms/test_uniform_groupelem_simplification.py
@@ -1,0 +1,43 @@
+"""Tests for UniformGroupElemSimplification (uniform * anything = uniform).
+
+Includes the F-279 loop-multiplicity regression: a single syntactic use of a
+uniform GroupElem inside a loop body is dynamically evaluated once per
+iteration, so the uniform is combined with a fresh partner each time and the
+absorption `u * g^i -> u` is unsound.
+"""
+
+from proof_frog import frog_parser
+from proof_frog.transforms.algebraic import UniformGroupElemSimplificationTransformer
+
+
+def test_f279_declines_single_use_inside_loop() -> None:
+    method = frog_parser.parse_method(
+        """
+        GroupElem<G> Run(Group G) {
+            Map<Int, GroupElem<G>> arr;
+            GroupElem<G> u <- GroupElem<G>;
+            for (Int i = 0 to 2) {
+                arr[i] = u * G.generator ^ i;
+            }
+            return arr[0] / arr[1];
+        }
+        """
+    )
+    out = UniformGroupElemSimplificationTransformer().transform(method)
+    # `u * G.generator ^ i` must NOT collapse to `u` inside the loop.
+    assert "u * G.generator ^ i" in str(out)
+
+
+def test_f279_still_fires_single_use_no_loop() -> None:
+    """Positive control: the same product outside a loop still absorbs."""
+    method = frog_parser.parse_method(
+        """
+        GroupElem<G> Run(Group G, GroupElem<G> m) {
+            GroupElem<G> u <- GroupElem<G>;
+            return u * m;
+        }
+        """
+    )
+    out = UniformGroupElemSimplificationTransformer().transform(method)
+    assert "u * m" not in str(out)
+    assert "return u" in str(out)

--- a/tests/unit/transforms/test_uniform_groupelem_simplification.py
+++ b/tests/unit/transforms/test_uniform_groupelem_simplification.py
@@ -77,3 +77,31 @@ def test_f282_matching_group_still_absorbed() -> None:
     )
     result = UniformGroupElemSimplificationTransformer().transform(game)
     assert result != game, "matching-group uniform should still be absorbed"
+
+
+def test_f281_shared_object_reads_counted_as_two() -> None:
+    """F-281: two live reads that share ONE Variable object must count as two
+    uses, not one. The old count replaced one occurrence at a time via an
+    is-identity ReplaceTransformer, so a shared object was replaced at both
+    slots at once and tallied as a single use -- making a twice-used value look
+    single-use and wrongly absorbed. `_count_variable_uses` counts by AST
+    position."""
+    from proof_frog import frog_ast
+    from proof_frog.transforms.algebraic import _count_variable_uses
+
+    u = frog_ast.Variable("u")  # ONE object referenced at both operand slots
+    shared = frog_ast.BinaryOperation(frog_ast.BinaryOperators.MULTIPLY, u, u)
+    block = frog_ast.Block([frog_ast.ReturnStatement(shared)])
+    assert _count_variable_uses("u", block) == 2, "shared-object reads must count as two"
+
+    # Distinct objects: also two.
+    two = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY,
+        frog_ast.Variable("u"),
+        frog_ast.Variable("u"),
+    )
+    assert _count_variable_uses("u", frog_ast.Block([frog_ast.ReturnStatement(two)])) == 2
+
+    # Single use: one.
+    one = frog_ast.Block([frog_ast.ReturnStatement(frog_ast.Variable("u"))])
+    assert _count_variable_uses("u", one) == 1

--- a/tests/unit/transforms/test_uniform_modint_simplification.py
+++ b/tests/unit/transforms/test_uniform_modint_simplification.py
@@ -137,3 +137,24 @@ def test_f292_matching_modulus_still_absorbed() -> None:
         """
     )
     assert "u + 2" not in result, f"matching-modulus uniform was not absorbed:\n{result}"
+
+
+def test_f293_type_parameterization_use_not_rewritten() -> None:
+    """F-293: the additive-use search descends into Type parameterizations, so a
+    `u + 3` inside a `ModInt<u + 3>` modulus position was found and rewritten to
+    `u`, editing the sampled type of `z` (changing Pr[z==0] from 1/(u+3) to 1/u).
+    A type parameter is not a value expression, so the absorption must decline."""
+    result = _apply(
+        """
+        Game G(Int q) {
+            Bool O() {
+                ModInt<q> z;
+                ModInt<q> u <- ModInt<q>;
+                z <- ModInt<u + 3>;
+                return z == 0;
+            }
+        }
+        """
+    )
+    assert "ModInt<u + 3>" in result, f"a type parameterization was rewritten:\n{result}"
+    assert "ModInt<u>" not in result, f"type edited to ModInt<u>:\n{result}"

--- a/tests/unit/transforms/test_uniform_modint_simplification.py
+++ b/tests/unit/transforms/test_uniform_modint_simplification.py
@@ -103,3 +103,37 @@ def test_loop_reuse_emits_near_miss() -> None:
         and "reused across" in nm.reason
         for nm in ctx.near_misses
     )
+
+
+def test_f292_modulus_mismatch_not_absorbed() -> None:
+    """F-292: `u <- ModInt<q_s>` is uniform over {0..q_s-1}, but `u + c` is
+    computed in the carrier `ModInt<q_t>`. When q_s != q_t (`ModInt<4> u <-
+    ModInt<2>; return u + 2;`) the support shifts from {0,1} to {2,3} -- disjoint
+    -- so absorbing `u + 2` to `u` is unsound and must be declined."""
+    result = _apply(
+        """
+        Game G() {
+            ModInt<4> O() {
+                ModInt<4> u <- ModInt<2>;
+                return u + 2;
+            }
+        }
+        """
+    )
+    assert "u + 2" in result, f"modulus-mismatch uniform was absorbed:\n{result}"
+
+
+def test_f292_matching_modulus_still_absorbed() -> None:
+    """F-292 positive control: when the sampled and carrier moduli match, the
+    absorption still fires (shift of a full-ring uniform is uniform)."""
+    result = _apply(
+        """
+        Game G() {
+            ModInt<4> O() {
+                ModInt<4> u <- ModInt<4>;
+                return u + 2;
+            }
+        }
+        """
+    )
+    assert "u + 2" not in result, f"matching-modulus uniform was not absorbed:\n{result}"

--- a/tests/unit/transforms/test_uniform_xor_simplification.py
+++ b/tests/unit/transforms/test_uniform_xor_simplification.py
@@ -182,3 +182,39 @@ def test_uniform_xor_simplification(
     print("EXPECTED", expected_ast)
     print("TRANSFORMED", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+def test_f288_declines_single_use_inside_loop() -> None:
+    """F-288: a single syntactic XOR-with-uniform use inside a loop is
+    dynamically evaluated per iteration, so the uniform is XORed against a
+    fresh partner each time -- absorbing the operand is unsound."""
+    method = frog_parser.parse_method(
+        """
+        BitString<lambda> f(Map<Int, BitString<lambda>> ms) {
+            BitString<lambda> u <- BitString<lambda>;
+            BitString<lambda> acc = 0^lambda;
+            for (Int i = 0 to 2) {
+                acc = acc + (u + ms[i]);
+            }
+            return acc;
+        }
+        """
+    )
+    out = UniformXorSimplificationTransformer().transform(method)
+    # `u + ms[i]` must NOT collapse to `u` inside the loop.
+    assert "u + ms[i]" in str(out)
+
+
+def test_f288_still_fires_single_use_no_loop() -> None:
+    """Positive control: the same shape without a loop still absorbs."""
+    method = frog_parser.parse_method(
+        """
+        BitString<lambda> f(BitString<lambda> m) {
+            BitString<lambda> u <- BitString<lambda>;
+            return u + m;
+        }
+        """
+    )
+    out = UniformXorSimplificationTransformer().transform(method)
+    assert "u + m" not in str(out)
+    assert "return u" in str(out)

--- a/tests/unit/transforms/test_unique_rf_simplification.py
+++ b/tests/unit/transforms/test_unique_rf_simplification.py
@@ -345,7 +345,16 @@ def test_guard_var_reassigned_before_rf_call_not_simplified() -> None:
 
 def test_fresh_guard_without_reassignment_still_simplified() -> None:
     """Positive control: with no intervening reassignment the guarded fresh
-    draw still enables simplification."""
+    draw still enables simplification.
+
+    This also locks the F-021 resolution. F-021 alleged the cross-call freshness
+    was unsound because a plain (non-``.domain``) ``Set`` field ``S`` stays empty,
+    so two ``<-uniq[S]`` draws could collide across calls. That was adjudicated
+    (USER-ATTENTION sec 1, RESOLVED 2026-06-12): ``x <-uniq[S] T`` has AUTO-ADD
+    semantics -- the sampled value is added to ``S`` -- so successive draws from
+    a persistent field ``S`` never collide, and rewriting the uniquely-keyed RF
+    evaluation to a fresh uniform is sound. Here ``S`` is exactly such a plain
+    ``Set`` field (not ``RF.domain``), so the simplification firing is correct."""
     game = frog_parser.parse_game("""
         Game G() {
             Set<BitString<8>> S;

--- a/tests/unit/transforms/test_unique_rf_simplification.py
+++ b/tests/unit/transforms/test_unique_rf_simplification.py
@@ -362,3 +362,47 @@ def test_fresh_guard_without_reassignment_still_simplified() -> None:
         """)
     result = UniqueRFSimplification().apply(game, _make_ctx())
     assert result != game, "clean fresh-draw RF call should still simplify"
+
+
+def test_f023_unsampled_function_field_not_simplified() -> None:
+    """F-023: a Function field that is never SAMPLED (`H <- Function<...>`) is a
+    known, adversary-computable standard-model function, not a random function.
+    Rewriting a unique-input evaluation `RF(r)` to a fresh uniform draw would
+    replace computable outputs with randomness -- unsound. The game-level
+    `apply` path must decline (it previously collected every FunctionType field
+    regardless of whether it was sampled)."""
+    game = frog_parser.parse_game("""
+        Game RealRF(Int n) {
+            Function<BitString<n>, BitString<n>> RF;
+            Set<BitString<n>> S;
+            BitString<n> Chal() {
+                BitString<n> r <-uniq[S] BitString<n>;
+                BitString<n> z = RF(r);
+                return z;
+            }
+        }
+        """)
+    result = UniqueRFSimplification().apply(game, _make_ctx())
+    assert result == game, "unsampled (known) Function field must not be simplified"
+
+
+def test_f023_sampled_function_field_in_initialize_still_simplified() -> None:
+    """F-023 positive control: a Function field genuinely sampled in Initialize
+    (`RF <- Function<...>`) IS a random function, so the guarded unique-input
+    rewrite still fires -- the sampled-field gate must not over-decline."""
+    game = frog_parser.parse_game("""
+        Game ProbeRF(Int n) {
+            Function<BitString<n>, BitString<n>> RF;
+            Set<BitString<n>> S;
+            Void Initialize() {
+                RF <- Function<BitString<n>, BitString<n>>;
+            }
+            BitString<n> Chal() {
+                BitString<n> r <-uniq[S] BitString<n>;
+                BitString<n> z = RF(r);
+                return z;
+            }
+        }
+        """)
+    result = UniqueRFSimplification().apply(game, _make_ctx())
+    assert result != game, "sampled random function should still be simplified"

--- a/tests/unit/transforms/test_xor_cancellation.py
+++ b/tests/unit/transforms/test_xor_cancellation.py
@@ -454,3 +454,50 @@ def test_xor_cancellation_skips_nondeterministic_pairs() -> None:
         "F.eval(x) + v + F.eval(x) should NOT cancel F.eval(x) terms when "
         "F.eval is non-deterministic"
     )
+
+
+def test_f267_shadowed_let_function_not_reflexive() -> None:
+    """F-267: a proof-let `Function<Int,Int> H` is deterministic, but a
+    method-LOCAL `Function<Int,Int> H;` (declared, unassigned) shadows it.
+    Calling the local is an undefined read, so `H(0) == H(0)` must NOT
+    simplify to `true` (the flat proof_let_types lookup misclassified it)."""
+    from proof_frog.visitors import NameTypeMap
+
+    let_types = NameTypeMap()
+    let_types.set(
+        "H", frog_ast.FunctionType(frog_ast.IntType(), frog_ast.IntType())
+    )
+    method = frog_parser.parse_method(
+        """
+        Bool Cmp() {
+            Function<Int, Int> H;
+            return H(0) == H(0);
+        }
+        """
+    )
+    out = ReflexiveComparisonTransformer(
+        proof_let_types=let_types
+    ).transform(method)
+    assert "H(0) == H(0)" in str(out)  # not simplified to true
+
+
+def test_f267_unshadowed_let_function_still_reflexive() -> None:
+    """Positive control: an unshadowed proof-let Function H is deterministic,
+    so `H(0) == H(0)` still simplifies to `true`."""
+    from proof_frog.visitors import NameTypeMap
+
+    let_types = NameTypeMap()
+    let_types.set(
+        "H", frog_ast.FunctionType(frog_ast.IntType(), frog_ast.IntType())
+    )
+    method = frog_parser.parse_method(
+        """
+        Bool Cmp() {
+            return H(0) == H(0);
+        }
+        """
+    )
+    out = ReflexiveComparisonTransformer(
+        proof_let_types=let_types
+    ).transform(method)
+    assert "H(0) == H(0)" not in str(out)  # simplified to true

--- a/tests/unit/transforms/test_xor_cancellation.py
+++ b/tests/unit/transforms/test_xor_cancellation.py
@@ -501,3 +501,25 @@ def test_f267_unshadowed_let_function_still_reflexive() -> None:
         proof_let_types=let_types
     ).transform(method)
     assert "H(0) == H(0)" not in str(out)  # simplified to true
+
+
+def test_f264_modint_evidence_overrides_leading_bitstring_literal() -> None:
+    """F-264: `_is_bitstring_add_chain` must scan ALL terms, not return on the
+    first. A ModInt term in an ADD chain is definitive evidence of ModInt
+    addition (where `z + z` is `2z`, not `0`), so it overrides a leading
+    `BitStringLiteral`. `0^n + z + z` with `z: ModInt<q>` must be classified as
+    NOT a bitstring/XOR chain, or the pass would XOR-cancel `z + z` to 0."""
+    from proof_frog.transforms.algebraic import _is_bitstring_add_chain
+    from proof_frog.visitors import NameTypeMap
+
+    type_map = NameTypeMap()
+    type_map.set("z", frog_ast.ModIntType(frog_ast.Variable("q")))
+    # 0^n + z + z  (leading BitStringLiteral, later ModInt terms)
+    chain = frog_parser.parse_expression("0^n + z + z")
+    assert _is_bitstring_add_chain(chain, type_map) is False, (
+        "a ModInt term must override a leading BitStringLiteral"
+    )
+    # Control: a pure BitString chain with a leading literal still cancels.
+    type_map.set("x", frog_ast.BitStringType(frog_ast.Variable("n")))
+    bs_chain = frog_parser.parse_expression("0^n + x + x")
+    assert _is_bitstring_add_chain(bs_chain, type_map) is True

--- a/tests/unit/visitors/test_reassigns_or_rebinds.py
+++ b/tests/unit/visitors/test_reassigns_or_rebinds.py
@@ -1,0 +1,53 @@
+"""Tests for the shared write/rebind-detection helper ``reassigns_or_rebinds``.
+
+It backs the RC1 interference checks in many structural-substitution passes, so
+its node-kind coverage must match its "node-kind-complete" docstring."""
+
+from proof_frog import frog_parser
+from proof_frog.visitors import reassigns_or_rebinds
+
+
+def _block(body: str):
+    return frog_parser.parse_method(body).block
+
+
+def test_f196_bare_declaration_counts_as_rebind() -> None:
+    """F-196: a no-initializer local re-declaration ``T x;`` shadows the name and
+    must be reported as a rebind -- otherwise a scope-blind structural
+    substitution could capture the inner binding."""
+    block = _block(
+        """
+        Int O(Int y) {
+            Int x;
+            return y;
+        }
+        """
+    )
+    assert reassigns_or_rebinds({"x"}, block) is True
+
+
+def test_f196_unrelated_declaration_is_not_a_rebind() -> None:
+    """Control: a declaration of a different name does not count."""
+    block = _block(
+        """
+        Int O(Int y) {
+            Int w;
+            return y;
+        }
+        """
+    )
+    assert reassigns_or_rebinds({"x"}, block) is False
+
+
+def test_typed_initializer_declaration_still_counts() -> None:
+    """A typed ``T x = e;`` is an Assignment and was already caught via the
+    l-value path; confirm the F-196 change does not disturb that."""
+    block = _block(
+        """
+        Int O(Int y) {
+            Int x = y + 1;
+            return x;
+        }
+        """
+    )
+    assert reassigns_or_rebinds({"x"}, block) is True

--- a/tests/unit/visitors/test_same_field_visitor.py
+++ b/tests/unit/visitors/test_same_field_visitor.py
@@ -327,3 +327,45 @@ def test_f298_adjacent_writes_still_paired() -> None:
     )
     result = visitors.SameFieldVisitor(("f1", "f2")).visit(game)
     assert isinstance(result, list), "adjacent equal writes should still pair"
+
+
+def test_f299_structurally_identical_unpaired_twin_not_conflated() -> None:
+    """F-299: the paired-statement exemption must match by IDENTITY, not
+    structural equality. `MarkF2Only` writes `f2 = 1` with no matching `f1 = 1`,
+    so f1 and f2 are not always equal. Because that write is structurally
+    identical to `MarkBoth`'s already-paired `f2 = 1`, a structural `in` test
+    wrongly exempted it from analysis and reported the fields as mergeable. With
+    identity matching the unpaired twin is analyzed and the visitor declines."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int f1;
+            Int f2;
+            Void Initialize() { f1 = 0; f2 = 0; }
+            Void MarkBoth() { f1 = 1; f2 = 1; }
+            Void MarkF2Only() { f2 = 1; }
+            Int Get() { return f2; }
+        }
+        """
+    )
+    result = visitors.SameFieldVisitor(("f1", "f2")).visit(game)
+    assert result is None, "an unpaired identical-looking twin write must decline the merge"
+
+
+def test_f299_genuinely_equal_fields_still_merge() -> None:
+    """F-299 positive control: when every write keeps the fields equal, they
+    still pair (identity matching does not over-decline legitimate merges)."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int f1;
+            Int f2;
+            Void Initialize() { f1 = 0; f2 = 0; }
+            Void MarkA() { f1 = 1; f2 = 1; }
+            Void MarkB() { f1 = 2; f2 = 2; }
+            Int Get() { return f2; }
+        }
+        """
+    )
+    result = visitors.SameFieldVisitor(("f1", "f2")).visit(game)
+    assert isinstance(result, list), "genuinely-equal fields should still merge"

--- a/tests/unit/visitors/test_same_field_visitor.py
+++ b/tests/unit/visitors/test_same_field_visitor.py
@@ -257,3 +257,73 @@ def test_same_field_visitor(game: str, pair: tuple[str, str], expected: bool) ->
         assert isinstance(are_the_same, list)
     else:
         assert are_the_same is None
+
+
+def test_f298_early_return_between_paired_writes_not_same() -> None:
+    """F-298: `f1 = 1; if (b) { return 0; } f2 = 1;` -- the two writes are
+    separated by an early return, so on the `Mark(true)` trace `f1` is written
+    but `f2` is not. The fields are NOT equal on every trace, so SameFieldVisitor
+    must report them as not-the-same (the pass must not merge them)."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int f1;
+            Int f2;
+            Void Initialize() { f1 = 0; f2 = 0; }
+            Int Mark(Bool b) {
+                f1 = 1;
+                if (b) { return 0; }
+                f2 = 1;
+                return 1;
+            }
+            Int GetTwo() { return f2; }
+        }
+        """
+    )
+    result = visitors.SameFieldVisitor(("f1", "f2")).visit(game)
+    assert result is None, "writes separated by an early return must not be paired"
+
+
+def test_f298_copy_behind_early_return_not_same() -> None:
+    """F-298 copy path: `f1 = G.rand(); if (b) { return 0; } f2 = f1;` -- the
+    copy that would equate the fields is skippable via the early return, so they
+    are not equal on every trace."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int f1;
+            Int f2;
+            Void Initialize() { f1 = 0; f2 = 0; }
+            Int Mark(Bool b) {
+                f1 = G.rand();
+                if (b) { return 0; }
+                f2 = f1;
+                return 1;
+            }
+            Int GetTwo() { return f2; }
+        }
+        """
+    )
+    result = visitors.SameFieldVisitor(("f1", "f2")).visit(game)
+    assert result is None, "a copy behind an early return must not be paired"
+
+
+def test_f298_adjacent_writes_still_paired() -> None:
+    """F-298 positive control: with no early return between them, the two equal
+    writes still pair (a return BEFORE both writes is fine -- both are skipped
+    together)."""
+    game = frog_parser.parse_game(
+        """
+        Game G() {
+            Int f1;
+            Int f2;
+            Void Initialize() { f1 = 0; f2 = 0; }
+            Void Mark() {
+                f1 = 1;
+                f2 = 1;
+            }
+        }
+        """
+    )
+    result = visitors.SameFieldVisitor(("f1", "f2")).visit(game)
+    assert isinstance(result, list), "adjacent equal writes should still pair"


### PR DESCRIPTION
## Transform-soundness fix campaign (audit 2026-06)

This branch lands the accumulated fixes from the transform-soundness audit — ~100
findings across the canonicalization engine. The campaign's one invariant: the
engine may **refuse** a true equivalence, but must **never certify** a false one.
Each finding is a place where a `TransformPass` (or a shared helper it relies on)
could rewrite one game into an observably different one, so the fix in every case
is a **soundness gate that declines** on the unsound precondition while still
firing on the sound control.

The audit's findings collapsed to a handful of recurring root-cause mechanisms,
so most fixes are centralized in shared helpers and inherited by every pass that
shared the blind spot, rather than patched pass-by-pass.

### Major mechanisms

- **Reference / write-scan completeness (RC1).** The shared scanners
  (`lvalue_base_name`, `referenced_variable_names`, `reassigns_or_rebinds`,
  `_stmt_mutates_var`, `_count_assignments_recursive`) now recognize element /
  slice / field writes (`M[k]=v`, `X.f=v`), `<-uniq[S]` exclusion-set insertion,
  `for`-binder rebinding, bare `VariableDeclaration` shadows, and names spelled
  through a `FieldAccess` — all previously invisible to a bare-`Variable` scan.
- **Purity / determinism gates (RC3).** Delete / dedup / duplicate / fold / move
  passes consult `has_nondeterministic_call` before treating two textual copies
  of a call as the same value.
- **Capture-unsafe naming & scope (RC4).** Fresh-name generation and
  structural substitution no longer capture loop counters, shadowed locals, or
  out-of-block references; several passes gained an `_variable_escapes_block`
  scope guard.
- **Sample-movement domain invariance (RC5).** Passes that relocate a uniform
  draw decline when a name in its sampling domain is mutated across the move, or
  when the domain is a capturable expression rather than a fixed type.
- **Method-scoped type maps.** Type-of-a-bare-name reasoning is scoped per
  method (fields + that method's locals/params) instead of a flat game-wide map
  that conflated same-named parameters across sibling methods. (`Expression`
  subclasses `Type` in the AST, so a genuine type test is `Type and not
  Expression`.)
- **Algebraic value-stability, commutative purity, exponent/modulus, GroupElem
  identity, uniform-absorption.**
- **Malformed-shape & node-kind guards** in control-flow and tuple passes
  (empty-condition / surplus-block if-statements, `NoneExpression` trailings,
  non-literal `ProductType` spaces, whole-var product samples).
- **Dependency-analysis fixpoints** for game-wide field-necessity and loop-body
  liveness.

### Findings closed (~100), by area

- **`visitors.py` (shared helpers):** F-196, F-255, F-298, F-299, F-322,
  F-330, F-331
- **`inlining.py`:** F-144, F-146, F-148, F-150, F-152, F-154, F-155, F-160,
  F-166, F-170, F-174, F-179, F-181, F-183, F-184, F-187, F-188, F-189, F-194,
  F-197, F-201, F-206, F-207, F-211, F-212, F-215, F-216, F-218, F-219, F-221,
  F-222, F-227, F-231, F-234, F-235
- **`algebraic.py`:** F-242, F-245, F-247, F-248, F-251, F-252, F-258, F-260,
  F-264, F-267, F-272, F-278, F-279, F-281, F-282, F-285, F-286, F-288, F-292,
  F-293
- **`sampling.py`:** F-030, F-033, F-036, F-042, F-051, F-052, F-058, F-065
- **`control_flow.py`:** F-085, F-117, F-123, F-125, F-127
- **`tuples.py`:** F-313, F-316, F-324
- **`standardization.py`:** F-306, F-307
- **`random_functions.py`:** F-010, F-015, F-023
- **`map_iteration.py`:** F-143
- **`dependencies.py`:** F-319, F-320
- **`alpha_rename.py`:** F-237  •  **`_wrappers.py`:** F-249
- **engine / AST:** F-328, F-329, F-333 (`proof_engine.py`), F-335, F-336
  (`frog_ast.py`)
- **verify-and-flip (regression test only, closed by a sibling fix):** F-021,
  F-075, F-077, F-078, F-158, F-198, F-264, F-296

Each commit closes one finding (or a small sibling group) and carries the full
root-cause analysis in its body — the history is intentionally atomic; please
merge-commit or rebase-merge, **not squash**.

### Testing

- `pytest tests/integration/test_proofs.py` — **170/170** example proofs pass
  (zero fallout on the flagship CFRG hybrid-KEM family).
- Full `pytest tests/unit` green; every finding has positive + negative
  regression tests (the attack shape declines, the sound control still fires),
  plus near-miss instrumentation tests.
- `make lint` — black / mypy / pylint **10.00/10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
