### PR TITLE
Bump vulnerable npm transitive deps in vscode-extension

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1233,16 +1233,16 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch": {
@@ -1440,9 +1440,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2099,9 +2099,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -2290,16 +2290,16 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -4234,9 +4234,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Resolves all 9 open Dependabot alerts, all of which are npm transitive dependencies in `vscode-extension/package-lock.json`. Fixed with `npm audit fix`; every patched version is within the existing semver ranges, so only the lockfile changes.

| Package | Old | New | Alerts |
| --- | --- | --- | --- |
| `brace-expansion` (root, via `vscode-languageclient`) | 2.1.2 | 2.1.4 | #33 |
| `brace-expansion` (dev, under `@vscode/vsce`, `glob`) | 5.0.7 | 5.0.9 | #32, #39 |
| `fast-uri` (dev) | 3.1.4 | 3.1.5 | #40 |
| `undici` (dev) | 7.28.0 | 7.29.0 | #34, #35, #36, #37, #38 |

Advisories addressed:

- GHSA-mh99-v99m-4gvg — brace-expansion: DoS via unbounded expansion length causing an OOM process crash (high)
- GHSA-rgw5-rvv9-x895 — brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation (high)
- GHSA-7p8r-x3mc-p8w7 — fast-uri: host confusion via backslash authority introducer (high)
- GHSA-4cwx-7wf7-3272 — undici: cross-user information disclosure and parse-time crash via degenerate private cache directives (high)
- GHSA-8xcm-r25x-g524 — undici: downstream response desynchronization via retry interceptor (medium)
- GHSA-m8rv-5g2x-5cg5 — undici: CRLF injection via blob-like body `type` property (medium)
- GHSA-jr45-8vmc-qm54 — undici: cross-user information disclosure via whitespace around equals in Cache-Control directives (medium)
- GHSA-v3r7-h72x-cjcm — undici: cookie attribute injection via unsanitized domain and unparsed setCookie fields (medium)

## Verification

- `npm audit` — 0 vulnerabilities (was 3 high-severity groups)
- `npx tsc --noEmit` — passes
- `npm run bundle` (esbuild) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
