### PR TITLE
Type-check bare Bool/Int/optional type keywords in expression position

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ The essentials for writing correct FrogLang:
 - `Type x <-uniq[S] Type;` — sample uniformly from `Type \ S` (rejection sampling)
 - `M[k] <- Type;` — sample into a map entry
 - `Function<D, R> H <- Function<D, R>;` — sample a random function (ROM)
+- A sampling domain must be finite: `Bool`, `BitString<n>`, `ModInt<q>`, `Set` members etc. are samplable, but `Int` (unbounded) and optional types `T?` (no weight for `None`) are rejected on both sampling forms
 
 **Non-determinism default:** Scheme method calls (e.g., `F.evaluate(k, x)`) are **non-deterministic by default** — each invocation may return a different result even with the same arguments.
 

--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -1901,6 +1901,9 @@ class CheckTypeVisitor(VariableTypeVisitor):
         self.ast_type_map.set(int_type, int_type)
 
     def leave_optional_type(self, optional_type: frog_ast.OptionalType) -> None:
+        # T? is only a type when T is: this rejects Set? and Group? the same
+        # way bare Set and Group are rejected (both are kinds, not types).
+        self.get_type_from_ast(optional_type.the_type)
         self.ast_type_map.set(optional_type, optional_type)
 
     def leave_bit_string_type(self, bit_string_type: frog_ast.BitStringType) -> None:
@@ -2435,6 +2438,31 @@ class CheckTypeVisitor(VariableTypeVisitor):
                 f"{_truncate_expr(assignment.value)} has type {found_type}, expected {expected_type}",
             )
 
+    def _check_samplable(
+        self, location: frog_ast.ASTNode, sampled_from: PossibleType
+    ) -> None:
+        """Reject sampling domains that carry no uniform distribution.
+
+        Bool, BitString<n>, ModInt<q> and friends are finite, so a uniform
+        draw is well defined. Int is unbounded, and an optional type has no
+        natural weight for None, so neither admits one. Applies to both
+        sampling forms ('<-' and '<-uniq[S]' / '<- T \\ E').
+        """
+        resolved = self._resolve_type_alias(sampled_from)
+        if isinstance(resolved, frog_ast.IntType):
+            self.print_error(
+                location,
+                "Cannot sample from Int: uniform sampling requires a finite type",
+                hint="use a bounded type such as BitString<n> or ModInt<q>",
+            )
+        if isinstance(resolved, frog_ast.OptionalType):
+            self.print_error(
+                location,
+                f"Cannot sample from optional type {resolved}:"
+                " uniform sampling requires a finite type",
+                hint=f"sample from {resolved.the_type} instead",
+            )
+
     def leave_sample(self, sample: frog_ast.Sample) -> None:
         super().leave_sample(sample)
         if not isinstance(sample.sampled_from, frog_ast.Type):
@@ -2450,6 +2478,7 @@ class CheckTypeVisitor(VariableTypeVisitor):
             else self.get_type_from_ast(sample.var)
         )
         found_type = self.get_type_from_ast(sample.sampled_from)
+        self._check_samplable(sample, found_type)
         if not self.check_types(expected_type, found_type):
             self.print_error(
                 sample,
@@ -2458,6 +2487,7 @@ class CheckTypeVisitor(VariableTypeVisitor):
 
     def leave_unique_sample(self, unique_sample: frog_ast.UniqueSample) -> None:
         super().leave_unique_sample(unique_sample)
+        self._check_samplable(unique_sample, unique_sample.sampled_from)
         # Check that unique_set has type Set<D> and sampled_from has type D
         set_type = self.get_type_from_ast(unique_sample.unique_set)
         if not isinstance(set_type, frog_ast.SetType):

--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -1894,6 +1894,15 @@ class CheckTypeVisitor(VariableTypeVisitor):
         my_type = self.get_type(variable.name)
         self.ast_type_map.set(variable, my_type)
 
+    def leave_bool_type(self, bool_type: frog_ast.BoolType) -> None:
+        self.ast_type_map.set(bool_type, bool_type)
+
+    def leave_int_type(self, int_type: frog_ast.IntType) -> None:
+        self.ast_type_map.set(int_type, int_type)
+
+    def leave_optional_type(self, optional_type: frog_ast.OptionalType) -> None:
+        self.ast_type_map.set(optional_type, optional_type)
+
     def leave_bit_string_type(self, bit_string_type: frog_ast.BitStringType) -> None:
         if bit_string_type.parameterization is not None:
             parameterized_type = self.get_type_from_ast(

--- a/tests/unit/typechecking/test_sample_domains.py
+++ b/tests/unit/typechecking/test_sample_domains.py
@@ -1,0 +1,131 @@
+"""A sampling domain must be a finite type.
+
+Registering ``Bool``/``Int``/``T?`` in the AST type map (so they can appear
+as tuple components) also makes them reachable as the right-hand side of a
+sample. ``Bool`` is a legitimate uniform domain; ``Int`` is unbounded and an
+optional type has no natural weight for ``None``, so both stay rejected on
+either sampling form."""
+
+import pytest
+
+from proof_frog import frog_parser, semantic_analysis
+
+
+def _check_game(source: str) -> None:
+    game = frog_parser.parse_game(source)
+    visitor = semantic_analysis.CheckTypeVisitor({}, "test", {})
+    visitor.visit(game)
+
+
+def _check_game_fails(source: str) -> None:
+    with pytest.raises(semantic_analysis.FailedTypeCheck):
+        _check_game(source)
+
+
+class TestSamplableDomains:
+    def test_bool_is_samplable(self) -> None:
+        _check_game("""
+            Game G() {
+                Bool Run() {
+                    Bool b <- Bool;
+                    return b;
+                }
+            }
+            """)
+
+    def test_bit_string_is_samplable(self) -> None:
+        _check_game("""
+            Game G(Int n) {
+                Bool Run() {
+                    BitString<n> r <- BitString<n>;
+                    return r == r;
+                }
+            }
+            """)
+
+    def test_mod_int_is_samplable(self) -> None:
+        _check_game("""
+            Game G(Int q) {
+                Bool Run() {
+                    ModInt<q> x <- ModInt<q>;
+                    return x == x;
+                }
+            }
+            """)
+
+    def test_uniq_sample_from_finite_type(self) -> None:
+        _check_game("""
+            Game G(Int n) {
+                Set<BitString<n>> seen;
+                Bool Run() {
+                    BitString<n> r <-uniq[seen] BitString<n>;
+                    return r == r;
+                }
+            }
+            """)
+
+
+class TestUnsamplableDomains:
+    def test_int_is_not_samplable(self) -> None:
+        _check_game_fails("""
+            Game G() {
+                Bool Run() {
+                    Int n <- Int;
+                    return n == 0;
+                }
+            }
+            """)
+
+    def test_int_is_not_samplable_with_uniq(self) -> None:
+        _check_game_fails("""
+            Game G() {
+                Set<Int> seen;
+                Bool Run() {
+                    Int n <-uniq[seen] Int;
+                    return n == 0;
+                }
+            }
+            """)
+
+    def test_int_is_not_samplable_with_exclusion(self) -> None:
+        """The one-shot ``x <- T \\ E`` form is checked too."""
+        _check_game_fails("""
+            Game G() {
+                Set<Int> seen;
+                Bool Run() {
+                    Int n <- Int \\ seen;
+                    return n == 0;
+                }
+            }
+            """)
+
+    def test_optional_bool_is_not_samplable(self) -> None:
+        _check_game_fails("""
+            Game G() {
+                Bool Run() {
+                    Bool? b <- Bool?;
+                    return b == None;
+                }
+            }
+            """)
+
+    def test_optional_bit_string_is_not_samplable(self) -> None:
+        _check_game_fails("""
+            Game G(Int n) {
+                Bool Run() {
+                    BitString<n>? r <- BitString<n>?;
+                    return r == None;
+                }
+            }
+            """)
+
+    def test_optional_is_not_samplable_with_uniq(self) -> None:
+        _check_game_fails("""
+            Game G(Int n) {
+                Set<BitString<n>?> seen;
+                Bool Run() {
+                    BitString<n>? r <-uniq[seen] BitString<n>?;
+                    return r == None;
+                }
+            }
+            """)

--- a/tests/unit/typechecking/test_type_keywords_in_set_exprs.py
+++ b/tests/unit/typechecking/test_type_keywords_in_set_exprs.py
@@ -1,0 +1,77 @@
+"""Bare type keywords must type-check in expression position, e.g. as
+components of a tuple-set field initializer like
+``Set State = [Bool, Message, Message];``.
+
+``CheckTypeVisitor`` records a type node in the AST type map from its
+``leave_*`` handler; a type node with no handler makes the enclosing
+product fail with ``Could not determine type of <T>``. ``Bool``, ``Int``
+and ``T?`` had no handler."""
+
+from pathlib import Path
+
+from proof_frog import frog_parser, semantic_analysis
+
+
+def _check_primitive(tmp_path: Path, source: str) -> None:
+    file_path = tmp_path / "Test.primitive"
+    file_path.write_text(source)
+    root = frog_parser.parse_file(str(file_path))
+    semantic_analysis.check_well_formed(root, str(file_path))
+
+
+def test_bool_in_tuple_set_field(tmp_path: Path) -> None:
+    _check_primitive(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set State = [Bool, Message, Message];
+
+            State Wrap(Bool choice, Message m0, Message m1);
+        }
+        """,
+    )
+
+
+def test_int_in_tuple_set_field(tmp_path: Path) -> None:
+    _check_primitive(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set Counters = [Int, Message];
+
+            Counters Wrap(Int n, Message m);
+        }
+        """,
+    )
+
+
+def test_optional_in_tuple_set_field(tmp_path: Path) -> None:
+    """``T?`` has the same missing-handler gap as ``Bool``/``Int``."""
+    _check_primitive(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set Maybe = [Message?, Bool];
+
+            Maybe Wrap(Message? m, Bool found);
+        }
+        """,
+    )
+
+
+def test_optional_of_keyword_type_in_tuple_set_field(tmp_path: Path) -> None:
+    """``Bool?`` needs both the optional and the bool handler."""
+    _check_primitive(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set Flags = [Bool?, Int?, Message];
+
+            Flags Wrap(Bool? b, Int? n, Message m);
+        }
+        """,
+    )

--- a/tests/unit/typechecking/test_type_keywords_in_set_exprs.py
+++ b/tests/unit/typechecking/test_type_keywords_in_set_exprs.py
@@ -9,6 +9,8 @@ and ``T?`` had no handler."""
 
 from pathlib import Path
 
+import pytest
+
 from proof_frog import frog_parser, semantic_analysis
 
 
@@ -17,6 +19,11 @@ def _check_primitive(tmp_path: Path, source: str) -> None:
     file_path.write_text(source)
     root = frog_parser.parse_file(str(file_path))
     semantic_analysis.check_well_formed(root, str(file_path))
+
+
+def _check_primitive_fails(tmp_path: Path, source: str) -> None:
+    with pytest.raises(semantic_analysis.FailedTypeCheck):
+        _check_primitive(tmp_path, source)
 
 
 def test_bool_in_tuple_set_field(tmp_path: Path) -> None:
@@ -75,3 +82,130 @@ def test_optional_of_keyword_type_in_tuple_set_field(tmp_path: Path) -> None:
         }
         """,
     )
+
+
+def test_tuple_component_type_is_recorded(tmp_path: Path) -> None:
+    """The recorded product must be usable, not merely accepted: indexing
+    ``State`` has to yield ``Bool`` at 0 and ``Message`` at 1."""
+    (tmp_path / "P.primitive").write_text("""
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set State = [Bool, Message, Message];
+
+            State Wrap(Bool choice, Message m0, Message m1);
+            Message Unwrap(State s);
+        }
+        """)
+    scheme_path = tmp_path / "Impl.scheme"
+    scheme_path.write_text("""
+        import 'P.primitive';
+
+        Scheme Impl(Set MessageSpace) extends P {
+            Set Message = MessageSpace;
+            Set State = [Bool, Message, Message];
+
+            State Wrap(Bool choice, Message m0, Message m1) {
+                return [choice, m0, m1];
+            }
+
+            Message Unwrap(State s) {
+                if (s[0]) {
+                    return s[1];
+                }
+                return s[2];
+            }
+        }
+        """)
+    root = frog_parser.parse_file(str(scheme_path))
+    semantic_analysis.check_well_formed(root, str(scheme_path))
+
+
+# Negative cases: bare `Set` and `Group` are kinds rather than types, so they
+# stay rejected as tuple components -- including under a `?`, which must not
+# launder a kind into a type.
+
+
+def test_bare_set_in_tuple_set_field_rejected(tmp_path: Path) -> None:
+    _check_primitive_fails(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set Bad = [Set, Message];
+
+            Bad Wrap(Message m);
+        }
+        """,
+    )
+
+
+def test_bare_group_in_tuple_set_field_rejected(tmp_path: Path) -> None:
+    _check_primitive_fails(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set Bad = [Group, Message];
+
+            Bad Wrap(Message m);
+        }
+        """,
+    )
+
+
+def test_optional_set_in_tuple_set_field_rejected(tmp_path: Path) -> None:
+    _check_primitive_fails(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set Bad = [Set?, Message];
+
+            Bad Wrap(Message m);
+        }
+        """,
+    )
+
+
+def test_optional_group_in_tuple_set_field_rejected(tmp_path: Path) -> None:
+    """``Group?`` parses as ``OptionalType(GroupType)``, so it slips past the
+    name resolution that rejects bare ``Group`` as an undefined variable."""
+    _check_primitive_fails(
+        tmp_path,
+        """
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set Bad = [Group?, Message];
+
+            Bad Wrap(Message m);
+        }
+        """,
+    )
+
+
+def test_tuple_component_mismatch_still_rejected(tmp_path: Path) -> None:
+    """Registering the components must not make the product permissive."""
+    (tmp_path / "P.primitive").write_text("""
+        Primitive P(Set MessageSpace) {
+            Set Message = MessageSpace;
+            Set State = [Bool, Message, Message];
+
+            State Wrap(Bool choice, Message m0, Message m1);
+        }
+        """)
+    scheme_path = tmp_path / "Impl.scheme"
+    scheme_path.write_text("""
+        import 'P.primitive';
+
+        Scheme Impl(Set MessageSpace) extends P {
+            Set Message = MessageSpace;
+            Set State = [Bool, Message, Message];
+
+            State Wrap(Bool choice, Message m0, Message m1) {
+                return [m0, m0, m1];
+            }
+        }
+        """)
+    with pytest.raises(semantic_analysis.FailedTypeCheck):
+        root = frog_parser.parse_file(str(scheme_path))
+        semantic_analysis.check_well_formed(root, str(scheme_path))


### PR DESCRIPTION
This issue was found together with @soechsner and @DoreenRiepel. The fix and following summary are from Claude.

### Problem
A tuple-set field initializer containing a bare `Bool`, `Int`, or an optional `T?` fails type checking:

```
Primitive P(Set MessageSpace) {
    Set Message = MessageSpace;
    Set State = [Bool, Message, Message];   // error: Could not determine type of Bool
    Set Maybe = [Message?, Bool];           // error: Could not determine type of Message?

    State Wrap(Bool choice, Message m0, Message m1);
}
```

The equivalent product with `BitString`/`ModInt`/`Array`/`Map` components type-checks fine. This blocks a natural way to write scheme state whenever a flag or counter has to sit alongside the other components — the error arrives at the primitive, before any proof can be attempted.

### Root cause
`CheckTypeVisitor` types a product by looking each component up in the AST type map, and a type node is registered there by its `leave_*` handler. `BitString, ModInt, Map, Array, GroupElem` and `Function` all have one; `BoolType`, `IntType` and `OptionalType` had none, so the enclosing product could not be typed.

### Fix
Three `leave_*` handlers following the existing `self.ast_type_map.set(X, X)` idiom used by `leave_function_type` / `leave_map_type` / `leave_product_type`.

`SetType` and `GroupType` are left unhandled deliberately — bare `Set` and `Group` are kinds rather than types, so continuing to reject them is correct.

### Tests
`tests/unit/typechecking/test_type_keywords_in_set_exprs.py` — `Bool`, `Int`, `T?`, and `Bool?`/`Int?` (which need both the optional and the keyword handler) as tuple-set components. Each raises `FailedTypeCheck` without the fix.