### PR TITLE
Split bare tuple declarations early so both tuple-local spellings canonicalize

### DIFF
--- a/proof_frog/transforms/pipelines.py
+++ b/proof_frog/transforms/pipelines.py
@@ -106,6 +106,7 @@ from .tuples import (
     SimplifyTuple,
     CollapseSingleIndexTuple,
     NormalizeProductLiteral,
+    SplitBareTupleDeclarations,
 )
 from .standardization import (
     VariableStandardize,
@@ -119,6 +120,11 @@ from .standardization import (
 CORE_PIPELINE: list[TransformPass] = [
     AlphaRename(),
     NormalizeProductLiteral(),
+    # Must run before Topological Sorting (which prunes bare declarations)
+    # and Collapse Assignment (which folds their assignments into use
+    # sites): once either fires, the split-declaration tuple spelling can
+    # no longer be normalized to the decl-with-initializer route (#255).
+    SplitBareTupleDeclarations(),
     SingleCallFieldToLocal(),
     CounterGuardedFieldToLocal(),
     SymbolicComputation(),

--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -51,6 +51,31 @@ def _count_var_refs(node: frog_ast.ASTNode, name: str) -> int:
     return count[0]
 
 
+def _has_self_referencing_whole_assignment(node: frog_ast.ASTNode, name: str) -> bool:
+    """Return True iff *node* contains a whole-variable assignment to *name*
+    whose right-hand side also references *name* (e.g. a swap
+    ``v = [v[1], v[0]];``).
+
+    F-321: ``ExpandTupleTransformer`` rewrites a whole-tuple assignment into
+    *sequential* per-component assignments. That is only faithful when the
+    right-hand side does not read the tuple being assigned: the RHS of
+    ``v = [v[1], v[0]];`` evaluates to a value before the assignment happens,
+    but the sequential expansion ``v@0 = v@1; v@1 = v@0;`` makes later
+    components read already-overwritten ones. Expansion must decline on any
+    such self-referencing whole-variable assignment.
+    """
+
+    def _p(n: frog_ast.ASTNode) -> bool:
+        return (
+            isinstance(n, frog_ast.Assignment)
+            and isinstance(n.var, frog_ast.Variable)
+            and n.var.name == name
+            and _count_var_refs(n.value, name) > 0
+        )
+
+    return SearchVisitor(_p).visit(node) is not None
+
+
 def _count_var_decls(node: frog_ast.ASTNode, name: str) -> int:
     """Count local declarations that bind *name* in *node* (typed
     sample/assignment/declaration, or a loop binder)."""
@@ -80,15 +105,60 @@ class ExpandTupleTransformer(Transformer):
     """Expands product-typed variables into individual component variables.
 
     A field or local of type ``T1 * T2`` is split into ``T1 v@0`` and
-    ``T2 v@1``.  Index accesses like ``v[0]`` are rewritten to the
-    corresponding component variable.  Only applies when all accesses
-    use constant indices (checked via ``AllConstantFieldAccesses``).
+    ``T2 v@1``.  Locals are handled both as declarations with an
+    initializer (``[T1, T2] v = [e0, e1];``) and as bare declarations
+    (``[T1, T2] v;``) later written by whole-variable or element
+    assignments (issue #255).  Index accesses like ``v[0]`` are rewritten
+    to the corresponding component variable.  Only applies when all
+    accesses use constant indices and no whole-variable reassignment
+    reads the variable in its own right-hand side (checked via
+    ``AllConstantFieldAccesses`` and
+    ``_has_self_referencing_whole_assignment``).
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        ctx: PipelineContext | None = None,
+        bare_locals_only: bool = False,
+        pass_name: str = "Expand Tuples",
+    ) -> None:
+        self.ctx = ctx
+        # ``bare_locals_only`` restricts the transformer to splitting bare
+        # product-typed local declarations (issue #255). It is used by the
+        # early ``Split Bare Tuple Declarations`` pass, which must run before
+        # Topological Sorting prunes bare declarations and Collapse Assignment
+        # folds their assignments away. Fields and decl-with-initializer
+        # locals keep their existing late-pipeline route (the full
+        # ``Expand Tuples`` pass) so their canonical routes are unchanged.
+        self.bare_locals_only = bare_locals_only
+        self.pass_name = pass_name
         self.to_transform: list[str] = []
         self.lengths: list[int] = []
         self._current_method: frog_ast.Method | None = None
+
+    def _near_miss(
+        self,
+        reason: str,
+        suggestion: str | None,
+        variable: str,
+        location: frog_ast.SourceOrigin | None = None,
+    ) -> None:
+        if self.ctx is None:
+            return
+        self.ctx.near_misses.append(
+            NearMiss(
+                transform_name=self.pass_name,
+                reason=reason,
+                location=location,
+                suggestion=suggestion,
+                variable=variable,
+                method=(
+                    self._current_method.signature.name
+                    if self._current_method is not None
+                    else None
+                ),
+            )
+        )
 
     def transform_method(self, method: frog_ast.Method) -> frog_ast.Method:
         # Capture the enclosing method so the F-324 scope guard can tell whether
@@ -124,9 +194,44 @@ class ExpandTupleTransformer(Transformer):
     def _is_transformable_tuple(
         self, the_type: frog_ast.Type, name: str, search_space: frog_ast.ASTNode
     ) -> bool:
-        return isinstance(the_type, frog_ast.ProductType) and AllConstantFieldAccesses(
-            name
-        ).visit(search_space)
+        if not isinstance(the_type, frog_ast.ProductType):
+            return False
+        if not AllConstantFieldAccesses(name).visit(search_space):
+            self._near_miss(
+                reason=(
+                    f"product-typed '{name}' was not split into components: "
+                    "an access uses a non-constant index, a whole-variable "
+                    "write is not a tuple literal, or the whole variable is "
+                    "sampled"
+                ),
+                suggestion=(
+                    f"Access '{name}' only at constant indices and write it "
+                    "either element-wise or as a whole-variable tuple literal"
+                ),
+                variable=name,
+            )
+            return False
+        # F-321: a whole-variable reassignment whose RHS reads the variable
+        # itself (e.g. a swap ``v = [v[1], v[0]];``) cannot be split into
+        # sequential component assignments -- later components would read
+        # already-overwritten values instead of the pre-assignment ones.
+        if _has_self_referencing_whole_assignment(search_space, name):
+            self._near_miss(
+                reason=(
+                    f"product-typed '{name}' was not split into components: "
+                    f"a whole-variable assignment reads '{name}' in its "
+                    "right-hand side, and sequential component assignments "
+                    "would overwrite components the right-hand side still "
+                    "needs"
+                ),
+                suggestion=(
+                    f"Copy '{name}' into a temporary variable and build the "
+                    "reassigned tuple from the temporary"
+                ),
+                variable=name,
+            )
+            return False
+        return True
 
     @staticmethod
     def _has_reference(name: str, block: frog_ast.Block) -> bool:
@@ -137,7 +242,59 @@ class ExpandTupleTransformer(Transformer):
 
         return SearchVisitor(is_named_variable).visit(block) is not None
 
+    def _can_expand_bare_declaration(
+        self,
+        statement: frog_ast.VariableDeclaration,
+        block: frog_ast.Block,
+        stmt_idx: int,
+    ) -> bool:
+        """Decide whether a bare product-typed local ``[T0, T1] v;`` may be
+        split into per-component declarations (issue #255: the split-decl
+        spelling must canonicalize like the decl-with-initializer one).
+
+        Carries the same guards as the decl-with-initializer branch: the
+        variable must be referenced in the remainder of THIS block (otherwise
+        the use site is in an enclosing scope, or the decl is dead code),
+        every access must pass ``_is_transformable_tuple``, and the F-324
+        scope guard must not trip.
+        """
+        if not isinstance(statement.type, frog_ast.ProductType):
+            return False
+        if not self._has_reference(
+            statement.name,
+            frog_ast.Block(list(block.statements[stmt_idx + 1 :])),
+        ):
+            return False
+        if not self._is_transformable_tuple(statement.type, statement.name, block):
+            # near-miss emitted by _is_transformable_tuple
+            return False
+        if self._local_escapes_block(block, statement.name):
+            self._near_miss(
+                reason=(
+                    f"product-typed '{statement.name}' was not split into "
+                    "components: it is referenced outside the block that "
+                    "declares it, and splitting would leave those references "
+                    "dangling"
+                ),
+                suggestion=(
+                    f"Declare '{statement.name}' in the block where it is " "used"
+                ),
+                variable=statement.name,
+                location=statement.origin,
+            )
+            return False
+        return True
+
     def transform_game(self, game: frog_ast.Game) -> frog_ast.Game:
+        if self.bare_locals_only:
+            return frog_ast.Game(
+                (
+                    game.name,
+                    game.parameters,
+                    list(game.fields),
+                    [self.transform(method) for method in game.methods],
+                )
+            )
         new_fields = []
         for field in game.fields:
             if self._is_transformable_tuple(field.type, field.name, game):
@@ -199,7 +356,8 @@ class ExpandTupleTransformer(Transformer):
                 )
                 new_statements.append(new_statement)
             elif (
-                isinstance(statement, frog_ast.Assignment)
+                not self.bare_locals_only
+                and isinstance(statement, frog_ast.Assignment)
                 and statement.the_type is not None
                 and isinstance(statement.var, frog_ast.Variable)
                 and self._is_transformable_tuple(
@@ -234,6 +392,24 @@ class ExpandTupleTransformer(Transformer):
                     )
                 self.to_transform.append(statement.var.name)
                 self.lengths.append(len(unfolded_types))
+                expanded_tuple_count += 1
+            # A bare product-typed declaration ``[T0, T1] v;`` (issue #255)
+            # is split into per-component declarations; the later
+            # whole-variable / element assignments and accesses are then
+            # handled by the branches above and by transform_array_access.
+            elif isinstance(
+                statement, frog_ast.VariableDeclaration
+            ) and self._can_expand_bare_declaration(statement, block, stmt_idx):
+                assert isinstance(statement.type, frog_ast.ProductType)
+                unfolded_decl_types = statement.type.types
+                for index, the_type in enumerate(unfolded_decl_types):
+                    new_statements.append(
+                        frog_ast.VariableDeclaration(
+                            the_type, f"{statement.name}@{index}"
+                        )
+                    )
+                self.to_transform.append(statement.name)
+                self.lengths.append(len(unfolded_decl_types))
                 expanded_tuple_count += 1
             else:
                 new_statements.append(statement)
@@ -368,7 +544,29 @@ class ExpandTuple(TransformPass):
     name = "Expand Tuples"
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
-        return ExpandTupleTransformer().transform(game)
+        return ExpandTupleTransformer(ctx).transform(game)
+
+
+class SplitBareTupleDeclarations(TransformPass):
+    """Splits a bare product-typed local declaration ``[T0, T1] v;`` into
+    per-component declarations, rewriting the later whole-variable / element
+    assignments and constant-index accesses (issue #255).
+
+    Runs EARLY in the pipeline: by the time the full ``Expand Tuples`` pass
+    runs, Topological Sorting has pruned bare declarations and Collapse
+    Assignment has folded their assignments into use sites, leaving a
+    ``[e0, e1][i]`` shape that ``Fold Tuple Literal Indexing`` must
+    conservatively decline when a discarded element is non-deterministic.
+    Splitting the declaration first lets the split-declaration spelling
+    canonicalize exactly like the declaration-with-initializer spelling.
+    """
+
+    name = "Split Bare Tuple Declarations"
+
+    def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
+        return ExpandTupleTransformer(
+            ctx, bare_locals_only=True, pass_name=self.name
+        ).transform(game)
 
 
 class FoldTupleIndex(TransformPass):

--- a/tests/integration/test_distinguishers.py
+++ b/tests/integration/test_distinguishers.py
@@ -1103,3 +1103,45 @@ def test_modint_loop_reused_uniform_not_absorbed() -> None:
         }
         """)
     assert not _engine_with().check_equivalent(twice, once).valid
+
+
+def test_f321_tuple_swap_reassignment_not_sequentialized() -> None:
+    """F-321: ``pair = [pair[1], pair[0]]; return pair[1];`` returns the
+    ORIGINAL ``pair[0]`` (the RHS evaluates before the assignment lands).
+    ExpandTuple used to sequentialize the swap into
+    ``pair@0 = pair@1; pair@1 = pair@0;``, after which BOTH components hold
+    the old ``pair[1]`` -- so the engine canonicalized the game to return
+    the wrong component and accepted an equivalence that any instantiation
+    with ``Left != Right`` refutes with advantage 1."""
+    prim = frog_parser.parse_primitive_file("""
+        Primitive P(Int n) {
+            BitString<n> Left(BitString<n> k);
+            BitString<n> Right(BitString<n> k);
+        }
+        """)
+    pre = frog_parser.parse_game("""
+        Game Pre(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair = [PP.Left(a), PP.Right(b)];
+                pair = [pair[1], pair[0]];
+                return pair[1];
+            }
+        }
+        """)
+    post = frog_parser.parse_game("""
+        Game Post(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> b <- BitString<n>;
+                return PP.Right(b);
+            }
+        }
+        """)
+    engine = _engine_with(P=prim, PP=prim)
+    result = engine.check_equivalent(pre, post)
+    assert not result.valid

--- a/tests/integration/test_tuple_decl_split.py
+++ b/tests/integration/test_tuple_decl_split.py
@@ -1,0 +1,203 @@
+"""Issue #255: split-declaration tuples must canonicalize like the
+declaration-with-initializer spelling.
+
+A bare product-typed local declaration (``[T, T] pair;``) followed by a
+whole-variable or element-wise assignment used to survive canonicalization
+unfolded (the ``Split Bare Tuple Declarations`` pass now normalizes it before
+Topological Sorting prunes the declaration), so an identity hop between the
+two spellings failed whenever the tuple elements were non-deterministic
+calls. These tests cover the reporter's variant matrix end-to-end via
+``check_equivalent``.
+"""
+
+from __future__ import annotations
+
+from sympy import Symbol
+
+from proof_frog import frog_parser
+from proof_frog.proof_engine import ProofEngine
+
+
+def _engine() -> ProofEngine:
+    """ProofEngine preloaded with a primitive exposing two distinct
+    un-annotated (hence non-deterministic) methods, the shape the issue-#255
+    reproduction needs: FoldTupleIndex must conservatively decline on the
+    discarded element, so only the declaration split can fold the index."""
+    prim = frog_parser.parse_primitive_file("""
+        Primitive P(Int n) {
+            BitString<n> Left(BitString<n> k);
+            BitString<n> Right(BitString<n> k);
+        }
+        """)
+    det_prim = frog_parser.parse_primitive_file("""
+        Primitive D(Int n) {
+            deterministic BitString<n> Left(BitString<n> k);
+            deterministic BitString<n> Right(BitString<n> k);
+        }
+        """)
+    engine = ProofEngine()
+    engine.variables["n"] = Symbol("n", positive=True, integer=True)
+    engine.proof_namespace["P"] = prim
+    engine.proof_namespace["PP"] = prim
+    engine.proof_namespace["D"] = det_prim
+    engine.proof_namespace["DD"] = det_prim
+    return engine
+
+
+_DECL_WITH_INIT = """
+    Game Post(P PP) {
+        Void Initialize() {
+        }
+        BitString<n> Run() {
+            BitString<n> a <- BitString<n>;
+            BitString<n> b <- BitString<n>;
+            [BitString<n>, BitString<n>] pair = [PP.Left(a), PP.Right(b)];
+            return pair[1];
+        }
+    }
+    """
+
+
+def test_split_decl_whole_assignment_matches_initializer() -> None:
+    """The issue's core reproduction: split declaration + whole-variable
+    assignment of non-deterministic calls is an identity hop against the
+    decl-with-initializer spelling."""
+    pre = frog_parser.parse_game("""
+        Game Pre(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair;
+                pair = [PP.Left(a), PP.Right(b)];
+                return pair[1];
+            }
+        }
+        """)
+    post = frog_parser.parse_game(_DECL_WITH_INIT)
+    result = _engine().check_equivalent(pre, post)
+    assert result.valid, result.failure_detail
+
+
+def test_split_decl_element_writes_match_initializer() -> None:
+    """Sibling spelling: the bare declaration written element-wise."""
+    pre = frog_parser.parse_game("""
+        Game Pre(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair;
+                pair[0] = PP.Left(a);
+                pair[1] = PP.Right(b);
+                return pair[1];
+            }
+        }
+        """)
+    post = frog_parser.parse_game(_DECL_WITH_INIT)
+    result = _engine().check_equivalent(pre, post)
+    assert result.valid, result.failure_detail
+
+
+def test_split_decl_conditional_assignment_matches_branch_form() -> None:
+    """A bare declaration assigned in both arms of an ``if`` splits at the
+    declaring block and the branch assignments rewrite in place."""
+    pre = frog_parser.parse_game("""
+        Game Pre(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run(Bool c) {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair;
+                if (c) {
+                    pair = [PP.Left(a), PP.Right(b)];
+                } else {
+                    pair = [PP.Right(b), PP.Left(a)];
+                }
+                return pair[1];
+            }
+        }
+        """)
+    post = frog_parser.parse_game("""
+        Game Post(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run(Bool c) {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                if (c) {
+                    return PP.Right(b);
+                }
+                return PP.Left(a);
+            }
+        }
+        """)
+    result = _engine().check_equivalent(pre, post)
+    assert result.valid, result.failure_detail
+
+
+def test_split_decl_plain_variables_matches_initializer() -> None:
+    """Reporter's matrix: with plain variables as elements the hop already
+    verified pre-fix (FoldTupleIndex folds it); it must keep verifying."""
+    pre = frog_parser.parse_game("""
+        Game Pre(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair;
+                pair = [a, b];
+                return pair[1];
+            }
+        }
+        """)
+    post = frog_parser.parse_game("""
+        Game Post(P PP) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair = [a, b];
+                return pair[1];
+            }
+        }
+        """)
+    result = _engine().check_equivalent(pre, post)
+    assert result.valid, result.failure_detail
+
+
+def test_split_decl_deterministic_calls_match_initializer() -> None:
+    """Reporter's matrix: with ``deterministic``-annotated elements the hop
+    already verified pre-fix; it must keep verifying."""
+    pre = frog_parser.parse_game("""
+        Game Pre(D DD) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair;
+                pair = [DD.Left(a), DD.Right(b)];
+                return pair[1];
+            }
+        }
+        """)
+    post = frog_parser.parse_game("""
+        Game Post(D DD) {
+            Void Initialize() {
+            }
+            BitString<n> Run() {
+                BitString<n> a <- BitString<n>;
+                BitString<n> b <- BitString<n>;
+                [BitString<n>, BitString<n>] pair = [DD.Left(a), DD.Right(b)];
+                return pair[1];
+            }
+        }
+        """)
+    result = _engine().check_equivalent(pre, post)
+    assert result.valid, result.failure_detail

--- a/tests/unit/transforms/test_expand_tuples.py
+++ b/tests/unit/transforms/test_expand_tuples.py
@@ -482,3 +482,208 @@ def test_f324_control_expands_when_all_uses_in_block() -> None:
         """)
     out = str(ExpandTupleTransformer().transform(method))
     assert "[1, 2]" not in out  # expanded into components
+
+
+# ---------------------------------------------------------------------------
+# Issue #255: bare product-typed local declarations
+# ---------------------------------------------------------------------------
+
+
+def test_bare_decl_whole_assignment_expands() -> None:
+    """Issue #255: a bare product-typed local declaration followed by a
+    whole-variable tuple-literal assignment splits into per-component
+    declarations and assignments, exactly like the decl-with-initializer
+    spelling."""
+    method = frog_parser.parse_method("""
+        Int Oracle() {
+            [Int, Int] v;
+            v = [1, 2];
+            return v[1];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[Int, Int]" not in out  # declaration split
+    assert "v@0 = 1;" in out
+    assert "v@1 = 2;" in out
+    assert "return v@1;" in out
+
+
+def test_bare_decl_element_writes_expand() -> None:
+    """Issue #255 sibling: a bare product-typed local written element-wise
+    also splits into components."""
+    method = frog_parser.parse_method("""
+        Int Oracle() {
+            [Int, Int] v;
+            v[0] = 1;
+            v[1] = 2;
+            return v[1];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[Int, Int]" not in out
+    assert "v@0 = 1;" in out
+    assert "v@1 = 2;" in out
+    assert "return v@1;" in out
+
+
+def test_bare_decl_dead_declaration_left_alone() -> None:
+    """A bare product-typed local that is never referenced afterwards is dead
+    code: splitting it is pointless (and the use site may be in an enclosing
+    scope), so the declaration is left intact for DCE."""
+    method = frog_parser.parse_method("""
+        Int Oracle() {
+            [Int, Int] v;
+            return 0;
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[Int, Int] v;" in out
+
+
+def test_bare_decl_non_constant_index_declines() -> None:
+    """A non-constant index access blocks splitting a bare declaration (the
+    component variable cannot be named at transform time). If the split fired
+    anyway, ``v[i]`` would dangle."""
+    method = frog_parser.parse_method("""
+        Int Oracle(Int i) {
+            [Int, Int] v;
+            v = [1, 2];
+            return v[i];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[Int, Int] v;" in out  # left intact
+    assert "v@0" not in out
+
+
+def test_f324_bare_decl_declines_when_local_escapes_block() -> None:
+    """F-324 guard on the bare-declaration path: a bare product local declared
+    in an inner block but read in an enclosing block (an out-of-scope AST the
+    typechecker rejects) must not be split -- the outer ``v[k]`` access would
+    dangle."""
+    method = frog_parser.parse_method("""
+        Int Oracle(Bool c) {
+            Int acc = 0;
+            if (c) {
+                [Int, Int] v;
+                v = [1, 2];
+                acc = acc + v[0];
+            }
+            return v[1];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[Int, Int] v;" in out  # declaration left intact
+    assert "v@1" not in out  # no dangling component reference
+
+
+# ---------------------------------------------------------------------------
+# F-321: whole-variable reassignment reading the tuple in its own RHS
+# ---------------------------------------------------------------------------
+
+
+def test_f321_swap_reassignment_declines_decl_with_init() -> None:
+    """F-321: a swap ``v = [v[1], v[0]];`` must NOT be split into sequential
+    component assignments ``v@0 = v@1; v@1 = v@0;`` -- after them BOTH
+    components hold the old ``v[1]``, whereas the swap leaves ``v[1]`` holding
+    the old ``v[0]``. Distinguisher (pre-fix): a game returning ``v[1]`` after
+    the swap was canonicalized to return the wrong component, and the engine
+    accepted an equivalence any instantiation with distinguishable components
+    refutes with advantage 1."""
+    method = frog_parser.parse_method("""
+        Int Oracle() {
+            [Int, Int] v = [1, 2];
+            v = [v[1], v[0]];
+            return v[1];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[Int, Int] v = [1, 2];" in out  # left intact
+    assert "v@0" not in out
+
+
+def test_f321_swap_reassignment_declines_bare_decl() -> None:
+    """F-321 on the bare-declaration path (issue #255): the same swap after a
+    bare declaration must equally decline."""
+    method = frog_parser.parse_method("""
+        Int Oracle() {
+            [Int, Int] v;
+            v = [1, 2];
+            v = [v[1], v[0]];
+            return v[1];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "[Int, Int] v;" in out
+    assert "v@0" not in out
+
+
+def test_f321_swap_reassignment_declines_field() -> None:
+    """F-321 on the field path: a product-typed game field whose oracle swaps
+    it in place must not be expanded either -- the same sequentialization bug
+    would corrupt the field across oracle calls."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            [Int, Int] pair;
+            Void Initialize() {
+                pair = [1, 2];
+            }
+            Int Swap() {
+                pair = [pair[1], pair[0]];
+                return pair[1];
+            }
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(game))
+    assert "[Int, Int] pair;" in out  # field left intact
+    assert "pair@0" not in out
+
+
+def test_f321_control_plain_reassignment_still_expands() -> None:
+    """Control for F-321: a whole-variable reassignment whose RHS does NOT
+    read the variable still expands component-wise."""
+    method = frog_parser.parse_method("""
+        Int Oracle(Int x) {
+            [Int, Int] v = [1, 2];
+            v = [x, 3];
+            return v[1];
+        }
+        """)
+    out = str(ExpandTupleTransformer().transform(method))
+    assert "v@0" in out  # expanded
+    assert "return v@1;" in out
+
+
+# ---------------------------------------------------------------------------
+# SplitBareTupleDeclarations (bare_locals_only mode)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_mode_splits_only_bare_local_declarations() -> None:
+    """The early ``Split Bare Tuple Declarations`` pass must split bare local
+    declarations but leave fields and decl-with-initializer locals to the full
+    ``Expand Tuples`` pass, so their canonical routes are unchanged."""
+    game = frog_parser.parse_game("""
+        Game G() {
+            [Int, Int] fieldPair;
+            Void Initialize() {
+                fieldPair = [1, 2];
+            }
+            Int WithInit() {
+                [Int, Int] a = [3, 4];
+                return a[0];
+            }
+            Int Bare() {
+                [Int, Int] b;
+                b = [5, 6];
+                return b[0];
+            }
+        }
+        """)
+    out = str(
+        ExpandTupleTransformer(bare_locals_only=True).transform(game)
+    )
+    assert "[Int, Int] fieldPair;" in out  # field untouched
+    assert "[Int, Int] a = [3, 4];" in out  # decl-with-init untouched
+    assert "b@0 = 5;" in out  # bare local split
+    assert "return b@0;" in out

--- a/tests/unit/transforms/test_near_misses.py
+++ b/tests/unit/transforms/test_near_misses.py
@@ -37,6 +37,7 @@ from proof_frog.transforms.random_functions import (
     LocalFunctionFieldToLet,
 )
 from proof_frog.transforms.structural import UniformBijectionElimination
+from proof_frog.transforms.tuples import ExpandTuple, SplitBareTupleDeclarations
 from proof_frog.transforms.map_iteration import LazyMapScan
 from proof_frog.visitors import NameTypeMap
 
@@ -2353,3 +2354,57 @@ def test_single_call_field_to_local_near_miss_on_domain_write() -> None:
         nm.transform_name == "Single Call Field To Local" and nm.variable == "x"
         for nm in ctx.near_misses
     )
+
+
+def test_expand_tuples_near_miss_f321_swap_reassignment():
+    """Expand Tuples reports a near-miss when a whole-variable tuple
+    reassignment reads the variable in its own RHS (F-321): sequential
+    component assignments would overwrite components the RHS still needs."""
+    game = _make_game(
+        "[Int, Int] v = [1, 2];\n"
+        "        v = [v[1], v[0]];\n"
+        "        return m;"
+    )
+    ctx = _make_ctx()
+    result = ExpandTuple().apply(game, ctx)
+
+    assert result == game  # transform should NOT have fired
+    matching = [nm for nm in ctx.near_misses if nm.variable == "v"]
+    assert matching
+    nm = matching[0]
+    assert nm.transform_name == "Expand Tuples"
+    assert "right-hand side" in nm.reason
+    assert nm.method == "Encrypt"
+
+
+def test_split_bare_tuple_declarations_near_miss_non_constant_index():
+    """Split Bare Tuple Declarations reports a near-miss when a bare
+    product-typed local is accessed at a non-constant index."""
+    game = _make_game(
+        "[Int, Int] v;\n"
+        "        v = [1, 2];\n"
+        "        Int i = 0;\n"
+        "        Int x = v[i];\n"
+        "        return m;"
+    )
+    ctx = _make_ctx()
+    SplitBareTupleDeclarations().apply(game, ctx)
+
+    matching = [nm for nm in ctx.near_misses if nm.variable == "v"]
+    assert matching
+    nm = matching[0]
+    assert nm.transform_name == "Split Bare Tuple Declarations"
+    assert "constant" in nm.reason
+    assert nm.method == "Encrypt"
+
+
+def test_split_bare_tuple_declarations_no_near_miss_when_it_fires():
+    """No near-miss when the bare declaration splits cleanly."""
+    game = _make_game(
+        "[Int, Int] v;\n"
+        "        v = [1, 2];\n"
+        "        return m;"
+    )
+    ctx = _make_ctx()
+    SplitBareTupleDeclarations().apply(game, ctx)
+    assert not [nm for nm in ctx.near_misses if nm.variable == "v"]


### PR DESCRIPTION
Fixes #255.

## Problem

A bare product-typed local declaration followed by assignment,

```
[P.Out, P.Out] pair;
pair = [P.Left(a), P.Right(b)];
return pair[1];
```

failed an identity hop against the declaration-with-initializer spelling of the same program whenever the tuple elements were non-deterministic calls. The declaration (a `VariableDeclaration` node) was invisible to `ExpandTuple`, and by the time that pass runs, `TopologicalSort` has pruned the bare declaration and `CollapseAssignment` has folded the assignment into `return [P.Left(a), P.Right(b)][1];` — a shape `FoldTupleIndex` must conservatively decline (its guard against silently dropping randomised computation). The element-write spelling (`pair[0] = ...; pair[1] = ...;`) was equally broken, ending up with orphaned element writes after its declaration was pruned.

## Fix

A new pass, **Split Bare Tuple Declarations**, early in `CORE_PIPELINE` (right after `Normalize Product-Literal Tuples`, before anything prunes declarations or folds assignments). It reuses `ExpandTupleTransformer` in a `bare_locals_only` mode: only bare product-typed locals are split into per-component declarations; fields and decl-with-initializer locals keep their existing late-pipeline route, so their canonical forms are unchanged. The new path carries the same guards as the existing local-declaration branch (`AllConstantFieldAccesses`, referenced-in-block, and the F-324 scope guard), and declines emit `NearMiss` diagnostics. `FoldTupleIndex`'s non-determinism guard is untouched.

## Also fixes F-321 (soundness)

Extending the whole-variable-assignment branch to a new declaration form required auditing it first, which confirmed the ledgered F-321 false accept: `pair = [pair[1], pair[0]];` was sequentialized into `pair@0 = pair@1; pair@1 = pair@0;`, so a swap canonicalized to the wrong component and the engine certified an equivalence that any instantiation with `Left != Right` refutes with advantage 1. The shared gate now refuses to expand any whole-variable tuple assignment whose RHS reads the tuple itself (fields, initializer locals, and the new bare-declaration path), with a near-miss suggesting a temporary copy. The example corpus contains no self-referencing whole-tuple assignments, so no proof is affected.

## Tests

- `tests/integration/test_tuple_decl_split.py`: the issue's variant matrix end-to-end (split declaration with non-deterministic calls, element-write spelling, conditional assignment, plain-variable and deterministic controls).
- `tests/integration/test_distinguishers.py`: the F-321 swap as a permanent negative test (the equivalence must be rejected).
- `tests/unit/transforms/test_expand_tuples.py` / `test_near_misses.py`: positives, decline cases for each guard (including F-321 on all three paths and F-324 on the new path), bare-mode isolation, and near-miss emission.

All new tests were flip-checked: on the pre-fix engine the broken-spelling equivalences fail and the F-321 attack is wrongly accepted.

## easycrypt-branch ripple

Checked by corpus scan: the new pass fires only on bare product-typed method-body locals, of which the examples corpus has none, and the F-321 guard declines an idiom the corpus never uses — so canonical forms of existing proofs are unchanged and the exporter branch should rebase cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)