### PR TITLE
Fix non-termination in ExtractRepeatedTupleAccess on shadowed tuple/slice locals

### DIFF
--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1589,11 +1589,12 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
     """Extract repeated ``var[constant]`` accesses and slice expressions.
 
     **Tuple phase.** When ``v[i]`` (variable + integer index) appears
-    2+ times in a block and ``v`` is declared with a product (tuple)
-    type, inserts ``Ti __cse_v_i__ = v[i];`` right after ``v``'s
-    assignment and replaces every occurrence with the new variable.
-    Also fires when ``v`` is a ``GenericFor`` loop binder, inserting the
-    extraction at the top of the loop body. This symmetrises games whose
+    2+ times *after ``v``'s definition* in a block and ``v`` is declared
+    with a product (tuple) type, inserts ``Ti __cse_v_i__ = v[i];`` right
+    after ``v``'s assignment and replaces every occurrence with the new
+    variable. Also fires when ``v`` is a ``GenericFor`` loop binder,
+    inserting the extraction at the top of the loop body. This
+    symmetrises games whose
     loop body source writes ``m = e[0]`` explicitly against games whose
     loop body obtains the same accesses via inlining a helper method.
 
@@ -1604,7 +1605,8 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
     parameter).
 
     **Slice phase.** When a ``v[A:B]`` slice expression (variable base,
-    syntactically-equal bounds) appears 2+ times in a block, inserts
+    syntactically-equal bounds) appears 2+ times *after ``v``'s
+    definition* in a block, inserts
     ``BitString<B - A> __cse_slice_v_N__ = v[A:B];`` at the definition
     point (after ``v``'s block-local assignment, or at position 0 for
     method parameters / fields / enclosing-scope bases) and replaces
@@ -1616,6 +1618,20 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
     ``k2enc`` in multiple branches) against games whose scan-loop body
     obtains the same slice via inlining a helper + concat-equality
     decomposition.
+
+    **Why both phases count only post-definition occurrences.** The
+    replacement step rewrites only the statements following the base's
+    definition, so an occurrence at or before it -- e.g. inside an
+    earlier branch block that redeclares the same name, which is a
+    *different* variable -- can never be replaced. Counting such an
+    occurrence makes the hoist fire without reducing the count: the
+    inserted extraction itself contains a fresh ``v[i]`` / ``v[A:B]``,
+    which pairs with the unreachable occurrence and re-fires the hoist
+    on the next pass, recursing until the interpreter's recursion
+    limit. Restricting the count to the region replacement reaches can
+    only ever *decline* a hoist -- and it cannot change the outcome of
+    any run that previously terminated, since every configuration it
+    declines is exactly one that used to diverge.
     """
 
     def __init__(
@@ -1631,6 +1647,42 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
         self._scope_types: dict[str, frog_ast.Type] = {}
         self._proof_namespace: frog_ast.Namespace = proof_namespace or {}
         self._proof_let_types = proof_let_types
+
+    def _record_unreachable_occurrences(
+        self,
+        block: frog_ast.Block,
+        target: str,
+        var_name: str,
+        def_idx: int,
+        total: int,
+        reachable: int,
+    ) -> None:
+        """Report a hoist declined because too few occurrences of ``target``
+        follow ``var_name``'s definition, so the rest are unreachable to the
+        replacement step (see the class docstring).
+
+        ``def_idx >= 0`` holds at every call site: a scope-external base has
+        ``def_idx == -1``, and then every occurrence index exceeds it, so
+        ``reachable == total >= 2`` and the decline cannot trigger. The guard
+        below is kept regardless -- a negative index would silently resolve to
+        the *last* statement of the block and report a misleading location if
+        that invariant is ever broken.
+        """
+        if self.ctx is None:
+            return
+        self.ctx.near_misses.append(
+            NearMiss(
+                transform_name="Extract Repeated Tuple Access",
+                reason=(
+                    f"Cannot extract {target}: appears {total} times but only"
+                    f" {reachable} after the definition of '{var_name}'"
+                ),
+                location=(block.statements[def_idx].origin if def_idx >= 0 else None),
+                suggestion=None,
+                variable=var_name,
+                method=None,
+            )
+        )
 
     def transform_generic_for(self, gf: frog_ast.GenericFor) -> frog_ast.GenericFor:
         new_over = self.transform(gf.over)
@@ -1700,6 +1752,10 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
         var_types: dict[str, frog_ast.Type] = dict(self._scope_types)
         # Sentinel -1 = scope-external (insert at top of this block).
         var_def_idx: dict[str, int] = {name: -1 for name in var_types}
+        # NOTE: this loop keeps the LAST block-local declaration of a name,
+        # whereas the slice phase below stops at the FIRST. Each phase is
+        # self-consistent -- the same index drives both the occurrence count
+        # and the insertion point -- but the two are not interchangeable.
         for idx, stmt in enumerate(block.statements):
             if (
                 isinstance(stmt, frog_ast.Assignment)
@@ -1710,12 +1766,9 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
                 var_def_idx[stmt.var.name] = idx
 
         # Count occurrences of each (var_name, index) ArrayAccess pattern,
-        # tracking the statement index of each occurrence. Replacement only
-        # rewrites statements after the base variable's definition, so only
-        # occurrences there may count toward the 2+ threshold: an occurrence
-        # at or before the definition (e.g. inside an earlier branch block
-        # that redeclares the same name) can never be replaced, and counting
-        # it would re-fire the extraction on every pass, recursing forever.
+        # tracking the statement index of each so that only those after the
+        # base's definition count toward the threshold (class docstring:
+        # "Why both phases count only post-definition occurrences").
         access_stmt_idxs: dict[tuple[str, int], list[int]] = {}
         for stmt_idx, stmt in enumerate(block.statements):
 
@@ -1746,27 +1799,14 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
 
             count = sum(1 for i in occurrence_idxs if i > var_def_idx[var_name])
             if count < 2:
-                if self.ctx is not None:
-                    def_idx = var_def_idx[var_name]
-                    self.ctx.near_misses.append(
-                        NearMiss(
-                            transform_name="Extract Repeated Tuple Access",
-                            reason=(
-                                f"Cannot extract '{var_name}[{idx_val}]':"
-                                f" appears {len(occurrence_idxs)} times but"
-                                f" only {count} after the definition of"
-                                f" '{var_name}'"
-                            ),
-                            location=(
-                                block.statements[def_idx].origin
-                                if def_idx >= 0
-                                else None
-                            ),
-                            suggestion=None,
-                            variable=var_name,
-                            method=None,
-                        )
-                    )
+                self._record_unreachable_occurrences(
+                    block,
+                    f"'{var_name}[{idx_val}]'",
+                    var_name,
+                    var_def_idx[var_name],
+                    len(occurrence_idxs),
+                    count,
+                )
                 continue
 
             # Skip if the base variable is reassigned after its definition
@@ -1852,10 +1892,8 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
         # Unlike the tuple path, method parameters are eligible as
         # bases (SimplifyTuple only folds ArrayAccess, not Slice, so
         # hoisting a slice of a param doesn't interact).
-        # As in the tuple phase, track the statement index of each occurrence:
-        # replacement only reaches statements after the base's definition, so
-        # an occurrence at or before it (e.g. inside an earlier branch block
-        # that redeclares the same name) must not count toward the threshold.
+        # As in the tuple phase, track the statement index of each occurrence
+        # so that only post-definition ones count toward the threshold.
         slice_occurrences: list[tuple[int, frog_ast.Slice]] = []
         for stmt_idx, stmt in enumerate(block.statements):
 
@@ -1917,32 +1955,17 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
                     break
 
             # Only occurrences the replacement step can actually reach may
-            # count toward the 2+ threshold. Counting an unreachable one
-            # re-fires the hoist on every pass -- and since the inserted
-            # extraction itself contains a fresh `v[A:B]`, the count never
-            # drops back below 2 and the recursion never terminates.
+            # count toward the 2+ threshold.
             count = sum(1 for i in occurrence_idxs if i > def_idx)
             if count < 2:
-                if self.ctx is not None:
-                    self.ctx.near_misses.append(
-                        NearMiss(
-                            transform_name="Extract Repeated Tuple Access",
-                            reason=(
-                                f"Cannot extract the slice '{rep_slice}':"
-                                f" appears {len(occurrence_idxs)} times but"
-                                f" only {count} after the definition of"
-                                f" '{var_name}'"
-                            ),
-                            location=(
-                                block.statements[def_idx].origin
-                                if def_idx >= 0
-                                else None
-                            ),
-                            suggestion=None,
-                            variable=var_name,
-                            method=None,
-                        )
-                    )
+                self._record_unreachable_occurrences(
+                    block,
+                    f"the slice '{rep_slice}'",
+                    var_name,
+                    def_idx,
+                    len(occurrence_idxs),
+                    count,
+                )
                 continue
 
             # Skip if any of the slice's free variables -- the base AND the

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1648,7 +1648,7 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
         self._proof_namespace: frog_ast.Namespace = proof_namespace or {}
         self._proof_let_types = proof_let_types
 
-    def _record_unreachable_occurrences(
+    def _record_unreachable_occurrences(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         block: frog_ast.Block,
         target: str,

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -1622,8 +1622,10 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
         self,
         proof_namespace: frog_ast.Namespace | None = None,
         proof_let_types: NameTypeMap | None = None,
+        ctx: PipelineContext | None = None,
     ) -> None:
         super().__init__()
+        self.ctx = ctx
         # Loop-binder types visible from the enclosing ``GenericFor``.
         # Extraction for these is inserted at position 0 of the loop body.
         self._scope_types: dict[str, frog_ast.Type] = {}
@@ -1707,25 +1709,32 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
                 var_types[stmt.var.name] = stmt.the_type
                 var_def_idx[stmt.var.name] = idx
 
-        # Count occurrences of each (var_name, index) ArrayAccess pattern
-        access_counts: dict[tuple[str, int], int] = {}
-        for stmt in block.statements:
+        # Count occurrences of each (var_name, index) ArrayAccess pattern,
+        # tracking the statement index of each occurrence. Replacement only
+        # rewrites statements after the base variable's definition, so only
+        # occurrences there may count toward the 2+ threshold: an occurrence
+        # at or before the definition (e.g. inside an earlier branch block
+        # that redeclares the same name) can never be replaced, and counting
+        # it would re-fire the extraction on every pass, recursing forever.
+        access_stmt_idxs: dict[tuple[str, int], list[int]] = {}
+        for stmt_idx, stmt in enumerate(block.statements):
 
-            def counter(node: frog_ast.ASTNode) -> bool:
+            def counter(node: frog_ast.ASTNode, stmt_idx: int = stmt_idx) -> bool:
                 if (
                     isinstance(node, frog_ast.ArrayAccess)
                     and isinstance(node.the_array, frog_ast.Variable)
                     and isinstance(node.index, frog_ast.Integer)
                 ):
                     key = (node.the_array.name, node.index.num)
-                    access_counts[key] = access_counts.get(key, 0) + 1
+                    access_stmt_idxs.setdefault(key, []).append(stmt_idx)
                 return False
 
             SearchVisitor(counter).visit(stmt)
 
-        # Find first pattern with 2+ uses whose base var has a product type
-        for (var_name, idx_val), count in access_counts.items():
-            if count < 2:
+        # Find first pattern with 2+ replaceable uses whose base var has a
+        # product type
+        for (var_name, idx_val), occurrence_idxs in access_stmt_idxs.items():
+            if len(occurrence_idxs) < 2:
                 continue
             if var_name not in var_types:
                 continue
@@ -1733,6 +1742,31 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
             if not isinstance(base_type, frog_ast.ProductType):
                 continue
             if idx_val < 0 or idx_val >= len(base_type.types):
+                continue
+
+            count = sum(1 for i in occurrence_idxs if i > var_def_idx[var_name])
+            if count < 2:
+                if self.ctx is not None:
+                    def_idx = var_def_idx[var_name]
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Extract Repeated Tuple Access",
+                            reason=(
+                                f"Cannot extract '{var_name}[{idx_val}]':"
+                                f" appears {len(occurrence_idxs)} times but"
+                                f" only {count} after the definition of"
+                                f" '{var_name}'"
+                            ),
+                            location=(
+                                block.statements[def_idx].origin
+                                if def_idx >= 0
+                                else None
+                            ),
+                            suggestion=None,
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
                 continue
 
             # Skip if the base variable is reassigned after its definition
@@ -1818,30 +1852,36 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
         # Unlike the tuple path, method parameters are eligible as
         # bases (SimplifyTuple only folds ArrayAccess, not Slice, so
         # hoisting a slice of a param doesn't interact).
-        slice_occurrences: list[frog_ast.Slice] = []
-        for stmt in block.statements:
+        # As in the tuple phase, track the statement index of each occurrence:
+        # replacement only reaches statements after the base's definition, so
+        # an occurrence at or before it (e.g. inside an earlier branch block
+        # that redeclares the same name) must not count toward the threshold.
+        slice_occurrences: list[tuple[int, frog_ast.Slice]] = []
+        for stmt_idx, stmt in enumerate(block.statements):
 
-            def slice_collector(node: frog_ast.ASTNode) -> bool:
+            def slice_collector(
+                node: frog_ast.ASTNode, stmt_idx: int = stmt_idx
+            ) -> bool:
                 if isinstance(node, frog_ast.Slice) and isinstance(
                     node.the_array, frog_ast.Variable
                 ):
-                    slice_occurrences.append(node)
+                    slice_occurrences.append((stmt_idx, node))
                 return False
 
             SearchVisitor(slice_collector).visit(stmt)
 
         # Group by structural equality.
-        slice_groups: list[tuple[frog_ast.Slice, int]] = []
-        for sl in slice_occurrences:
-            for idx, (rep, cnt) in enumerate(slice_groups):
+        slice_groups: list[tuple[frog_ast.Slice, list[int]]] = []
+        for stmt_idx, sl in slice_occurrences:
+            for idx, (rep, idxs) in enumerate(slice_groups):
                 if sl == rep:
-                    slice_groups[idx] = (rep, cnt + 1)
+                    idxs.append(stmt_idx)
                     break
             else:
-                slice_groups.append((sl, 1))
+                slice_groups.append((sl, [stmt_idx]))
 
-        for rep_slice, count in slice_groups:
-            if count < 2:
+        for rep_slice, occurrence_idxs in slice_groups:
+            if len(occurrence_idxs) < 2:
                 continue
             # F-235: the slice BOUNDS must be deterministic. A non-deterministic
             # call in a bound (`v[I.Cut():j]`) means two structurally-equal
@@ -1875,6 +1915,35 @@ class ExtractRepeatedTupleAccessTransformer(BlockTransformer):
                 ):
                     def_idx = idx
                     break
+
+            # Only occurrences the replacement step can actually reach may
+            # count toward the 2+ threshold. Counting an unreachable one
+            # re-fires the hoist on every pass -- and since the inserted
+            # extraction itself contains a fresh `v[A:B]`, the count never
+            # drops back below 2 and the recursion never terminates.
+            count = sum(1 for i in occurrence_idxs if i > def_idx)
+            if count < 2:
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Extract Repeated Tuple Access",
+                            reason=(
+                                f"Cannot extract the slice '{rep_slice}':"
+                                f" appears {len(occurrence_idxs)} times but"
+                                f" only {count} after the definition of"
+                                f" '{var_name}'"
+                            ),
+                            location=(
+                                block.statements[def_idx].origin
+                                if def_idx >= 0
+                                else None
+                            ),
+                            suggestion=None,
+                            variable=var_name,
+                            method=None,
+                        )
+                    )
+                continue
 
             # Skip if any of the slice's free variables -- the base AND the
             # bound expressions' variables -- is reassigned or rebound after
@@ -1953,6 +2022,7 @@ class ExtractRepeatedTupleAccess(TransformPass):
         return ExtractRepeatedTupleAccessTransformer(
             proof_namespace=ctx.proof_namespace,
             proof_let_types=ctx.proof_let_types,
+            ctx=ctx,
         ).transform(game)
 
 

--- a/tests/unit/transforms/test_extract_repeated_tuple_access.py
+++ b/tests/unit/transforms/test_extract_repeated_tuple_access.py
@@ -149,6 +149,38 @@ def _transform_and_compare(source: str, expected: str) -> None:
             }
             """,
         ),
+        # 7. Shadowed redeclaration in an earlier branch block: the nested
+        # v[1] refers to a different (inner) v, and the outer v[1] appears
+        # only once after the outer definition -> no extraction. Previously
+        # both occurrences were counted together, firing an extraction whose
+        # replacement could never reach the nested occurrence, so the
+        # transform re-fired on every pass and recursed forever.
+        (
+            """
+            Game Test() {
+                Int Run(Bool choice) {
+                    if (choice) {
+                        [Int, Int] v = [1, 2];
+                        return v[1];
+                    }
+                    [Int, Int] v = [3, 4];
+                    return v[1];
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int Run(Bool choice) {
+                    if (choice) {
+                        [Int, Int] v = [1, 2];
+                        return v[1];
+                    }
+                    [Int, Int] v = [3, 4];
+                    return v[1];
+                }
+            }
+            """,
+        ),
     ],
 )
 def test_extract_repeated_tuple_access(source: str, expected: str) -> None:
@@ -279,6 +311,43 @@ def test_extract_repeated_tuple_access(source: str, expected: str) -> None:
                     m = m;
                     BitString<K> b = m[0 : K];
                     return a;
+                }
+            }
+            """,
+        ),
+        # Shadowed redeclaration in an earlier branch block -- the slice-phase
+        # analogue of case 7 above. The nested m[0 : K] belongs to a different
+        # (inner) m, so only one occurrence follows the outer definition and
+        # nothing is hoisted. Counting both fires a hoist whose replacement
+        # cannot reach the nested occurrence; because the inserted extraction
+        # itself contains a fresh m[0 : K], the count stays at 2 and the
+        # transform recurses until the recursion limit.
+        (
+            """
+            Game Test() {
+                Int N;
+                Int K;
+                BitString<K> F(Bool choice) {
+                    if (choice) {
+                        BitString<N> m <- BitString<N>;
+                        return m[0 : K];
+                    }
+                    BitString<N> m <- BitString<N>;
+                    return m[0 : K];
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int N;
+                Int K;
+                BitString<K> F(Bool choice) {
+                    if (choice) {
+                        BitString<N> m <- BitString<N>;
+                        return m[0 : K];
+                    }
+                    BitString<N> m <- BitString<N>;
+                    return m[0 : K];
                 }
             }
             """,

--- a/tests/unit/transforms/test_extract_repeated_tuple_access.py
+++ b/tests/unit/transforms/test_extract_repeated_tuple_access.py
@@ -181,6 +181,39 @@ def _transform_and_compare(source: str, expected: str) -> None:
             }
             """,
         ),
+        # 8. Mirror of case 7: the shadowing redeclaration sits AFTER the
+        # outer definition. Here the replacement step WOULD reach the nested
+        # occurrence, so counting it would capture a different variable --
+        # blocked instead by the reassignment guard, which treats the inner
+        # declaration as a write to `v` after its definition. Pinned so a
+        # future change to that guard cannot silently open a capture (or
+        # revive the recursion) on this side.
+        (
+            """
+            Game Test() {
+                Int Run(Bool choice) {
+                    [Int, Int] v = [3, 4];
+                    if (choice) {
+                        [Int, Int] v = [1, 2];
+                        return v[1];
+                    }
+                    return v[1];
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int Run(Bool choice) {
+                    [Int, Int] v = [3, 4];
+                    if (choice) {
+                        [Int, Int] v = [1, 2];
+                        return v[1];
+                    }
+                    return v[1];
+                }
+            }
+            """,
+        ),
     ],
 )
 def test_extract_repeated_tuple_access(source: str, expected: str) -> None:
@@ -347,6 +380,41 @@ def test_extract_repeated_tuple_access(source: str, expected: str) -> None:
                         return m[0 : K];
                     }
                     BitString<N> m <- BitString<N>;
+                    return m[0 : K];
+                }
+            }
+            """,
+        ),
+        # Mirror of the case above, with the shadowing redeclaration AFTER
+        # the outer definition -- the slice-phase analogue of tuple case 8.
+        # Declined by `reassigns_or_rebinds` (the inner sample rebinds `m`),
+        # not by the post-definition count; pinned so neither guard can
+        # regress unnoticed.
+        (
+            """
+            Game Test() {
+                Int N;
+                Int K;
+                BitString<K> F(Bool choice) {
+                    BitString<N> m <- BitString<N>;
+                    if (choice) {
+                        BitString<N> m <- BitString<N>;
+                        return m[0 : K];
+                    }
+                    return m[0 : K];
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int N;
+                Int K;
+                BitString<K> F(Bool choice) {
+                    BitString<N> m <- BitString<N>;
+                    if (choice) {
+                        BitString<N> m <- BitString<N>;
+                        return m[0 : K];
+                    }
                     return m[0 : K];
                 }
             }

--- a/tests/unit/transforms/test_near_misses.py
+++ b/tests/unit/transforms/test_near_misses.py
@@ -20,6 +20,7 @@ from proof_frog.transforms.inlining import (
     InlineSingleUseVariable,
     InlineSingleUseField,
     DeduplicateDeterministicCalls,
+    ExtractRepeatedTupleAccess,
     HoistDeterministicCallToInitialize,
 )
 from proof_frog.transforms.sampling import (
@@ -178,6 +179,72 @@ def test_inline_near_miss_free_var_modified():
     assert (
         "k" in ct_misses[0].reason.lower() or "modified" in ct_misses[0].reason.lower()
     )
+
+
+def test_extract_tuple_near_miss_shadowed_redeclaration():
+    """ExtractRepeatedTupleAccess reports a near-miss (and terminates) when
+    the only other occurrence of ``v[i]`` is inside an earlier branch block
+    that redeclares ``v``, so it cannot be replaced."""
+    game = frog_parser.parse_game(
+        """
+        Game TestGame() {
+            Int Run(Bool choice) {
+                if (choice) {
+                    [Int, Int] v = [1, 2];
+                    return v[1];
+                }
+                [Int, Int] v = [3, 4];
+                return v[1];
+            }
+        }
+        """
+    )
+    ctx = _make_ctx()
+    result = ExtractRepeatedTupleAccess().apply(game, ctx)
+
+    assert result == game  # transform should NOT have fired
+    misses = [
+        nm
+        for nm in ctx.near_misses
+        if nm.transform_name == "Extract Repeated Tuple Access"
+    ]
+    assert len(misses) == 1
+    assert misses[0].variable == "v"
+    assert "v[1]" in misses[0].reason
+
+
+def test_extract_slice_near_miss_shadowed_redeclaration():
+    """The slice phase of the same pass reports a near-miss (and terminates)
+    when the only other occurrence of ``v[A:B]`` is inside an earlier branch
+    block that redeclares ``v``."""
+    game = frog_parser.parse_game(
+        """
+        Game TestGame() {
+            Int N;
+            Int K;
+            BitString<K> Run(Bool choice) {
+                if (choice) {
+                    BitString<N> m <- BitString<N>;
+                    return m[0 : K];
+                }
+                BitString<N> m <- BitString<N>;
+                return m[0 : K];
+            }
+        }
+        """
+    )
+    ctx = _make_ctx()
+    result = ExtractRepeatedTupleAccess().apply(game, ctx)
+
+    assert result == game  # transform should NOT have fired
+    misses = [
+        nm
+        for nm in ctx.near_misses
+        if nm.transform_name == "Extract Repeated Tuple Access"
+    ]
+    assert len(misses) == 1
+    assert misses[0].variable == "m"
+    assert "slice" in misses[0].reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/transforms/test_near_misses.py
+++ b/tests/unit/transforms/test_near_misses.py
@@ -244,7 +244,7 @@ def test_extract_slice_near_miss_shadowed_redeclaration():
     ]
     assert len(misses) == 1
     assert misses[0].variable == "m"
-    assert "slice" in misses[0].reason
+    assert "m[0 : K]" in misses[0].reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This issue was found together with @soechsner and @DoreenRiepel. The fix and following summary are from Claude.

### Problem

`prove` aborts with `Error during proof verification: maximum recursion depth exceeded`. Self-contained reproduction against the transformer directly:

```python
from proof_frog import frog_parser
from proof_frog.transforms.inlining import ExtractRepeatedTupleAccessTransformer

game = frog_parser.parse_game("""
Game Test() {
    Int Run(Bool choice) {
        if (choice) {
            [Int, Int] v = [1, 2];
            return v[1];
        }
        [Int, Int] v = [3, 4];
        return v[1];
    }
}
""")
ExtractRepeatedTupleAccessTransformer().transform(game)   # never terminates
```

This block shape does not have to be written by hand: the canonicalization pipeline produces it, because if-with-early-return tail duplication redeclares tuple locals inside the branch. It was found that way — three separate hand-written proof files abort this way on current `main`.

### Root cause

The transformer counted `v[i]` occurrences across the whole block, including inside a nested branch block that redeclares `v` (a shadowing inner variable), but its replacement step only rewrites statements after the outer definition of `v`.

When the only other occurrence sits in an earlier branch block, the count never falls back below 2: the inserted extraction `__cse_v_1__ = v[1]` *itself* contains a fresh occurrence, which pairs with the unreachable one. Every pass inserts another extraction and recurses on the grown block until the recursion limit.

Reading the slice phase of the same transformer showed it counts and replaces the same way, so it carries the defect by construction:

```
Game Test() {
    Int N; Int K;
    BitString<K> F(Bool choice) {
        if (choice) { BitString<N> m <- BitString<N>; return m[0 : K]; }
        BitString<N> m <- BitString<N>; return m[0 : K];
    }
}
```

I have observed only the tuple phase aborting a real proof run; the slice case above is constructed, and is fixed alongside its twin rather than left as a known hole.

### Fix

In both phases, track the statement index of each occurrence and count only those after the base variable's definition — the region replacement actually reaches. Scope-external bases (method parameters, `GenericFor` binders) keep the existing `-1` sentinel definition index, so all of their occurrences still count and their hoisting is unaffected.

A `NearMiss` is recorded when unreachable occurrences are what pushed the raw count over the threshold, so the diagnostic engine can explain the decline.

The guard only ever *declines* to fire, so it cannot change the outcome of any canonicalization that previously terminated.

### Tests

- `tests/unit/transforms/test_extract_repeated_tuple_access.py` — one parametrized shadowed-redeclaration case per phase, asserting the game is left unchanged.
- `tests/unit/transforms/test_near_misses.py` — one near-miss test per phase.

All four fail with `RecursionError` without the fix. Full suite green, including the 115-proof `examples/` corpus.
